### PR TITLE
Auto-refresh entry lists on bfcache restore

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -844,6 +844,20 @@
                 }
             }
         };
+
+        // Helper for pages to set up bfcache restore behavior.
+        // Defined in <head> so child templates can call it during their script execution.
+        window.setupPersistedRestore = function(loadFn, getEntries, selectFn) {
+            window.onPersistedPageShow = async function() {
+                const idx = window._resumeIndex;
+                window._resumeIndex = undefined;
+                await loadFn();
+                const items = getEntries();
+                if (idx !== undefined && items.length > 0) {
+                    selectFn(Math.min(idx, items.length - 1));
+                }
+            };
+        };
     </script>
     {% block head %}{% endblock %}
 </head>

--- a/templates/category_entries.html
+++ b/templates/category_entries.html
@@ -403,7 +403,7 @@
     function openSelectedEntry() {
         const entry = getSelectedEntry();
         if (entry) {
-            if (selectedIndex >= 0) window._resumeIndex = selectedIndex + 1;
+            if (selectedIndex >= 0) window._resumeIndex = selectedIndex;
             window.location.href = `/entries/${entry.id}?category=${categoryId}&origin=category`;
         }
     }
@@ -541,14 +541,7 @@
     });
 
     // Refresh list when restored from bfcache
-    window.onPersistedPageShow = async function() {
-        var idx = window._resumeIndex;
-        window._resumeIndex = undefined;
-        await loadEntries();
-        if (idx !== undefined && entries.length > 0) {
-            selectEntry(Math.min(idx, entries.length - 1));
-        }
-    };
+    window.setupPersistedRestore(loadEntries, () => entries, selectEntry);
 
     // Initialize
     (function() {

--- a/templates/entries.html
+++ b/templates/entries.html
@@ -344,7 +344,7 @@
     function openSelectedEntry() {
         const entry = getSelectedEntry();
         if (entry) {
-            if (selectedIndex >= 0) window._resumeIndex = selectedIndex + 1;
+            if (selectedIndex >= 0) window._resumeIndex = selectedIndex;
             window.location.href = `/entries/${entry.id}?origin=entries`;
         }
     }
@@ -473,14 +473,7 @@
     });
 
     // Refresh list when restored from bfcache
-    window.onPersistedPageShow = async function() {
-        var idx = window._resumeIndex;
-        window._resumeIndex = undefined;
-        await loadEntries();
-        if (idx !== undefined && entries.length > 0) {
-            selectEntry(Math.min(idx, entries.length - 1));
-        }
-    };
+    window.setupPersistedRestore(loadEntries, () => entries, selectEntry);
 
     // Initialize
     loadEntries();

--- a/templates/entries_archive.html
+++ b/templates/entries_archive.html
@@ -296,7 +296,7 @@
     function openSelectedEntry() {
         const entry = getSelectedEntry();
         if (entry) {
-            if (selectedIndex >= 0) window._resumeIndex = selectedIndex + 1;
+            if (selectedIndex >= 0) window._resumeIndex = selectedIndex;
             window.location.href = `/entries/${entry.id}?origin=${pageMode}`;
         }
     }
@@ -435,14 +435,7 @@
     });
 
     // Refresh list when restored from bfcache
-    window.onPersistedPageShow = async function() {
-        var idx = window._resumeIndex;
-        window._resumeIndex = undefined;
-        await loadEntries();
-        if (idx !== undefined && entries.length > 0) {
-            selectEntry(Math.min(idx, entries.length - 1));
-        }
-    };
+    window.setupPersistedRestore(loadEntries, () => entries, selectEntry);
 
     // Initialize
     loadEntries();

--- a/templates/entry.html
+++ b/templates/entry.html
@@ -45,6 +45,7 @@
         if (filterOrigin === 'read') return '/entries/read';
         if (filterOrigin === 'starred') return '/entries/starred';
         if (filterOrigin === 'summarized') return '/entries/summarized';
+        if (filterOrigin === 'search') return '/search';
         return '/';
     }
 
@@ -55,6 +56,7 @@
         if (filterOrigin === 'starred') return 'Back to Starred';
         if (filterOrigin === 'summarized') return 'Back to Summarized';
         if (filterOrigin === 'entries') return 'Back to All Entries';
+        if (filterOrigin === 'search') return 'Back to Search';
         return 'Back to Unread';
     }
 

--- a/templates/feed_entries.html
+++ b/templates/feed_entries.html
@@ -400,7 +400,7 @@
     function openSelectedEntry() {
         const entry = getSelectedEntry();
         if (entry) {
-            if (selectedIndex >= 0) window._resumeIndex = selectedIndex + 1;
+            if (selectedIndex >= 0) window._resumeIndex = selectedIndex;
             window.location.href = `/entries/${entry.id}?feed=${feedId}&origin=feed`;
         }
     }
@@ -532,14 +532,7 @@
     });
 
     // Refresh list when restored from bfcache
-    window.onPersistedPageShow = async function() {
-        var idx = window._resumeIndex;
-        window._resumeIndex = undefined;
-        await loadEntries();
-        if (idx !== undefined && entries.length > 0) {
-            selectEntry(Math.min(idx, entries.length - 1));
-        }
-    };
+    window.setupPersistedRestore(loadEntries, () => entries, selectEntry);
 
     // Initialize
     (function() {

--- a/templates/search.html
+++ b/templates/search.html
@@ -149,7 +149,7 @@
             return `
             <div class="entry-item${isSelected ? ' selected' : ''}${isRead ? ' entry-read' : ''}" id="entry-${entry.id}" data-index="${index}">
                 <div>
-                    <a href="/entries/${entry.id}" class="entry-item-title ${isRead ? 'entry-title-normal' : 'entry-title-bold'}">${titleHtml}</a>
+                    <a href="/entries/${entry.id}?origin=search" class="entry-item-title ${isRead ? 'entry-title-normal' : 'entry-title-bold'}">${titleHtml}</a>
                     ${isStarred ? '<span title="Starred">*</span>' : ''}
                     ${summaryBadgeHtml}
                 </div>${contentSnippetHtml}
@@ -341,8 +341,8 @@
     function openSelectedEntry() {
         const entry = getSelectedEntry();
         if (entry) {
-            if (selectedIndex >= 0) window._resumeIndex = selectedIndex + 1;
-            window.location.href = `/entries/${entry.id}`;
+            if (selectedIndex >= 0) window._resumeIndex = selectedIndex;
+            window.location.href = `/entries/${entry.id}?origin=search`;
         }
     }
 
@@ -453,14 +453,7 @@
     });
 
     // Refresh list when restored from bfcache
-    window.onPersistedPageShow = async function() {
-        var idx = window._resumeIndex;
-        window._resumeIndex = undefined;
-        await loadEntries();
-        if (idx !== undefined && entries.length > 0) {
-            selectEntry(Math.min(idx, entries.length - 1));
-        }
-    };
+    window.setupPersistedRestore(loadEntries, () => entries, selectEntry);
 
     // Initialize from URL
     (function() {

--- a/templates/unread.html
+++ b/templates/unread.html
@@ -134,7 +134,7 @@
             return `
             <div class="entry-item${isSelected ? ' selected' : ''}" id="entry-${entry.id}" data-index="${index}">
                 <div>
-                    <a href="/entries/${entry.id}" class="entry-item-title entry-title-bold" onclick="openEntry(${entry.id}); return false;">${escapeHtml(title)}</a>
+                    <a href="/entries/${entry.id}" class="entry-item-title entry-title-bold">${escapeHtml(title)}</a>
                     ${isStarred ? '<span title="Starred">*</span>' : ''}
                     ${summaryBadgeHtml}
                 </div>
@@ -360,23 +360,11 @@
         return -1;
     }
 
-    function openEntry(id) {
-        // Remember position so bfcache restore can select the next entry
-        if (selectedIndex >= 0) window._resumeIndex = selectedIndex;
-        // Remove from list immediately so back button won't show it
-        entries = entries.filter(e => e.id !== id);
-        total--;
-        renderEntries();
-        updateLoadMoreButton();
-        updateUnreadCount();
-        // Navigate to entry page
-        window.location.href = `/entries/${id}`;
-    }
-
     function openSelectedEntry() {
         const entry = getSelectedEntry();
         if (entry) {
-            openEntry(entry.id);
+            if (selectedIndex >= 0) window._resumeIndex = selectedIndex;
+            window.location.href = `/entries/${entry.id}`;
         }
     }
 
@@ -491,14 +479,7 @@
     });
 
     // Refresh list when restored from bfcache
-    window.onPersistedPageShow = async function() {
-        var idx = window._resumeIndex;
-        window._resumeIndex = undefined;
-        await loadEntries();
-        if (idx !== undefined && entries.length > 0) {
-            selectEntry(Math.min(idx, entries.length - 1));
-        }
-    };
+    window.setupPersistedRestore(loadEntries, () => entries, selectEntry);
 
     // Initialize
     loadEntries();


### PR DESCRIPTION
## Summary
- Auto-refresh entry lists when the browser restores a page from bfcache (back/forward navigation), so users always see up-to-date read/star states
- Bypass browser HTTP cache (`cache: 'no-store'`) for entry list API fetches to ensure fresh data
- Remember selected entry position before navigating to detail page; restore selection on return
- Extract shared `setupPersistedRestore` helper in `base.html` to DRY up duplicated bfcache logic across 6 list templates
- Add `origin=search` to search result links so the entry detail page shows "Back to Search" instead of "Back to Unread"

## Test plan
- [x] From each list page (unread, entries, category, feed, search, archive), open an entry and press browser back — verify the list refreshes and the previously selected entry is re-selected
- [x] From search results, open an entry — verify "Back to Search" link appears (not "Back to Unread")
- [x] Verify normal page loads (non-bfcache) still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)