### PR TITLE
Bump askama from 0.12 to 0.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,46 +115,54 @@ dependencies = [
 
 [[package]]
 name = "askama"
-version = "0.12.1"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b79091df18a97caea757e28cd2d5fda49c6cd4bd01ddffd7ff01ace0c0ad2c28"
+checksum = "08e1676b346cadfec169374f949d7490fd80a24193d37d2afce0c047cf695e57"
 dependencies = [
- "askama_derive",
- "askama_escape",
- "humansize",
- "num-traits",
+ "askama_macros",
+ "itoa",
  "percent-encoding",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "askama_derive"
-version = "0.12.5"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19fe8d6cb13c4714962c072ea496f3392015f0989b1a2847bb4b2d9effd71d83"
+checksum = "7661ff56517787343f376f75db037426facd7c8d3049cef8911f1e75016f3a37"
 dependencies = [
  "askama_parser",
  "basic-toml",
- "mime",
- "mime_guess",
+ "memchr",
  "proc-macro2",
  "quote",
+ "rustc-hash",
  "serde",
+ "serde_derive",
  "syn 2.0.114",
 ]
 
 [[package]]
-name = "askama_escape"
-version = "0.10.3"
+name = "askama_macros"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
+checksum = "713ee4dbfd1eb719c2dab859465b01fa1d21cb566684614a713a6b7a99a4e47b"
+dependencies = [
+ "askama_derive",
+]
 
 [[package]]
 name = "askama_parser"
-version = "0.2.1"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acb1161c6b64d1c3d83108213c2a2533a342ac225aabd0bda218278c2ddb00c0"
+checksum = "1d62d674238a526418b30c0def480d5beadb9d8964e7f38d635b03bf639c704c"
 dependencies = [
- "nom 7.1.3",
+ "rustc-hash",
+ "serde",
+ "serde_derive",
+ "unicode-ident",
+ "winnow",
 ]
 
 [[package]]
@@ -1354,15 +1362,6 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
-name = "humansize"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
-dependencies = [
- "libm",
-]
 
 [[package]]
 name = "hyper"
@@ -4256,6 +4255,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wiremock"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
 rusqlite = { version = "0.38", features = ["bundled"] }
-askama = "0.12"
+askama = "0.15"
 argon2 = "0.5"
 rand = "0.8"
 tower-http = { version = "0.6", features = ["fs", "trace"] }
@@ -29,7 +29,12 @@ thiserror = "2"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 axum-extra = { version = "0.12", features = ["cookie"] }
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "charset", "http2", "json"] }
+reqwest = { version = "0.12", default-features = false, features = [
+  "rustls-tls",
+  "charset",
+  "http2",
+  "json",
+] }
 feed-rs = "2.1"
 scraper = "0.22"
 url = "2"
@@ -39,7 +44,9 @@ readability = { version = "0.3", default-features = false }
 base64 = "0.22"
 hmac = "0.12"
 sha2 = "0.10"
-webauthn-rs = { version = "0.5", features = ["danger-allow-state-serialisation"] }
+webauthn-rs = { version = "0.5", features = [
+  "danger-allow-state-serialisation",
+] }
 webauthn-rs-proto = "0.5"
 uuid = { version = "1", features = ["v4", "serde"] }
 openssl = { version = "0.10", features = ["vendored"] }

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -3,10 +3,10 @@
 
 {% block title %}Admin Panel - RDRS{% endblock %}
 
-{% block flash %}{% call macros::flash(flash_messages) %}{% endblock %}
+{% block flash %}{% call macros::flash(flash_messages) %}{% endcall %}{% endblock %}
 
 {% block content %}
-{% call macros::nav("admin", true, is_masquerading, username) %}
+{% call macros::nav("admin", true, is_masquerading, username) %}{% endcall %}
 
 <h1>Admin Panel</h1>
 

--- a/templates/categories.html
+++ b/templates/categories.html
@@ -3,10 +3,10 @@
 
 {% block title %}Categories - RDRS{% endblock %}
 
-{% block flash %}{% call macros::flash(flash_messages) %}{% endblock %}
+{% block flash %}{% call macros::flash(flash_messages) %}{% endcall %}{% endblock %}
 
 {% block content %}
-{% call macros::nav("categories", is_admin, is_masquerading, username) %}
+{% call macros::nav("categories", is_admin, is_masquerading, username) %}{% endcall %}
 
 <h1>Categories</h1>
 

--- a/templates/entries.html
+++ b/templates/entries.html
@@ -3,10 +3,10 @@
 
 {% block title %}Entries - RDRS{% endblock %}
 
-{% block flash %}{% call macros::flash(flash_messages) %}{% endblock %}
+{% block flash %}{% call macros::flash(flash_messages) %}{% endcall %}{% endblock %}
 
 {% block content %}
-{% call macros::nav("entries", is_admin, is_masquerading, username) %}
+{% call macros::nav("entries", is_admin, is_masquerading, username) %}{% endcall %}
 
 <h1>Entries</h1>
 

--- a/templates/entry.html
+++ b/templates/entry.html
@@ -3,10 +3,10 @@
 
 {% block title %}Entry - RDRS{% endblock %}
 
-{% block flash %}{% call macros::flash(flash_messages) %}{% endblock %}
+{% block flash %}{% call macros::flash(flash_messages) %}{% endcall %}{% endblock %}
 
 {% block content %}
-{% call macros::nav("entries", is_admin, is_masquerading, username) %}
+{% call macros::nav("entries", is_admin, is_masquerading, username) %}{% endcall %}
 
 <div id="entry-container">
     <p class="muted">Loading...</p>

--- a/templates/feeds.html
+++ b/templates/feeds.html
@@ -3,10 +3,10 @@
 
 {% block title %}Feeds - RDRS{% endblock %}
 
-{% block flash %}{% call macros::flash(flash_messages) %}{% endblock %}
+{% block flash %}{% call macros::flash(flash_messages) %}{% endcall %}{% endblock %}
 
 {% block content %}
-{% call macros::nav("feeds", is_admin, is_masquerading, username) %}
+{% call macros::nav("feeds", is_admin, is_masquerading, username) %}{% endcall %}
 
 <h1>Feeds</h1>
 

--- a/templates/home.html
+++ b/templates/home.html
@@ -3,10 +3,10 @@
 
 {% block title %}Unread - RDRS{% endblock %}
 
-{% block flash %}{% call macros::flash(flash_messages) %}{% endblock %}
+{% block flash %}{% call macros::flash(flash_messages) %}{% endcall %}{% endblock %}
 
 {% block content %}
-{% call macros::nav("home", is_admin, is_masquerading, username) %}
+{% call macros::nav("home", is_admin, is_masquerading, username) %}{% endcall %}
 
 <style>
 .filter-toggle {

--- a/templates/login.html
+++ b/templates/login.html
@@ -3,7 +3,7 @@
 
 {% block title %}Login - RDRS{% endblock %}
 
-{% block flash %}{% call macros::flash(flash_messages) %}{% endblock %}
+{% block flash %}{% call macros::flash(flash_messages) %}{% endcall %}{% endblock %}
 
 {% block content %}
 <h1>Login</h1>

--- a/templates/register.html
+++ b/templates/register.html
@@ -3,7 +3,7 @@
 
 {% block title %}Register - RDRS{% endblock %}
 
-{% block flash %}{% call macros::flash(flash_messages) %}{% endblock %}
+{% block flash %}{% call macros::flash(flash_messages) %}{% endcall %}{% endblock %}
 
 {% block content %}
 <h1>Register</h1>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -3,10 +3,10 @@
 
 {% block title %}Settings - RDRS{% endblock %}
 
-{% block flash %}{% call macros::flash(flash_messages) %}{% endblock %}
+{% block flash %}{% call macros::flash(flash_messages) %}{% endcall %}{% endblock %}
 
 {% block content %}
-{% call macros::nav("settings", is_admin, is_masquerading, username) %}
+{% call macros::nav("settings", is_admin, is_masquerading, username) %}{% endcall %}
 
 <h1>Settings</h1>
 

--- a/templates/user-settings.html
+++ b/templates/user-settings.html
@@ -3,10 +3,10 @@
 
 {% block title %}User Settings - RDRS{% endblock %}
 
-{% block flash %}{% call macros::flash(flash_messages) %}{% endblock %}
+{% block flash %}{% call macros::flash(flash_messages) %}{% endcall %}{% endblock %}
 
 {% block content %}
-{% call macros::nav("user-settings", is_admin, is_masquerading, username) %}
+{% call macros::nav("user-settings", is_admin, is_masquerading, username) %}{% endcall %}
 
 <h1>User Settings</h1>
 


### PR DESCRIPTION
## Summary
- Upgrade askama template engine from 0.12 to 0.15
- Update all template files to use `{% endcall %}` syntax for macro calls (required in Askama 0.15)

## Test plan
- [x] `cargo check` passes
- [x] `cargo test` - all 242 tests pass
- [x] `cargo build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)