### PR TITLE
Add max_age to session cookies to persist auth across browser restarts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2624,6 +2624,7 @@ dependencies = [
  "sha2",
  "tempfile",
  "thiserror 2.0.18",
+ "time",
  "tokio",
  "tower",
  "tower-http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ webauthn-rs-proto = "0.5"
 uuid = { version = "1", features = ["v4", "serde"] }
 openssl = { version = "0.10", features = ["vendored"] }
 moka = { version = "0.12", features = ["sync"] }
+time = "0.3"
 
 [build-dependencies]
 resvg = "0.45"

--- a/src/handlers/auth.rs
+++ b/src/handlers/auth.rs
@@ -1,6 +1,7 @@
 use axum::{extract::State, http::StatusCode, Json};
 use axum_extra::extract::cookie::{Cookie, CookieJar};
 use serde::{Deserialize, Serialize};
+use time::Duration;
 
 use crate::auth::{hash_password, verify_password};
 use crate::error::{AppError, AppResult};
@@ -104,6 +105,7 @@ pub async fn login(
         .path("/")
         .http_only(true)
         .same_site(axum_extra::extract::cookie::SameSite::Lax)
+        .max_age(Duration::days(session::SESSION_EXPIRY_DAYS))
         .build();
 
     Ok((

--- a/src/handlers/passkey.rs
+++ b/src/handlers/passkey.rs
@@ -5,6 +5,7 @@ use axum::{
 };
 use axum_extra::extract::cookie::{Cookie, CookieJar};
 use serde::{Deserialize, Serialize};
+use time::Duration;
 use uuid::Uuid;
 use webauthn_rs::prelude::*;
 
@@ -260,6 +261,7 @@ pub async fn finish_authentication(
         .path("/")
         .http_only(true)
         .same_site(axum_extra::extract::cookie::SameSite::Lax)
+        .max_age(Duration::days(session::SESSION_EXPIRY_DAYS))
         .build();
 
     Ok((

--- a/src/models/session.rs
+++ b/src/models/session.rs
@@ -4,7 +4,7 @@ use rusqlite::{params, Connection, OptionalExtension};
 
 use crate::error::{AppError, AppResult};
 
-const SESSION_EXPIRY_DAYS: i64 = 7;
+pub const SESSION_EXPIRY_DAYS: i64 = 7;
 const TOKEN_LENGTH: usize = 32;
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
## Summary
- Add `time` crate dependency for `Duration` type
- Set 7-day `max_age` on session cookies in both password and passkey login flows
- Export `SESSION_EXPIRY_DAYS` constant from session model for reuse

This fixes the issue where session cookies were cleared when the browser closed because they lacked a `max_age` attribute (making them session cookies). Now cookies persist for 7 days, matching the database session expiry.

## Test plan
- [x] `cargo build` compiles successfully
- [x] `cargo test` passes all 444 tests
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt --all -- --check` passes
- [x] Manual test: Login, close browser, reopen browser, verify still logged in

🤖 Generated with [Claude Code](https://claude.com/claude-code)