### PR TITLE
Improve entry view navigation context with origin tracking

### DIFF
--- a/templates/category_entries.html
+++ b/templates/category_entries.html
@@ -183,7 +183,7 @@
             return `
             <div class="entry-item${isSelected ? ' selected' : ''}" id="entry-${entry.id}" data-index="${index}"${isRead ? ' style="opacity:0.6;"' : ''}>
                 <div>
-                    <a href="/entries/${entry.id}" class="entry-item-title" style="font-weight:${isRead ? 'normal' : 'bold'};">${escapeHtml(title)}</a>
+                    <a href="/entries/${entry.id}?category=${categoryId}&origin=category" class="entry-item-title" style="font-weight:${isRead ? 'normal' : 'bold'};">${escapeHtml(title)}</a>
                     ${isStarred ? '<span title="Starred">*</span>' : ''}
                     ${summaryBadgeHtml}
                 </div>
@@ -403,7 +403,7 @@
     function openSelectedEntry() {
         const entry = getSelectedEntry();
         if (entry) {
-            window.location.href = `/entries/${entry.id}`;
+            window.location.href = `/entries/${entry.id}?category=${categoryId}&origin=category`;
         }
     }
 

--- a/templates/entries.html
+++ b/templates/entries.html
@@ -147,7 +147,7 @@
             return `
             <div class="entry-item${isSelected ? ' selected' : ''}" id="entry-${entry.id}" data-index="${index}"${isRead ? ' style="opacity:0.6;"' : ''}>
                 <div>
-                    <a href="/entries/${entry.id}" class="entry-item-title" style="font-weight:${isRead ? 'normal' : 'bold'};">${escapeHtml(title)}</a>
+                    <a href="/entries/${entry.id}?origin=entries" class="entry-item-title" style="font-weight:${isRead ? 'normal' : 'bold'};">${escapeHtml(title)}</a>
                     ${isStarred ? '<span title="Starred">*</span>' : ''}
                     ${summaryBadgeHtml}
                 </div>
@@ -344,7 +344,7 @@
     function openSelectedEntry() {
         const entry = getSelectedEntry();
         if (entry) {
-            window.location.href = `/entries/${entry.id}`;
+            window.location.href = `/entries/${entry.id}?origin=entries`;
         }
     }
 

--- a/templates/entries_archive.html
+++ b/templates/entries_archive.html
@@ -153,7 +153,7 @@
             return `
             <div class="entry-item${isSelected ? ' selected' : ''}" id="entry-${entry.id}" data-index="${index}"${isRead ? ' style="opacity:0.6;"' : ''}>
                 <div>
-                    <a href="/entries/${entry.id}" class="entry-item-title" style="font-weight:${isRead ? 'normal' : 'bold'};">${escapeHtml(title)}</a>
+                    <a href="/entries/${entry.id}?origin=${pageMode}" class="entry-item-title" style="font-weight:${isRead ? 'normal' : 'bold'};">${escapeHtml(title)}</a>
                     ${isStarred ? '<span title="Starred">*</span>' : ''}
                     ${summaryBadgeHtml}
                 </div>
@@ -296,7 +296,7 @@
     function openSelectedEntry() {
         const entry = getSelectedEntry();
         if (entry) {
-            window.location.href = `/entries/${entry.id}`;
+            window.location.href = `/entries/${entry.id}?origin=${pageMode}`;
         }
     }
 

--- a/templates/entry.html
+++ b/templates/entry.html
@@ -27,24 +27,46 @@
     const urlParams = new URLSearchParams(window.location.search);
     const filterFeedId = urlParams.get('feed');
     const filterCategoryId = urlParams.get('category');
+    const filterOrigin = urlParams.get('origin');
 
     function getFilterQueryString() {
         const params = new URLSearchParams();
         if (filterFeedId) params.set('feed', filterFeedId);
         if (filterCategoryId) params.set('category', filterCategoryId);
+        if (filterOrigin) params.set('origin', filterOrigin);
         const str = params.toString();
         return str ? '?' + str : '';
     }
 
     function getBackUrl() {
-        // If we have filters, go back to unread page with filters; otherwise go to /entries
-        const filterQuery = getFilterQueryString();
-        return filterQuery ? '/' + filterQuery : '/entries';
+        if (filterOrigin === 'feed' && filterFeedId) return `/feeds/${filterFeedId}/entries`;
+        if (filterOrigin === 'category' && filterCategoryId) return `/categories/${filterCategoryId}/entries`;
+        if (filterOrigin === 'entries') return '/entries';
+        if (filterOrigin === 'read') return '/entries/read';
+        if (filterOrigin === 'starred') return '/entries/starred';
+        if (filterOrigin === 'summarized') return '/entries/summarized';
+        return '/';
+    }
+
+    function getBackLabel() {
+        if (filterOrigin === 'feed') return 'Back to Feed';
+        if (filterOrigin === 'category') return 'Back to Category';
+        if (filterOrigin === 'read') return 'Back to Read';
+        if (filterOrigin === 'starred') return 'Back to Starred';
+        if (filterOrigin === 'summarized') return 'Back to Summarized';
+        if (filterOrigin === 'entries') return 'Back to All Entries';
+        return 'Back to Unread';
     }
 
     async function loadNeighbors() {
         try {
-            const response = await fetch(`/api/entries/${entryId}/neighbors`);
+            let url = `/api/entries/${entryId}/neighbors`;
+            const params = new URLSearchParams();
+            if (filterFeedId) params.set('feed_id', filterFeedId);
+            if (filterCategoryId) params.set('category_id', filterCategoryId);
+            const qs = params.toString();
+            if (qs) url += '?' + qs;
+            const response = await fetch(url);
             if (response.ok) {
                 neighbors = await response.json();
                 updateNeighborLinks();
@@ -253,7 +275,7 @@
 
         document.getElementById('entry-container').innerHTML = `
             <div class="entry-nav">
-                <a href="${getBackUrl()}">&larr; Back to Entries</a>
+                <a href="${getBackUrl()}">&larr; ${getBackLabel()}</a>
                 <span class="entry-nav-sep">&middot;</span>
                 <a href="#" id="prev-entry-link" class="disabled">&larr; Previous</a>
                 <span class="entry-nav-sep">&middot;</span>
@@ -304,7 +326,7 @@
                 <span class="entry-nav-sep">&middot;</span>
                 <a href="#" id="prev-unread-link-bottom" class="disabled">&larr; Previous Unread</a>
                 <span class="entry-nav-sep">&middot;</span>
-                <a href="${getBackUrl()}">Back to Entries</a>
+                <a href="${getBackUrl()}">${getBackLabel()}</a>
                 <span class="entry-nav-sep">&middot;</span>
                 <a href="#" id="next-unread-link-bottom" class="disabled">Next Unread &rarr;</a>
                 <span class="entry-nav-sep">&middot;</span>

--- a/templates/feed_entries.html
+++ b/templates/feed_entries.html
@@ -180,7 +180,7 @@
             return `
             <div class="entry-item${isSelected ? ' selected' : ''}" id="entry-${entry.id}" data-index="${index}"${isRead ? ' style="opacity:0.6;"' : ''}>
                 <div>
-                    <a href="/entries/${entry.id}" class="entry-item-title" style="font-weight:${isRead ? 'normal' : 'bold'};">${escapeHtml(title)}</a>
+                    <a href="/entries/${entry.id}?feed=${feedId}&origin=feed" class="entry-item-title" style="font-weight:${isRead ? 'normal' : 'bold'};">${escapeHtml(title)}</a>
                     ${isStarred ? '<span title="Starred">*</span>' : ''}
                     ${summaryBadgeHtml}
                 </div>
@@ -400,7 +400,7 @@
     function openSelectedEntry() {
         const entry = getSelectedEntry();
         if (entry) {
-            window.location.href = `/entries/${entry.id}`;
+            window.location.href = `/entries/${entry.id}?feed=${feedId}&origin=feed`;
         }
     }
 


### PR DESCRIPTION
## Summary
- Add `origin` query parameter to entry URLs so the back button (`q` key) returns to the correct source page (feed, category, all entries, read/starred/summarized archive) instead of always defaulting to `/entries`
- Pass `feed_id`/`category_id` to the neighbors API in `loadNeighbors()`, so `n`/`p` navigation stays scoped to the current feed or category (matching existing `loadUnreadNeighbors()` behavior)
- Display context-aware back link labels (e.g., "Back to Feed", "Back to Category") instead of generic "Back to Entries"

## Test plan
- [x] From unread page → open entry → press `q` → returns to `/`
- [x] From feed entries → open entry → press `q` → returns to `/feeds/N/entries`
- [x] From category entries → open entry → press `q` → returns to `/categories/N/entries`
- [x] From all entries (`/entries`) → open entry → press `q` → returns to `/entries`
- [x] From read/starred/summarized archive → open entry → press `q` → returns to corresponding archive page
- [x] From feed page → open entry → press `n`/`p` → navigates within feed scope only
- [x] From feed page → open entry → press `n` → press `q` → still returns to original feed page (origin preserved)
- [x] Direct click on entry title link behaves same as keyboard navigation
- [x] Old URLs without params (bookmarks) still work — defaults to unread page

🤖 Generated with [Claude Code](https://claude.com/claude-code)