### PR TITLE
fix(docker): install cross-compile target against pinned toolchain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,13 @@ FROM chef AS builder
 ARG TARGETPLATFORM
 ARG GIT_VERSION=dev
 
+# Copy the toolchain pin BEFORE any rustup invocation so that rustup resolves
+# against the pinned toolchain (rust-toolchain.toml) rather than whatever patch
+# version the base image happens to ship. Without this the base image's default
+# toolchain gets the cross-compile target installed, and then `cargo build`
+# downloads the pinned toolchain fresh (without the target) and fails.
+COPY rust-toolchain.toml .
+
 # Install cross-compilation toolchain based on target
 RUN case "$TARGETPLATFORM" in \
         "linux/arm64") \


### PR DESCRIPTION
## Summary
Docker workflow has been failing on every push since 2026-03-27 with the arm64 cross-compile stage erroring out:

```
error[E0463]: can't find crate for `core`
  = note: the `aarch64-unknown-linux-gnu` target may not be installed
```

## Root cause
- `rust-toolchain.toml` pins `channel = "1.94.0"` (added in #124 on 2026-03-15).
- `Dockerfile` uses `FROM rust:1.94-bookworm`, a floating patch tag.
- Rust **1.94.1** was released on 2026-03-25, so the base image started shipping 1.94.1 shortly after — matching the date of the first failure.
- The builder stage ran `rustup target add aarch64-unknown-linux-gnu` **before** `COPY . .`, so the target was installed under the base image's default toolchain (1.94.1).
- When `cargo build` ran later, `rust-toolchain.toml` had been copied in; rustup honored the pin and downloaded a fresh 1.94.0 toolchain — **without** the aarch64 target — and the build failed.

Verified locally:
```
$ docker run --rm -v $PWD:/app rust:1.94-bookworm bash -c '
    cd /tmp && rustup target add aarch64-unknown-linux-gnu
    cd /app && rustup show active-toolchain && rustup target list --installed'
...
1.94.0-x86_64-unknown-linux-gnu (overridden by '/app/rust-toolchain.toml')
x86_64-unknown-linux-gnu          # ← aarch64 missing
```

## Fix
Copy `rust-toolchain.toml` at the top of the builder stage, before any `rustup` invocation. rustup then resolves against the pin when installing the cross-compile target, so the target ends up on 1.94.0 — which is the toolchain `cargo build` uses later in the same stage.

## Verification
- Reproduced the broken vs. fixed rustup behavior with two throwaway `docker run` invocations (shown above).
- Full `docker buildx build --platform linux/arm64 --target builder --build-arg GIT_VERSION=test` now compiles the project end-to-end:
  - `cargo chef cook` (deps): ✅ 83 s
  - `cargo build --target aarch64-unknown-linux-gnu`: ✅ 78 s
  - Image exported: ✅

## Test plan
- [x] Scripted reproduction of the broken resolution (target missing after rust-toolchain.toml takes effect)
- [x] Scripted verification of the fix (aarch64 target listed after `rustup target add` with toolchain pin in place)
- [x] Local end-to-end `docker buildx build --platform linux/arm64 --target builder` succeeds
- [ ] Docker workflow on CI goes green after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)