### PR TITLE
Add z key toggle for Kagi summary dismiss

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -565,6 +565,8 @@
                     html += '<tr><td>s</td><td>Toggle star</td></tr>';
                     html += '<tr><td>v</td><td>Open original in new tab</td></tr>';
                     html += '<tr><td>f</td><td>Toggle full content</td></tr>';
+                    html += '<tr><td>b</td><td>Save to bookmarks</td></tr>';
+                    html += '<tr><td>z</td><td>Toggle Kagi summary</td></tr>';
                     html += '<tr><td>Esc / q</td><td>Back to list</td></tr>';
                     html += '</table>';
                 }

--- a/templates/entry.html
+++ b/templates/entry.html
@@ -678,8 +678,10 @@
                     }
                     return true;
                 case 'z':
-                    // Summarize with Kagi
-                    if (hasKagiConfigured && entryData && entryData.link) {
+                    // Toggle summary - dismiss if shown, otherwise summarize with Kagi
+                    if (currentSummary) {
+                        dismissSummary();
+                    } else if (hasKagiConfigured && entryData && entryData.link) {
                         const summarizeBtn = document.getElementById('summarize-btn');
                         if (summarizeBtn && !summarizeBtn.disabled) {
                             summarizeEntry();


### PR DESCRIPTION
## Summary
- Change the `z` shortcut in Entry View from only triggering summarization to a toggle mode
- If summary is displayed, pressing `z` dismisses it (calls `dismissSummary()`)
- If summary is not displayed, pressing `z` triggers Kagi summarization (existing behavior)
- Add missing `b` and `z` shortcut descriptions to the keyboard help modal

## Test plan
- [x] Open an entry with a link
- [x] Press `z` to trigger Kagi summary
- [x] Press `z` again to dismiss the summary
- [x] Press `?` to verify help modal shows "Toggle Kagi summary" for `z` key

🤖 Generated with [Claude Code](https://claude.ai/code)