### PR TITLE
Add entries link to categories list page

### DIFF
--- a/templates/categories.html
+++ b/templates/categories.html
@@ -55,7 +55,8 @@
                 .filter(tag => tag.id.includes('/label/'))
                 .map(tag => {
                     const name = tag.id.split('/label/').pop();
-                    return { id: tag.id, name: name };
+                    const numericId = parseInt(tag.sortid, 16);
+                    return { id: tag.id, name: name, numericId: numericId };
                 });
 
             if (feedResponse.ok) {
@@ -93,6 +94,7 @@
                 <td>${feedCount}</td>
                 <td class="actions">
                     <a href="/feeds?category=${encodeURIComponent(cat.id)}">feeds</a>
+                    <a href="/categories/${cat.numericId}/entries">entries</a>
                     <a href="#" class="edit-btn" onclick="startEdit(${index}); return false;">rename</a>
                     <a href="#" class="save-btn" onclick="saveEdit(${index}); return false;" style="display:none;">save</a>
                     <a href="#" class="cancel-btn" onclick="cancelEdit(${index}); return false;" style="display:none;">cancel</a>


### PR DESCRIPTION
## Summary

- Parse `sortid` field (hex format) from GReader API response to extract numeric category ID
- Add an \"entries\" link in the Actions column of the categories table that navigates to `/categories/{id}/entries`

## Test plan

- [ ] Start the server with `cargo run`
- [ ] Navigate to `/categories`
- [ ] Verify each category row shows an \"entries\" link
- [ ] Click the link and confirm it navigates to `/categories/{id}/entries` and displays the correct entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)