### PR TITLE
Add move-to-next behavior for 'm' key on category/feed pages

### DIFF
--- a/templates/category_entries.html
+++ b/templates/category_entries.html
@@ -376,6 +376,10 @@
         if (entry) {
             if (entry.read_at === null) {
                 await markEntryRead(entry.id);
+                // Move to next entry
+                if (selectedIndex < entries.length - 1) {
+                    selectEntry(selectedIndex + 1);
+                }
             } else {
                 await markEntryUnread(entry.id);
             }
@@ -403,7 +407,7 @@
         { key: 'N', desc: 'Previous unread entry' },
         { key: 'Enter / o', desc: 'Open entry' },
         { key: 'v', desc: 'Open original in new tab' },
-        { key: 'm', desc: 'Toggle read/unread' },
+        { key: 'm', desc: 'Mark read and next / Toggle unread' },
         { key: 's', desc: 'Toggle star' },
         { key: 'r', desc: 'Refresh list' },
         { key: 'c', desc: 'Go to category page (current)' },

--- a/templates/feed_entries.html
+++ b/templates/feed_entries.html
@@ -373,6 +373,10 @@
         if (entry) {
             if (entry.read_at === null) {
                 await markEntryRead(entry.id);
+                // Move to next entry
+                if (selectedIndex < entries.length - 1) {
+                    selectEntry(selectedIndex + 1);
+                }
             } else {
                 await markEntryUnread(entry.id);
             }
@@ -400,7 +404,7 @@
         { key: 'N', desc: 'Previous unread entry' },
         { key: 'Enter / o', desc: 'Open entry' },
         { key: 'v', desc: 'Open original in new tab' },
-        { key: 'm', desc: 'Toggle read/unread' },
+        { key: 'm', desc: 'Mark read and next / Toggle unread' },
         { key: 's', desc: 'Toggle star' },
         { key: 'r', desc: 'Refresh list' },
         { key: 'c', desc: 'Go to category page' },


### PR DESCRIPTION
## Summary
- When marking an unread entry as read with 'm' key on category/feed pages, automatically move selection to the next entry
- Matches the home page behavior for consistent keyboard navigation
- Updated help text to reflect the new behavior

## Test plan
- [x] Go to a category page with multiple unread entries
- [x] Press 'm' on an unread entry and verify it marks as read and moves to the next
- [x] Press 'm' on a read entry and verify it toggles back to unread
- [x] Repeat on a feed page

🤖 Generated with [Claude Code](https://claude.com/claude-code)