### PR TITLE
Unify font sizes for better visual hierarchy

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -222,12 +222,16 @@
             padding-bottom: var(--space-4);
             border-bottom: 1px solid #ccc;
         }
+        .entry-item-title {
+            font-size: 1.1rem;
+        }
         .entry-item-meta {
-            font-size: 0.875rem;
+            font-size: 0.85rem;
             margin-top: var(--space-1);
         }
         .entry-item-actions {
             margin-top: var(--space-2);
+            font-size: 0.85rem;
         }
         /* Modal */
         .modal-overlay {

--- a/templates/entries.html
+++ b/templates/entries.html
@@ -229,7 +229,7 @@
             return `
             <div class="entry-item${isSelected ? ' selected' : ''}" id="entry-${entry.id}" data-index="${index}"${isRead ? ' style="opacity:0.6;"' : ''}>
                 <div>
-                    <a href="/entries/${entry.id}" style="font-weight:${isRead ? 'normal' : 'bold'};">${titleHtml}</a>
+                    <a href="/entries/${entry.id}" class="entry-item-title" style="font-weight:${isRead ? 'normal' : 'bold'};">${titleHtml}</a>
                     ${isStarred ? '<span title="Starred">*</span>' : ''}
                     ${summaryBadgeHtml}
                 </div>${contentSnippetHtml}

--- a/templates/entry.html
+++ b/templates/entry.html
@@ -738,7 +738,7 @@
 
 <style>
     .entry-title {
-        font-size: 1.875rem;
+        font-size: 1.6rem;
         font-weight: bold;
         line-height: 1.3;
         margin-bottom: var(--space-3);
@@ -748,7 +748,7 @@
     .entry-meta {
         color: #666;
         margin-bottom: var(--space-5);
-        font-size: 0.8rem;
+        font-size: 0.85rem;
     }
 
     .entry-actions {
@@ -781,7 +781,7 @@
     }
 
     .entry-nav a {
-        font-size: 0.8rem;
+        font-size: 0.85rem;
     }
 
     .entry-nav a.disabled {

--- a/templates/home.html
+++ b/templates/home.html
@@ -399,7 +399,7 @@
             return `
             <div class="entry-item${isSelected ? ' selected' : ''}" id="entry-${entry.id}" data-index="${index}">
                 <div>
-                    <a href="/entries/${entry.id}${getFilterQueryString()}" onclick="openEntry(${entry.id}); return false;" style="font-weight:bold;">${escapeHtml(title)}</a>
+                    <a href="/entries/${entry.id}${getFilterQueryString()}" class="entry-item-title" onclick="openEntry(${entry.id}); return false;" style="font-weight:bold;">${escapeHtml(title)}</a>
                     ${isStarred ? '<span title="Starred">*</span>' : ''}
                     ${summaryBadgeHtml}
                 </div>


### PR DESCRIPTION
## Summary
- Add `.entry-item-title` class with 1.1rem for list titles
- Adjust single entry title from 1.875rem to 1.6rem for better proportion
- Unify meta/actions/nav to 0.85rem across both list and single entry pages

This creates a consistent visual hierarchy between entry list and single entry pages.

Closes #55

## Test plan
- [x] Visit `/entries` page and verify title is larger than meta/actions
- [x] Visit single entry page and verify balanced font sizes
- [x] Confirm consistent sizing between list and single entry views

🤖 Generated with [Claude Code](https://claude.com/claude-code)