### PR TITLE
Add Docker support with multi-platform builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,34 @@
+# Build artifacts
+target/
+
+# Git
+.git/
+.gitignore
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Database files
+*.sqlite3
+*.sqlite3-journal
+*.sqlite3-wal
+*.sqlite3-shm
+
+# Environment files
+.env
+.env.*
+
+# Documentation
+*.md
+LICENSE
+
+# CI/CD
+.github/
+
+# Nix
+flake.nix
+flake.lock
+.direnv/

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,44 @@
+name: Docker
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# Stage 1: Chef - prepare recipe
+FROM rust:1.92-bookworm AS chef
+RUN cargo install cargo-chef
+WORKDIR /app
+
+# Stage 2: Planner - create recipe.json
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+# Stage 3: Builder - build dependencies then app
+FROM chef AS builder
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
+COPY . .
+RUN cargo build --release
+
+# Stage 4: Runtime
+FROM gcr.io/distroless/cc-debian12
+
+COPY --from=builder /app/target/release/rdrs /rdrs
+
+VOLUME /data
+
+ENV DATABASE_URL=/data/rdrs.sqlite3
+ENV SERVER_PORT=3000
+
+EXPOSE 3000
+
+ENTRYPOINT ["/rdrs"]


### PR DESCRIPTION
## Summary
- Add multi-stage Dockerfile using cargo-chef for efficient dependency caching
- Add GitHub Actions workflow for automated Docker image builds and pushes to ghcr.io
- Support multi-platform builds (linux/amd64, linux/arm64)
- Add .dockerignore to exclude unnecessary files from build context

## Test plan
- [x] Verify `cargo fmt --all -- --check` passes
- [x] Verify `cargo clippy -- -D warnings` passes
- [x] Verify `cargo build` succeeds
- [x] Verify `cargo test` passes (166 tests)
- [x] Verify Docker image builds locally with `docker build -t rdrs:test .`

🤖 Generated with [Claude Code](https://claude.com/claude-code)