### PR TITLE
Fix version showing as 'dev' in Docker images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,6 +16,10 @@ jobs:
         with:
           fetch-depth: 0  # Fetch full history for git describe
 
+      - name: Get version from git
+        id: version
+        run: echo "GIT_VERSION=$(git describe --tags --always --dirty)" >> $GITHUB_OUTPUT
+
       - uses: docker/setup-qemu-action@v3
 
       - uses: docker/setup-buildx-action@v3
@@ -42,5 +46,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            GIT_VERSION=${{ steps.version.outputs.GIT_VERSION }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,14 @@ RUN cargo chef prepare --recipe-path recipe.json
 
 # Stage 3: Builder - build dependencies then app
 FROM chef AS builder
+
+# Accept version as build argument (for Docker builds where .git is not available)
+ARG GIT_VERSION=dev
+
 COPY --from=planner /app/recipe.json recipe.json
 RUN cargo chef cook --release --recipe-path recipe.json
 COPY . .
-RUN cargo build --release
+RUN GIT_VERSION=${GIT_VERSION} cargo build --release
 
 # Stage 4: Runtime
 FROM gcr.io/distroless/cc-debian12

--- a/build.rs
+++ b/build.rs
@@ -16,6 +16,14 @@ fn main() {
 }
 
 fn get_git_version() -> String {
+    // First, check if GIT_VERSION is set via environment variable
+    // This is used for Docker builds where .git directory is not available
+    if let Ok(version) = std::env::var("GIT_VERSION") {
+        if !version.is_empty() && version != "dev" {
+            return version;
+        }
+    }
+
     // git describe --tags --always --dirty
     // --tags: Use both annotated and lightweight tags
     // --always: Fall back to commit hash when no tags exist


### PR DESCRIPTION
Pass GIT_VERSION as a build argument to Docker builds since the .git
directory is excluded via .dockerignore. The build.rs script now checks
for a GIT_VERSION environment variable first before falling back to
git describe.

https://claude.ai/code/session_019hBoakXB5AZ5FYeMMeU1Lf