### PR TITLE
Add 'x' key for consistent navigation from feed entries

### DIFF
--- a/templates/feed_entries.html
+++ b/templates/feed_entries.html
@@ -409,7 +409,7 @@
         { key: 'm', desc: 'Mark read and next / Toggle unread' },
         { key: 's', desc: 'Toggle star' },
         { key: 'r', desc: 'Refresh list' },
-        { key: 'c', desc: 'Go to category page' },
+        { key: 'c / x', desc: 'Go to category page' },
         { key: 'f', desc: 'Refresh list (current feed)' },
     ]);
     window.keyboard.registerHandlers({
@@ -472,6 +472,7 @@
                     loadEntries();
                     return true;
                 case 'c':
+                case 'x':
                     window.location.href = `/categories/${categoryId}/entries`;
                     return true;
                 case 'f':


### PR DESCRIPTION
## Summary
- Add 'x' key binding to navigate from feed entries page to category page
- Users can now consistently press 'x' on any page to go up one level in the hierarchy (feed → category → home)

## Test plan
- [x] On feed entries page, press 'x' and verify it navigates to category entries page
- [x] On feed entries page, press 'c' and verify it still works as before
- [x] On category entries page, press 'x' and verify it navigates to home

🤖 Generated with [Claude Code](https://claude.com/claude-code)