### PR TITLE
Mark entry as read when viewing original content

### DIFF
--- a/templates/entries.html
+++ b/templates/entries.html
@@ -225,7 +225,7 @@
                         : `<a href="#" onclick="markRead(${entry.id}); return false;">[read]</a>`
                     }
                     <a href="#" onclick="toggleStar(${entry.id}); return false;">[${isStarred ? 'unstar' : 'star'}]</a>
-                    ${entry.link ? `<a href="${escapeHtml(entry.link)}" target="_blank" rel="noopener noreferrer">[original]</a>` : ''}
+                    ${entry.link ? `<a href="${escapeHtml(entry.link)}" target="_blank" rel="noopener noreferrer" onclick="markRead(${entry.id})">[original]</a>` : ''}
                 </div>
             </div>
             `;
@@ -500,6 +500,7 @@
     function openOriginalLink() {
         const entry = getSelectedEntry();
         if (entry && entry.link) {
+            markRead(entry.id);
             window.open(entry.link, '_blank', 'noopener,noreferrer');
         }
     }

--- a/templates/home.html
+++ b/templates/home.html
@@ -395,7 +395,7 @@
                 <div class="entry-item-actions">
                     <a href="#" onclick="markRead(${entry.id}); return false;">[read]</a>
                     <a href="#" onclick="toggleStar(${entry.id}); return false;">[${isStarred ? 'unstar' : 'star'}]</a>
-                    ${entry.link ? `<a href="${escapeHtml(entry.link)}" target="_blank" rel="noopener noreferrer">[original]</a>` : ''}
+                    ${entry.link ? `<a href="${escapeHtml(entry.link)}" target="_blank" rel="noopener noreferrer" onclick="markRead(${entry.id})">[original]</a>` : ''}
                 </div>
             </div>
             `;
@@ -698,6 +698,7 @@
     function openOriginalLink() {
         const entry = getSelectedEntry();
         if (entry && entry.link) {
+            markRead(entry.id);
             window.open(entry.link, '_blank', 'noopener,noreferrer');
         }
     }


### PR DESCRIPTION
## Summary
- Clicking the `[original]` link or pressing `v` on the Home and Entries pages now marks the entry as read automatically
- Fixes #34

## Test plan
- [x] On the Home page, click `[original]` on an unread entry and verify it is removed from the list (marked as read)
- [x] On the Home page, select an entry with `j`/`k` and press `v` to open original link, verify it is marked as read
- [x] On the Entries page, click `[original]` on an unread entry and verify it shows as read
- [x] On the Entries page, select an entry and press `v`, verify it is marked as read
- [x] Verify the Entry detail page behavior is unchanged (already auto-marks as read on load)

🤖 Generated with [Claude Code](https://claude.com/claude-code)