### PR TITLE
Add vim-style G and gg keyboard shortcuts

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -495,6 +495,10 @@
                     case 'g f': window.location.href = '/feeds'; return true;
                     case 'g c': window.location.href = '/categories'; return true;
                 }
+                // Page-specific combo handlers
+                if (this.handlers.handleCombo) {
+                    return this.handlers.handleCombo(combo);
+                }
                 return false;
             },
 
@@ -544,6 +548,8 @@
                     html += '<h3>List Navigation</h3><table>';
                     html += '<tr><td>j</td><td>Next entry</td></tr>';
                     html += '<tr><td>k</td><td>Previous entry</td></tr>';
+                    html += '<tr><td>g g</td><td>First entry</td></tr>';
+                    html += '<tr><td>G</td><td>Last entry</td></tr>';
                     html += '<tr><td>n</td><td>Next unread entry</td></tr>';
                     html += '<tr><td>N</td><td>Previous unread entry</td></tr>';
                     html += '<tr><td>Enter / o</td><td>Open entry</td></tr>';
@@ -565,6 +571,8 @@
                     html += '<h3>Entry View</h3><table>';
                     html += '<tr><td>j</td><td>Scroll down</td></tr>';
                     html += '<tr><td>k</td><td>Scroll up</td></tr>';
+                    html += '<tr><td>g g</td><td>Scroll to top</td></tr>';
+                    html += '<tr><td>G</td><td>Scroll to bottom</td></tr>';
                     html += '<tr><td>n</td><td>Next entry</td></tr>';
                     html += '<tr><td>N</td><td>Next unread entry</td></tr>';
                     html += '<tr><td>p</td><td>Previous entry</td></tr>';

--- a/templates/entries.html
+++ b/templates/entries.html
@@ -525,6 +525,13 @@
     // Register keyboard handlers
     window.keyboard.init('list');
     window.keyboard.registerHandlers({
+        handleCombo: function(combo) {
+            if (combo === 'g g') {
+                selectEntry(0);
+                return true;
+            }
+            return false;
+        },
         handleKey: function(key, shiftKey) {
             switch (key) {
                 case 'j':
@@ -532,6 +539,9 @@
                     return true;
                 case 'k':
                     selectEntry(selectedIndex - 1);
+                    return true;
+                case 'G':
+                    if (entries.length > 0) selectEntry(entries.length - 1);
                     return true;
                 case 'n':
                     const nextUnread = findNextUnread(1);

--- a/templates/entry.html
+++ b/templates/entry.html
@@ -652,6 +652,13 @@
     // Register keyboard handlers
     window.keyboard.init('entry');
     window.keyboard.registerHandlers({
+        handleCombo: function(combo) {
+            if (combo === 'g g') {
+                window.scrollTo({ top: 0, behavior: 'smooth' });
+                return true;
+            }
+            return false;
+        },
         handleKey: function(key, shiftKey) {
             switch (key) {
                 case 'j':
@@ -659,6 +666,9 @@
                     return true;
                 case 'k':
                     scrollContent(-1);
+                    return true;
+                case 'G':
+                    window.scrollTo({ top: document.body.scrollHeight, behavior: 'smooth' });
                     return true;
                 case 'n':
                     goToNextEntry();

--- a/templates/home.html
+++ b/templates/home.html
@@ -726,6 +726,13 @@
     // Register keyboard handlers
     window.keyboard.init('list');
     window.keyboard.registerHandlers({
+        handleCombo: function(combo) {
+            if (combo === 'g g') {
+                selectEntry(0);
+                return true;
+            }
+            return false;
+        },
         handleKey: function(key, shiftKey) {
             switch (key) {
                 case 'j':
@@ -733,6 +740,9 @@
                     return true;
                 case 'k':
                     selectEntry(selectedIndex - 1);
+                    return true;
+                case 'G':
+                    if (entries.length > 0) selectEntry(entries.length - 1);
                     return true;
                 case 'n':
                     const nextUnread = findNextUnread(1);


### PR DESCRIPTION
## Summary
- Add `G` (Shift+G) shortcut: jump to last entry on list pages, scroll to bottom on entry page
- Add `g g` combo shortcut: jump to first entry on list pages, scroll to top on entry page
- Add page-specific combo handler support in the base keyboard system
- Update help panel (`?`) to document the new shortcuts

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)