### PR TITLE
Add more keyboard shortcuts (x, A, Esc)

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -551,6 +551,9 @@
                     html += '<tr><td>m</td><td>Toggle read/unread</td></tr>';
                     html += '<tr><td>s</td><td>Toggle star</td></tr>';
                     html += '<tr><td>r</td><td>Refresh list</td></tr>';
+                    html += '<tr><td>x</td><td>Reset filters</td></tr>';
+                    html += '<tr><td>A</td><td>Mark above as read</td></tr>';
+                    html += '<tr><td>Esc</td><td>Blur selector</td></tr>';
                     html += '<tr><td>/</td><td>Focus search box</td></tr>';
                     html += '</table>';
                 } else if (this.pageType === 'entry') {

--- a/templates/home.html
+++ b/templates/home.html
@@ -37,13 +37,13 @@
     </div>
     <div class="form-group form-group-inline">
         <label for="filter-category">Category</label>
-        <select id="filter-category" onchange="handleFilterChange('category')" style="width:14em;">
+        <select id="filter-category" onchange="handleFilterChange('category')" onkeydown="if(event.key==='Escape'){event.preventDefault();this.blur();}" style="width:14em;">
             <option value="">All Categories (0)</option>
         </select>
     </div>
     <div class="form-group form-group-inline">
         <label for="filter-feed">Feed</label>
-        <select id="filter-feed" onchange="handleFilterChange('feed')" style="width:14em;">
+        <select id="filter-feed" onchange="handleFilterChange('feed')" onkeydown="if(event.key==='Escape'){event.preventDefault();this.blur();}" style="width:14em;">
             <option value="">All Feeds (0)</option>
         </select>
     </div>
@@ -709,6 +709,12 @@
                 case 'r':
                     loadEntries();
                     loadUnreadStats();
+                    return true;
+                case 'x':
+                    resetFilters();
+                    return true;
+                case 'A':
+                    markAboveAsRead();
                     return true;
             }
             return false;


### PR DESCRIPTION
## Summary
- Add `x` key shortcut to reset filters on the home page
- Add `A` (Shift+A) key shortcut to mark above entries as read
- Add `Esc` keydown handler on `#filter-category` and `#filter-feed` selects to blur the focused selector
- Update the help modal (`?`) with the three new shortcuts

Closes #32

## Test plan
- [ ] Navigate to Home page, apply a category/feed filter, press `x` → filters should reset
- [ ] Load entries, press `A` → confirmation dialog appears, confirm → entries marked as read
- [ ] Click on category or feed dropdown to focus it, press `Esc` → dropdown loses focus
- [ ] Press `?` → help panel shows the three new shortcuts (x, A, Esc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)