### PR TITLE
fix: remove auth requirement from image proxy endpoint

### DIFF
--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -9,7 +9,6 @@ use url::Url;
 
 use crate::{
     error::{AppError, AppResult},
-    middleware::auth::AuthUser,
     services::http::{send_with_retry_on_error, RetryConfig, DEFAULT_TIMEOUT},
     services::{verify_signature, verify_signature_with_referrer},
     utils::url_validation,
@@ -49,7 +48,6 @@ fn verify_proxy_signature(
 
 pub async fn proxy_image(
     State(state): State<AppState>,
-    _user: AuthUser,
     Query(query): Query<ProxyQuery>,
 ) -> AppResult<Response> {
     // Decode the base64 URL


### PR DESCRIPTION
## Summary

- Removes `_user: AuthUser` extractor from `proxy_image` handler in `src/handlers/proxy.rs`
- External RSS readers (NetNewsWire, Reeder, etc.) load images without session cookies, causing 401 errors
- Security is maintained through HMAC-SHA256 signature verification, URL validation, Content-Type checks, and size limits

Closes #100

## Test plan

- [x] All `handlers::proxy` unit tests pass (7/7)
- [x] Web UI image loading unaffected (signature verification still required)
- [x] External RSS readers can now load proxied images without session cookies

🤖 Generated with [Claude Code](https://claude.com/claude-code)