### PR TITLE
feat: enable gzip compression for HTTP responses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,6 +215,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -565,6 +577,23 @@ name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
 
 [[package]]
 name = "const-oid"
@@ -3909,14 +3938,17 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
+ "async-compression",
  "bitflags 2.11.0",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
  "iri-string",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ argon2 = "0.5"
 password-hash = { version = "0.6", features = ["getrandom"] }
 rand_core = { version = "0.6", features = ["getrandom"] }
 rand = "0.10"
-tower-http = { version = "0.6", features = ["timeout", "trace"] }
+tower-http = { version = "0.6", features = ["compression-gzip", "timeout", "trace"] }
 tower = "0.5"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ use axum::{
     Router,
 };
 use tokio::sync::mpsc;
-use tower_http::timeout::TimeoutLayer;
+use tower_http::{compression::CompressionLayer, timeout::TimeoutLayer};
 use webauthn_rs::prelude::Webauthn;
 
 use services::http::SERVER_REQUEST_TIMEOUT;
@@ -188,6 +188,7 @@ pub fn create_router(state: AppState) -> Router {
         .route("/static/{*path}", get(handlers::static_assets::serve))
         .with_state(state)
         .layer(middleware::DateHeaderLayer::new())
+        .layer(CompressionLayer::new().gzip(true))
         .layer(TimeoutLayer::with_status_code(
             axum::http::StatusCode::REQUEST_TIMEOUT,
             SERVER_REQUEST_TIMEOUT,

--- a/tests/compression_test.rs
+++ b/tests/compression_test.rs
@@ -1,0 +1,86 @@
+//! Verifies that responses are gzip-compressed when the client advertises
+//! `Accept-Encoding: gzip`, and left untouched otherwise.
+
+use std::sync::Arc;
+
+use axum::http::{header, HeaderValue};
+use axum_test::TestServer;
+use rdrs::{auth, create_router, db, services, AppState, Config, DbPool};
+use rusqlite::Connection;
+
+fn open_shared_memory(name: &str) -> Connection {
+    let uri = format!("file:{}?mode=memory&cache=shared", name);
+    Connection::open_with_flags(
+        uri,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_WRITE
+            | rusqlite::OpenFlags::SQLITE_OPEN_CREATE
+            | rusqlite::OpenFlags::SQLITE_OPEN_URI,
+    )
+    .unwrap()
+}
+
+fn default_test_config() -> Config {
+    Config {
+        database_url: ":memory:".to_string(),
+        server_port: 3000,
+        signup_enabled: true,
+        multi_user_enabled: true,
+        image_proxy_secret: vec![0u8; 32],
+        image_proxy_secret_generated: false,
+        user_agent: "RDRS-Test/1.0".to_string(),
+        webauthn_rp_id: "localhost".to_string(),
+        webauthn_rp_origin: "http://localhost:3000".to_string(),
+        webauthn_rp_name: "rdrs-test".to_string(),
+        public_base_url: None,
+    }
+}
+
+fn create_test_server(config: Config) -> TestServer {
+    let write_conn = open_shared_memory("test_compression");
+    db::init_db(&write_conn).unwrap();
+    let read_conn = open_shared_memory("test_compression");
+
+    let (db, _handle) = DbPool::new(write_conn, read_conn);
+    let webauthn = auth::create_webauthn(&config).unwrap();
+    let summary_cache = services::create_summary_cache(100, 24);
+    let (summary_tx, _summary_rx) = services::create_summary_channel(10);
+
+    let state = AppState {
+        db,
+        config: Arc::new(config),
+        webauthn: Arc::new(webauthn),
+        summary_cache,
+        summary_tx,
+    };
+
+    TestServer::builder().build(create_router(state))
+}
+
+#[tokio::test]
+async fn test_login_page_gzip_when_accepted() {
+    let server = create_test_server(default_test_config());
+
+    let response = server
+        .get("/login")
+        .add_header(header::ACCEPT_ENCODING, HeaderValue::from_static("gzip"))
+        .await;
+
+    response.assert_status_ok();
+    let encoding = response.headers().get(header::CONTENT_ENCODING).expect(
+        "CompressionLayer should set Content-Encoding when client sends Accept-Encoding: gzip",
+    );
+    assert_eq!(encoding.to_str().unwrap(), "gzip");
+}
+
+#[tokio::test]
+async fn test_login_page_not_compressed_without_accept_encoding() {
+    let server = create_test_server(default_test_config());
+
+    let response = server.get("/login").await;
+
+    response.assert_status_ok();
+    assert!(
+        response.headers().get(header::CONTENT_ENCODING).is_none(),
+        "Responses must not be compressed when client does not advertise support"
+    );
+}


### PR DESCRIPTION
## Summary
- Wire `tower-http`'s `CompressionLayer` into the Axum router so responses are gzipped when clients advertise `Accept-Encoding: gzip`.
- Enable `compression-gzip` feature on `tower-http` in `Cargo.toml`.
- Add integration tests covering both the compressed and uncompressed paths.

## Measured impact (release build, local loopback)

| Path | Raw | gzip | Reduction |
|------|----:|-----:|----------:|
| `/login` (HTML) | 69,724 B | 10,329 B | **85.2%** |
| `/static/js/components/rdrs-entry-list.js` | 70,284 B | 12,927 B | **81.6%** |
| `/static/js/keyboard.js` | 3,449 B | 1,022 B | 70.4% |

On first page load this saves ~117 KB of transfer, i.e. ~1 s on a 3G link.

Note: tower-http's default predicate compresses bodies above 32 bytes, so very small JSON responses (e.g. `/health` at 56 B) pick up ~30 B of gzip framing overhead. Harmless in practice but worth revisiting if we later serve lots of tiny endpoints.

## Test plan
- [x] `cargo nextest run` — 667 existing + 2 new tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Manual `curl` comparison on /login and static JS confirms `Content-Encoding: gzip` and expected size reduction
- [x] Manual `curl` without `Accept-Encoding` confirms no compression header / body

🤖 Generated with [Claude Code](https://claude.com/claude-code)