### PR TITLE
Use cross-compilation for faster ARM64 Docker builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -50,3 +50,5 @@ jobs:
             GIT_VERSION=${{ steps.version.outputs.GIT_VERSION }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          # Provenance false avoids unknown/unknown platform in manifest
+          provenance: false


### PR DESCRIPTION
## Summary
- Replace QEMU emulation with cross-compilation for ARM64 Docker builds
- Use `--platform=$BUILDPLATFORM` to run Rust compiler natively on x86_64
- Install `gcc-aarch64-linux-gnu` and configure cargo linker for ARM64 target
- Disable provenance to avoid `unknown/unknown` platform in manifest

## Motivation
QEMU emulation for ARM64 Rust compilation is 10-20x slower than native. Cross-compilation runs the compiler natively while outputting ARM64 binaries, significantly reducing CI build time.

## Test plan
- [x] Verify Docker build succeeds for both `linux/amd64` and `linux/arm64`
- [x] Verify the ARM64 image runs correctly on ARM64 hardware

🤖 Generated with [Claude Code](https://claude.com/claude-code)