### PR TITLE
Add focus selector shortcuts and entry filtering keys

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -553,6 +553,11 @@
                     html += '<tr><td>r</td><td>Refresh list</td></tr>';
                     html += '<tr><td>x</td><td>Reset filters</td></tr>';
                     html += '<tr><td>A</td><td>Mark above as read</td></tr>';
+                    html += '<tr><td>c</td><td>Filter by selected entry\'s category</td></tr>';
+                    html += '<tr><td>f</td><td>Filter by selected entry\'s feed</td></tr>';
+                    html += '<tr><td>S</td><td>Focus sort selector</td></tr>';
+                    html += '<tr><td>C</td><td>Focus category selector</td></tr>';
+                    html += '<tr><td>F</td><td>Focus feed selector</td></tr>';
                     html += '<tr><td>Esc</td><td>Blur selector</td></tr>';
                     html += '<tr><td>/</td><td>Focus search box</td></tr>';
                     html += '</table>';

--- a/templates/home.html
+++ b/templates/home.html
@@ -30,7 +30,7 @@
 <div class="filter-bar">
     <div class="form-group form-group-inline">
         <label for="filter-sort">Sort</label>
-        <select id="filter-sort" onchange="handleSortChange()" style="width:8em;">
+        <select id="filter-sort" onchange="handleSortChange()" onkeydown="if(event.key==='Escape'){event.preventDefault();this.blur();}" style="width:8em;">
             <option value="name" selected>Name</option>
             <option value="unread">Unread</option>
         </select>
@@ -715,6 +715,31 @@
                     return true;
                 case 'A':
                     markAboveAsRead();
+                    return true;
+                case 'c':
+                    const entryC = getSelectedEntry();
+                    if (entryC) {
+                        document.getElementById('filter-category').value = entryC.category_id;
+                        document.getElementById('filter-feed').value = '';
+                        handleFilterChange('category');
+                    }
+                    return true;
+                case 'f':
+                    const entryF = getSelectedEntry();
+                    if (entryF) {
+                        document.getElementById('filter-feed').value = entryF.feed_id;
+                        document.getElementById('filter-category').value = entryF.category_id;
+                        handleFilterChange('feed');
+                    }
+                    return true;
+                case 'S':
+                    document.getElementById('filter-sort').focus();
+                    return true;
+                case 'C':
+                    document.getElementById('filter-category').focus();
+                    return true;
+                case 'F':
+                    document.getElementById('filter-feed').focus();
                     return true;
             }
             return false;


### PR DESCRIPTION
## Summary
- Add `S`/`C`/`F` shortcuts to focus sort/category/feed selectors
- Add `c`/`f` shortcuts to filter by the selected entry's category/feed
- Add Esc handler to sort selector for consistency with category/feed selectors
- Update help modal with the five new shortcuts

## Test plan
- [x] `cargo test` — all 444 tests pass
- [ ] Press `S` → sort selector gets focus
- [ ] Press `C` → category selector gets focus
- [ ] Press `F` → feed selector gets focus
- [ ] Select an entry with `j`/`k`, press `c` → filters by that entry's category
- [ ] Select an entry with `j`/`k`, press `f` → filters by that entry's feed
- [ ] Press `Esc` while sort selector is focused → selector blurs
- [ ] Press `?` → help modal shows all five new shortcuts

🤖 Generated with [Claude Code](https://claude.com/claude-code)