### PR TITLE
Store entry summaries in database with recovery and cleanup

### DIFF
--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -80,6 +80,22 @@ pub fn init_db(conn: &Connection) -> AppResult<()> {
         CREATE INDEX IF NOT EXISTS idx_entry_read_at ON entry(read_at);
         CREATE INDEX IF NOT EXISTS idx_entry_starred_at ON entry(starred_at);
 
+        CREATE TABLE IF NOT EXISTS entry_summary (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL REFERENCES user(id) ON DELETE CASCADE,
+            entry_id INTEGER NOT NULL REFERENCES entry(id) ON DELETE CASCADE,
+            status TEXT NOT NULL CHECK (status IN ('pending', 'processing', 'completed', 'failed')),
+            summary_text TEXT,
+            error_message TEXT,
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+            UNIQUE(user_id, entry_id)
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_entry_summary_user_entry ON entry_summary(user_id, entry_id);
+        CREATE INDEX IF NOT EXISTS idx_entry_summary_user_status ON entry_summary(user_id, status);
+        CREATE INDEX IF NOT EXISTS idx_entry_summary_entry_id ON entry_summary(entry_id);
+
         CREATE TABLE IF NOT EXISTS image (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             entity_type TEXT NOT NULL,
@@ -165,5 +181,6 @@ mod tests {
         assert!(tables.contains(&"session".to_string()));
         assert!(tables.contains(&"passkey".to_string()));
         assert!(tables.contains(&"webauthn_challenge".to_string()));
+        assert!(tables.contains(&"entry_summary".to_string()));
     }
 }

--- a/src/models/entry_summary.rs
+++ b/src/models/entry_summary.rs
@@ -1,0 +1,553 @@
+use chrono::{DateTime, Utc};
+use rusqlite::{params, Connection, OptionalExtension};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+use crate::error::{AppError, AppResult};
+
+/// Summary processing status
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SummaryStatus {
+    Pending,
+    Processing,
+    Completed,
+    Failed,
+}
+
+impl SummaryStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            SummaryStatus::Pending => "pending",
+            SummaryStatus::Processing => "processing",
+            SummaryStatus::Completed => "completed",
+            SummaryStatus::Failed => "failed",
+        }
+    }
+
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "pending" => Some(SummaryStatus::Pending),
+            "processing" => Some(SummaryStatus::Processing),
+            "completed" => Some(SummaryStatus::Completed),
+            "failed" => Some(SummaryStatus::Failed),
+            _ => None,
+        }
+    }
+}
+
+/// An entry summary stored in the database
+#[derive(Debug, Clone, Serialize)]
+pub struct EntrySummary {
+    pub id: i64,
+    pub user_id: i64,
+    pub entry_id: i64,
+    pub status: SummaryStatus,
+    pub summary_text: Option<String>,
+    pub error_message: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+fn parse_datetime(s: &str) -> DateTime<Utc> {
+    DateTime::parse_from_rfc3339(s)
+        .map(|dt| dt.with_timezone(&Utc))
+        .or_else(|_| {
+            chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S").map(|dt| dt.and_utc())
+        })
+        .unwrap_or_else(|_| Utc::now())
+}
+
+fn row_to_entry_summary(row: &rusqlite::Row) -> rusqlite::Result<EntrySummary> {
+    let status_str: String = row.get(3)?;
+    let created_at: String = row.get(6)?;
+    let updated_at: String = row.get(7)?;
+
+    Ok(EntrySummary {
+        id: row.get(0)?,
+        user_id: row.get(1)?,
+        entry_id: row.get(2)?,
+        status: SummaryStatus::parse(&status_str).unwrap_or(SummaryStatus::Failed),
+        summary_text: row.get(4)?,
+        error_message: row.get(5)?,
+        created_at: parse_datetime(&created_at),
+        updated_at: parse_datetime(&updated_at),
+    })
+}
+
+const SELECT_COLUMNS: &str =
+    "id, user_id, entry_id, status, summary_text, error_message, created_at, updated_at";
+
+/// Find a summary by user and entry
+pub fn find_by_user_and_entry(
+    conn: &Connection,
+    user_id: i64,
+    entry_id: i64,
+) -> AppResult<Option<EntrySummary>> {
+    conn.query_row(
+        &format!(
+            "SELECT {} FROM entry_summary WHERE user_id = ?1 AND entry_id = ?2",
+            SELECT_COLUMNS
+        ),
+        params![user_id, entry_id],
+        row_to_entry_summary,
+    )
+    .optional()
+    .map_err(AppError::Database)
+}
+
+/// Create or update a summary with pending status
+pub fn upsert_pending(conn: &Connection, user_id: i64, entry_id: i64) -> AppResult<EntrySummary> {
+    conn.execute(
+        r#"
+        INSERT INTO entry_summary (user_id, entry_id, status)
+        VALUES (?1, ?2, 'pending')
+        ON CONFLICT(user_id, entry_id) DO UPDATE SET
+            status = 'pending',
+            summary_text = NULL,
+            error_message = NULL,
+            updated_at = datetime('now')
+        "#,
+        params![user_id, entry_id],
+    )?;
+
+    find_by_user_and_entry(conn, user_id, entry_id)?
+        .ok_or(AppError::NotFound("Entry summary not found".to_string()))
+}
+
+/// Update status to processing
+pub fn set_processing(conn: &Connection, user_id: i64, entry_id: i64) -> AppResult<()> {
+    let rows = conn.execute(
+        r#"
+        UPDATE entry_summary
+        SET status = 'processing', updated_at = datetime('now')
+        WHERE user_id = ?1 AND entry_id = ?2
+        "#,
+        params![user_id, entry_id],
+    )?;
+
+    if rows == 0 {
+        return Err(AppError::NotFound("Entry summary not found".to_string()));
+    }
+
+    Ok(())
+}
+
+/// Set summary as completed with the summary text
+pub fn set_completed(
+    conn: &Connection,
+    user_id: i64,
+    entry_id: i64,
+    summary_text: &str,
+) -> AppResult<EntrySummary> {
+    let rows = conn.execute(
+        r#"
+        UPDATE entry_summary
+        SET status = 'completed', summary_text = ?3, error_message = NULL, updated_at = datetime('now')
+        WHERE user_id = ?1 AND entry_id = ?2
+        "#,
+        params![user_id, entry_id, summary_text],
+    )?;
+
+    if rows == 0 {
+        return Err(AppError::NotFound("Entry summary not found".to_string()));
+    }
+
+    find_by_user_and_entry(conn, user_id, entry_id)?
+        .ok_or(AppError::NotFound("Entry summary not found".to_string()))
+}
+
+/// Set summary as failed with error message
+pub fn set_failed(
+    conn: &Connection,
+    user_id: i64,
+    entry_id: i64,
+    error_message: &str,
+) -> AppResult<EntrySummary> {
+    let rows = conn.execute(
+        r#"
+        UPDATE entry_summary
+        SET status = 'failed', error_message = ?3, updated_at = datetime('now')
+        WHERE user_id = ?1 AND entry_id = ?2
+        "#,
+        params![user_id, entry_id, error_message],
+    )?;
+
+    if rows == 0 {
+        return Err(AppError::NotFound("Entry summary not found".to_string()));
+    }
+
+    find_by_user_and_entry(conn, user_id, entry_id)?
+        .ok_or(AppError::NotFound("Entry summary not found".to_string()))
+}
+
+/// Delete a summary
+pub fn delete(conn: &Connection, user_id: i64, entry_id: i64) -> AppResult<bool> {
+    let rows = conn.execute(
+        "DELETE FROM entry_summary WHERE user_id = ?1 AND entry_id = ?2",
+        params![user_id, entry_id],
+    )?;
+
+    Ok(rows > 0)
+}
+
+/// Check if an entry has a completed summary
+pub fn has_completed_summary(conn: &Connection, user_id: i64, entry_id: i64) -> AppResult<bool> {
+    let count: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM entry_summary WHERE user_id = ?1 AND entry_id = ?2 AND status = 'completed'",
+        params![user_id, entry_id],
+        |row| row.get(0),
+    )?;
+
+    Ok(count > 0)
+}
+
+/// Get summary statuses for multiple entries (batch query for list display)
+pub fn get_statuses_for_entries(
+    conn: &Connection,
+    user_id: i64,
+    entry_ids: &[i64],
+) -> AppResult<HashMap<i64, SummaryStatus>> {
+    if entry_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    // Build placeholders for IN clause
+    let placeholders: Vec<String> = entry_ids
+        .iter()
+        .enumerate()
+        .map(|(i, _)| format!("?{}", i + 2))
+        .collect();
+    let in_clause = placeholders.join(", ");
+
+    let sql = format!(
+        "SELECT entry_id, status FROM entry_summary WHERE user_id = ?1 AND entry_id IN ({})",
+        in_clause
+    );
+
+    let mut params_vec: Vec<Box<dyn rusqlite::ToSql>> = vec![Box::new(user_id)];
+    for id in entry_ids {
+        params_vec.push(Box::new(*id));
+    }
+
+    let params_refs: Vec<&dyn rusqlite::ToSql> = params_vec.iter().map(|p| p.as_ref()).collect();
+
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(params_refs.as_slice(), |row| {
+        let entry_id: i64 = row.get(0)?;
+        let status_str: String = row.get(1)?;
+        Ok((entry_id, status_str))
+    })?;
+
+    let mut map = HashMap::new();
+    for row in rows {
+        let (entry_id, status_str) = row?;
+        if let Some(status) = SummaryStatus::parse(&status_str) {
+            map.insert(entry_id, status);
+        }
+    }
+
+    Ok(map)
+}
+
+/// Get entry IDs that have completed summaries
+pub fn get_completed_entry_ids(conn: &Connection, user_id: i64) -> AppResult<Vec<i64>> {
+    let mut stmt = conn.prepare(
+        "SELECT entry_id FROM entry_summary WHERE user_id = ?1 AND status = 'completed'",
+    )?;
+
+    let ids = stmt
+        .query_map(params![user_id], |row| row.get(0))?
+        .filter_map(Result::ok)
+        .collect();
+
+    Ok(ids)
+}
+
+/// Find incomplete summaries (pending or processing) for recovery on startup
+/// Returns (user_id, entry_id, entry_link) tuples
+pub fn find_incomplete(conn: &Connection) -> AppResult<Vec<(i64, i64, String)>> {
+    let mut stmt = conn.prepare(
+        r#"
+        SELECT es.user_id, es.entry_id, e.link
+        FROM entry_summary es
+        INNER JOIN entry e ON es.entry_id = e.id
+        WHERE es.status IN ('pending', 'processing') AND e.link IS NOT NULL
+        "#,
+    )?;
+
+    let rows = stmt
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, i64>(0)?,
+                row.get::<_, i64>(1)?,
+                row.get::<_, String>(2)?,
+            ))
+        })?
+        .filter_map(Result::ok)
+        .collect();
+
+    Ok(rows)
+}
+
+/// Delete expired summaries (older than specified hours)
+pub fn delete_expired(conn: &Connection, hours: i64) -> AppResult<usize> {
+    let rows = conn.execute(
+        &format!(
+            "DELETE FROM entry_summary WHERE created_at < datetime('now', '-{} hours')",
+            hours
+        ),
+        [],
+    )?;
+
+    Ok(rows)
+}
+
+/// Check if a summary record exists (any status)
+pub fn exists(conn: &Connection, user_id: i64, entry_id: i64) -> AppResult<bool> {
+    let count: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM entry_summary WHERE user_id = ?1 AND entry_id = ?2",
+        params![user_id, entry_id],
+        |row| row.get(0),
+    )?;
+
+    Ok(count > 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::init_db;
+    use crate::models::user::Role;
+    use crate::models::{category, entry, feed, user};
+
+    fn setup_db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        init_db(&conn).unwrap();
+        conn
+    }
+
+    fn create_test_user(conn: &Connection, username: &str) -> i64 {
+        user::create_user(conn, username, "hash123", Role::User)
+            .unwrap()
+            .id
+    }
+
+    fn create_test_entry(conn: &Connection, user_id: i64) -> i64 {
+        let category_id = category::create_category(conn, user_id, "Tech").unwrap().id;
+        let feed_id = feed::create_feed(
+            conn,
+            category_id,
+            "https://example.com/feed.xml",
+            Some("Test Feed"),
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap()
+        .id;
+
+        let (entry, _) = entry::upsert_entry(
+            conn,
+            feed_id,
+            "guid-123",
+            Some("Test Entry"),
+            Some("https://example.com/entry"),
+            Some("Content"),
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+        entry.id
+    }
+
+    #[test]
+    fn test_upsert_pending() {
+        let conn = setup_db();
+        let user_id = create_test_user(&conn, "testuser");
+        let entry_id = create_test_entry(&conn, user_id);
+
+        let summary = upsert_pending(&conn, user_id, entry_id).unwrap();
+        assert_eq!(summary.status, SummaryStatus::Pending);
+        assert!(summary.summary_text.is_none());
+        assert!(summary.error_message.is_none());
+    }
+
+    #[test]
+    fn test_status_transitions() {
+        let conn = setup_db();
+        let user_id = create_test_user(&conn, "testuser");
+        let entry_id = create_test_entry(&conn, user_id);
+
+        // Create pending
+        upsert_pending(&conn, user_id, entry_id).unwrap();
+
+        // Set processing
+        set_processing(&conn, user_id, entry_id).unwrap();
+        let summary = find_by_user_and_entry(&conn, user_id, entry_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(summary.status, SummaryStatus::Processing);
+
+        // Set completed
+        set_completed(&conn, user_id, entry_id, "This is the summary").unwrap();
+        let summary = find_by_user_and_entry(&conn, user_id, entry_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(summary.status, SummaryStatus::Completed);
+        assert_eq!(summary.summary_text.as_deref(), Some("This is the summary"));
+    }
+
+    #[test]
+    fn test_set_failed() {
+        let conn = setup_db();
+        let user_id = create_test_user(&conn, "testuser");
+        let entry_id = create_test_entry(&conn, user_id);
+
+        upsert_pending(&conn, user_id, entry_id).unwrap();
+        set_failed(&conn, user_id, entry_id, "API error").unwrap();
+
+        let summary = find_by_user_and_entry(&conn, user_id, entry_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(summary.status, SummaryStatus::Failed);
+        assert_eq!(summary.error_message.as_deref(), Some("API error"));
+    }
+
+    #[test]
+    fn test_delete() {
+        let conn = setup_db();
+        let user_id = create_test_user(&conn, "testuser");
+        let entry_id = create_test_entry(&conn, user_id);
+
+        upsert_pending(&conn, user_id, entry_id).unwrap();
+        assert!(exists(&conn, user_id, entry_id).unwrap());
+
+        let deleted = delete(&conn, user_id, entry_id).unwrap();
+        assert!(deleted);
+        assert!(!exists(&conn, user_id, entry_id).unwrap());
+    }
+
+    #[test]
+    fn test_has_completed_summary() {
+        let conn = setup_db();
+        let user_id = create_test_user(&conn, "testuser");
+        let entry_id = create_test_entry(&conn, user_id);
+
+        assert!(!has_completed_summary(&conn, user_id, entry_id).unwrap());
+
+        upsert_pending(&conn, user_id, entry_id).unwrap();
+        assert!(!has_completed_summary(&conn, user_id, entry_id).unwrap());
+
+        set_completed(&conn, user_id, entry_id, "Summary text").unwrap();
+        assert!(has_completed_summary(&conn, user_id, entry_id).unwrap());
+    }
+
+    #[test]
+    fn test_get_statuses_for_entries() {
+        let conn = setup_db();
+        let user_id = create_test_user(&conn, "testuser");
+
+        // Create multiple entries
+        let category_id = category::create_category(&conn, user_id, "Tech")
+            .unwrap()
+            .id;
+        let feed_id = feed::create_feed(
+            &conn,
+            category_id,
+            "https://example.com/feed.xml",
+            Some("Test Feed"),
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap()
+        .id;
+
+        let mut entry_ids = Vec::new();
+        for i in 0..3 {
+            let (e, _) = entry::upsert_entry(
+                &conn,
+                feed_id,
+                &format!("guid-{}", i),
+                Some(&format!("Entry {}", i)),
+                Some("https://example.com/entry"),
+                None,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+            entry_ids.push(e.id);
+        }
+
+        // Set different statuses
+        upsert_pending(&conn, user_id, entry_ids[0]).unwrap();
+        upsert_pending(&conn, user_id, entry_ids[1]).unwrap();
+        set_completed(&conn, user_id, entry_ids[1], "Summary").unwrap();
+        // entry_ids[2] has no summary
+
+        let statuses = get_statuses_for_entries(&conn, user_id, &entry_ids).unwrap();
+        assert_eq!(statuses.len(), 2);
+        assert_eq!(statuses.get(&entry_ids[0]), Some(&SummaryStatus::Pending));
+        assert_eq!(statuses.get(&entry_ids[1]), Some(&SummaryStatus::Completed));
+        assert_eq!(statuses.get(&entry_ids[2]), None);
+    }
+
+    #[test]
+    fn test_find_incomplete() {
+        let conn = setup_db();
+        let user_id = create_test_user(&conn, "testuser");
+        let entry_id = create_test_entry(&conn, user_id);
+
+        upsert_pending(&conn, user_id, entry_id).unwrap();
+
+        let incomplete = find_incomplete(&conn).unwrap();
+        assert_eq!(incomplete.len(), 1);
+        assert_eq!(incomplete[0].0, user_id);
+        assert_eq!(incomplete[0].1, entry_id);
+    }
+
+    #[test]
+    fn test_upsert_resets_to_pending() {
+        let conn = setup_db();
+        let user_id = create_test_user(&conn, "testuser");
+        let entry_id = create_test_entry(&conn, user_id);
+
+        // Create and complete
+        upsert_pending(&conn, user_id, entry_id).unwrap();
+        set_completed(&conn, user_id, entry_id, "Summary").unwrap();
+
+        // Upsert should reset to pending
+        let summary = upsert_pending(&conn, user_id, entry_id).unwrap();
+        assert_eq!(summary.status, SummaryStatus::Pending);
+        assert!(summary.summary_text.is_none());
+    }
+
+    #[test]
+    fn test_status_string_conversion() {
+        assert_eq!(SummaryStatus::Pending.as_str(), "pending");
+        assert_eq!(SummaryStatus::Processing.as_str(), "processing");
+        assert_eq!(SummaryStatus::Completed.as_str(), "completed");
+        assert_eq!(SummaryStatus::Failed.as_str(), "failed");
+
+        assert_eq!(
+            SummaryStatus::parse("pending"),
+            Some(SummaryStatus::Pending)
+        );
+        assert_eq!(
+            SummaryStatus::parse("processing"),
+            Some(SummaryStatus::Processing)
+        );
+        assert_eq!(
+            SummaryStatus::parse("completed"),
+            Some(SummaryStatus::Completed)
+        );
+        assert_eq!(SummaryStatus::parse("failed"), Some(SummaryStatus::Failed));
+        assert_eq!(SummaryStatus::parse("invalid"), None);
+    }
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,5 +1,6 @@
 pub mod category;
 pub mod entry;
+pub mod entry_summary;
 pub mod feed;
 pub mod image;
 pub mod passkey;
@@ -8,4 +9,5 @@ pub mod user;
 pub mod user_settings;
 pub mod webauthn_challenge;
 
+pub use entry_summary::SummaryStatus;
 pub use user::{Role, User};

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -9,6 +9,7 @@ pub mod sanitize;
 pub mod save;
 pub mod summarize;
 pub mod summary_cache;
+pub mod summary_cleanup;
 pub mod summary_worker;
 
 pub use background::start_background_sync;
@@ -21,4 +22,7 @@ pub use sanitize::sanitize_html;
 pub use save::{BookmarkData, LinkdingConfig, SaveResult, SaveServicesConfig};
 pub use summarize::KagiConfig;
 pub use summary_cache::{create_summary_cache, SummaryCache, SummaryCacheEntry, SummaryStatus};
-pub use summary_worker::{create_summary_channel, start_summary_worker, SummaryJob};
+pub use summary_cleanup::start_cleanup_worker;
+pub use summary_worker::{
+    create_summary_channel, recover_incomplete_jobs, start_summary_worker, SummaryJob,
+};

--- a/src/services/summary_cleanup.rs
+++ b/src/services/summary_cleanup.rs
@@ -1,0 +1,124 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use rusqlite::Connection;
+use std::sync::Mutex;
+
+use crate::models::entry_summary;
+
+/// Start the summary cleanup worker that periodically removes expired summaries
+///
+/// # Arguments
+/// * `db` - Database connection
+/// * `interval_hours` - How often to run cleanup (in hours)
+/// * `ttl_hours` - Delete summaries older than this many hours
+pub fn start_cleanup_worker(db: Arc<Mutex<Connection>>, interval_hours: u64, ttl_hours: i64) {
+    tokio::spawn(async move {
+        tracing::info!(
+            "Summary cleanup worker started: interval={}h, ttl={}h",
+            interval_hours,
+            ttl_hours
+        );
+
+        let mut interval = tokio::time::interval(Duration::from_secs(interval_hours * 3600));
+
+        loop {
+            interval.tick().await;
+
+            tracing::debug!("Running summary cleanup...");
+
+            let deleted = {
+                let conn = match db.lock() {
+                    Ok(c) => c,
+                    Err(e) => {
+                        tracing::error!("Failed to acquire DB lock for cleanup: {}", e);
+                        continue;
+                    }
+                };
+
+                match entry_summary::delete_expired(&conn, ttl_hours) {
+                    Ok(count) => count,
+                    Err(e) => {
+                        tracing::error!("Failed to cleanup expired summaries: {}", e);
+                        continue;
+                    }
+                }
+            };
+
+            if deleted > 0 {
+                tracing::info!("Cleaned up {} expired summaries", deleted);
+            }
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::init_db;
+    use crate::models::user::Role;
+    use crate::models::{category, entry, feed, user};
+
+    fn setup_db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        init_db(&conn).unwrap();
+        conn
+    }
+
+    #[test]
+    fn test_delete_expired() {
+        let conn = setup_db();
+        let user_id = user::create_user(&conn, "testuser", "hash", Role::User)
+            .unwrap()
+            .id;
+        let category_id = category::create_category(&conn, user_id, "Tech")
+            .unwrap()
+            .id;
+        let feed_id = feed::create_feed(
+            &conn,
+            category_id,
+            "https://example.com/feed.xml",
+            Some("Feed"),
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap()
+        .id;
+
+        let (entry, _) = entry::upsert_entry(
+            &conn,
+            feed_id,
+            "guid-1",
+            Some("Entry"),
+            Some("https://example.com"),
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+
+        // Create a summary
+        entry_summary::upsert_pending(&conn, user_id, entry.id).unwrap();
+        entry_summary::set_completed(&conn, user_id, entry.id, "Summary text").unwrap();
+
+        // Verify it exists
+        assert!(entry_summary::exists(&conn, user_id, entry.id).unwrap());
+
+        // Manually set created_at to 25 hours ago
+        conn.execute(
+            "UPDATE entry_summary SET created_at = datetime('now', '-25 hours') WHERE user_id = ?1 AND entry_id = ?2",
+            rusqlite::params![user_id, entry.id],
+        )
+        .unwrap();
+
+        // Delete entries older than 24 hours
+        let deleted = entry_summary::delete_expired(&conn, 24).unwrap();
+        assert_eq!(deleted, 1);
+
+        // Verify it's gone
+        assert!(!entry_summary::exists(&conn, user_id, entry.id).unwrap());
+    }
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -382,11 +382,31 @@
             padding: 0 2px;
             border-radius: 2px;
         }
-        /* Summary badge */
+        /* Summary badges */
         .summary-badge {
             color: #0066cc;
             font-weight: normal;
             margin-left: 0.25rem;
+        }
+        .summary-badge-pending {
+            color: #888;
+            font-weight: normal;
+            margin-left: 0.25rem;
+        }
+        .summary-badge-processing {
+            color: #0066cc;
+            font-weight: normal;
+            margin-left: 0.25rem;
+            animation: blink 1s infinite;
+        }
+        .summary-badge-failed {
+            color: #cc0000;
+            font-weight: normal;
+            margin-left: 0.25rem;
+        }
+        @keyframes blink {
+            0%, 100% { opacity: 1; }
+            50% { opacity: 0.3; }
         }
         /* Entries count spacing */
         #entries-count {

--- a/templates/entries.html
+++ b/templates/entries.html
@@ -130,12 +130,15 @@
         const starredOnly = document.getElementById('filter-starred').checked;
         const search = document.getElementById('filter-search').value.trim();
 
+        const hasSummaryFilter = document.getElementById('filter-has-summary').checked;
+
         let url = `/api/entries?limit=${limit}&offset=${currentOffset}`;
         if (feedId) url += `&feed_id=${feedId}`;
         if (categoryId) url += `&category_id=${categoryId}`;
         if (unreadOnly) url += `&unread_only=true`;
         if (starredOnly) url += `&starred_only=true`;
         if (search) url += `&search=${encodeURIComponent(search)}`;
+        if (hasSummaryFilter) url += `&has_summary=true`;
 
         try {
             const response = await fetch(url);
@@ -162,13 +165,9 @@
     function renderEntries() {
         const container = document.getElementById('entries-list');
         const search = document.getElementById('filter-search').value.trim();
-        const hasSummaryFilter = document.getElementById('filter-has-summary').checked;
 
-        // Client-side filter for has_summary (since it's not a DB filter)
+        // Entries are already filtered server-side when has_summary is set
         let filteredEntries = entries;
-        if (hasSummaryFilter) {
-            filteredEntries = entries.filter(e => e.has_summary);
-        }
 
         if (filteredEntries.length === 0) {
             container.innerHTML = '<p class="muted">No entries found.</p>';
@@ -182,12 +181,24 @@
             const dateTitle = entry.published_at ? formatDateTime(entry.published_at) : '';
             const isRead = entry.read_at !== null;
             const isStarred = entry.starred_at !== null;
-            const hasSummary = entry.has_summary;
+            const summaryStatus = entry.summary_status;
             const feedIconHtml = entry.feed_has_icon
                 ? `<img src="/api/feeds/${entry.feed_id}/icon" alt="" class="feed-icon" onerror="this.style.display='none'">`
                 : '';
             const isSelected = index === selectedIndex;
             const titleHtml = search ? highlightText(title, search) : escapeHtml(title);
+
+            // Determine summary badge based on status
+            let summaryBadgeHtml = '';
+            if (summaryStatus === 'completed') {
+                summaryBadgeHtml = '<span title="Has Summary" class="summary-badge">[S]</span>';
+            } else if (summaryStatus === 'pending') {
+                summaryBadgeHtml = '<span title="Pending" class="summary-badge-pending">[P]</span>';
+            } else if (summaryStatus === 'processing') {
+                summaryBadgeHtml = '<span title="Processing" class="summary-badge-processing">[...]</span>';
+            } else if (summaryStatus === 'failed') {
+                summaryBadgeHtml = '<span title="Failed" class="summary-badge-failed">[F]</span>';
+            }
 
             // Check if search matches in content and generate snippet
             let contentSnippetHtml = '';
@@ -203,7 +214,7 @@
                 <div>
                     <a href="/entries/${entry.id}" style="font-weight:${isRead ? 'normal' : 'bold'};">${titleHtml}</a>
                     ${isStarred ? '<span title="Starred">*</span>' : ''}
-                    ${hasSummary ? '<span title="Has Summary" class="summary-badge">[S]</span>' : ''}
+                    ${summaryBadgeHtml}
                 </div>${contentSnippetHtml}
                 <div class="muted entry-item-meta">
                     ${feedIconHtml}<a href="#" data-feed-id="${entry.feed_id}" data-feed-category-id="${entry.category_id}">${escapeHtml(feedTitle)}</a> &middot; <a href="#" data-category-id="${entry.category_id}">${escapeHtml(entry.category_name)}</a>${date ? ` &middot; <span title="${dateTitle}">${date}</span>` : ''}
@@ -231,9 +242,7 @@
     }
 
     function updateEntriesCount() {
-        const hasSummaryFilter = document.getElementById('filter-has-summary').checked;
-        const displayedCount = hasSummaryFilter ? entries.filter(e => e.has_summary).length : entries.length;
-        document.getElementById('entries-count').textContent = `Showing ${displayedCount} of ${total} entries`;
+        document.getElementById('entries-count').textContent = `Showing ${entries.length} of ${total} entries`;
     }
 
     async function loadMore() {

--- a/templates/entry.html
+++ b/templates/entry.html
@@ -163,16 +163,34 @@
             // Load unread neighbors for N/P navigation
             loadUnreadNeighbors();
 
-            // Load cached summary if exists
-            if (data.has_summary) {
-                loadCachedSummary();
+            // Load summary based on status
+            if (data.summary_status) {
+                handleSummaryStatus(data.summary_status);
             }
         } catch (err) {
             document.getElementById('entry-container').innerHTML = '<p class="muted">[ERROR] Failed to load entry</p>';
         }
     }
 
-    async function loadCachedSummary() {
+    function handleSummaryStatus(status) {
+        if (status === 'completed') {
+            // Load the completed summary
+            loadSummaryFromServer();
+        } else if (status === 'pending' || status === 'processing') {
+            // Summary is being generated, start polling
+            const btn = document.getElementById('summarize-btn');
+            if (btn) {
+                btn.textContent = '[Summarizing...]';
+                btn.disabled = true;
+            }
+            startSummaryPolling();
+        } else if (status === 'failed') {
+            // Summary generation failed - user can retry by clicking the button
+            console.log('Previous summary generation failed');
+        }
+    }
+
+    async function loadSummaryFromServer() {
         try {
             const response = await fetch(`/api/entries/${entryId}/summary`);
             if (response.ok) {
@@ -180,10 +198,18 @@
                 if (data.status === 'completed' && data.summary_text) {
                     currentSummary = data.summary_text;
                     showSummary(data.summary_text);
+                } else if (data.status === 'pending' || data.status === 'processing') {
+                    // Still processing, start polling
+                    const btn = document.getElementById('summarize-btn');
+                    if (btn) {
+                        btn.textContent = '[Summarizing...]';
+                        btn.disabled = true;
+                    }
+                    startSummaryPolling();
                 }
             }
         } catch (err) {
-            console.error('Failed to load cached summary:', err);
+            console.error('Failed to load summary:', err);
         }
     }
 

--- a/templates/home.html
+++ b/templates/home.html
@@ -188,16 +188,30 @@
             const date = entry.published_at ? formatDate(entry.published_at) : '';
             const dateTitle = entry.published_at ? formatDateTime(entry.published_at) : '';
             const isStarred = entry.starred_at !== null;
+            const summaryStatus = entry.summary_status;
             const feedIconHtml = entry.feed_has_icon
                 ? `<img src="/api/feeds/${entry.feed_id}/icon" alt="" class="feed-icon" onerror="this.style.display='none'">`
                 : '';
             const isSelected = index === selectedIndex;
+
+            // Determine summary badge based on status
+            let summaryBadgeHtml = '';
+            if (summaryStatus === 'completed') {
+                summaryBadgeHtml = '<span title="Has Summary" class="summary-badge">[S]</span>';
+            } else if (summaryStatus === 'pending') {
+                summaryBadgeHtml = '<span title="Pending" class="summary-badge-pending">[P]</span>';
+            } else if (summaryStatus === 'processing') {
+                summaryBadgeHtml = '<span title="Processing" class="summary-badge-processing">[...]</span>';
+            } else if (summaryStatus === 'failed') {
+                summaryBadgeHtml = '<span title="Failed" class="summary-badge-failed">[F]</span>';
+            }
 
             return `
             <div class="entry-item${isSelected ? ' selected' : ''}" id="entry-${entry.id}" data-index="${index}">
                 <div>
                     <a href="/entries/${entry.id}" style="font-weight:bold;">${escapeHtml(title)}</a>
                     ${isStarred ? '<span title="Starred">*</span>' : ''}
+                    ${summaryBadgeHtml}
                 </div>
                 <div class="muted entry-item-meta">
                     ${feedIconHtml}<a href="#" data-feed-id="${entry.feed_id}" data-feed-category-id="${entry.category_id}">${escapeHtml(feedTitle)}</a> &middot; <a href="#" data-category-id="${entry.category_id}">${escapeHtml(entry.category_name)}</a>${date ? ` &middot; <span title="${dateTitle}">${date}</span>` : ''}


### PR DESCRIPTION
## Summary
- Add `entry_summary` table to persist summaries across server restarts
- Recover incomplete (pending/processing) jobs automatically on startup
- Add cleanup worker to delete expired summaries (24h TTL, runs every hour)
- Change `has_summary` boolean to `summary_status` enum (pending/processing/completed/failed)
- Move `has_summary` filter from client-side to server-side for better performance
- Add distinct UI badges for different summary states ([P] pending, [...] processing, [S] completed, [F] failed)

## Test plan
- [x] All existing tests pass (219 unit tests, 225 integration tests)
- [x] Create a summary and verify it persists after server restart
- [x] Verify incomplete summaries are recovered on startup
- [x] Verify expired summaries are cleaned up after 24 hours
- [x] Check UI shows correct badges for each summary status

🤖 Generated with [Claude Code](https://claude.com/claude-code)