### PR TITLE
feat: replace generic RSS favicon with RDRS-branded icon

### DIFF
--- a/favicon.svg
+++ b/favicon.svg
@@ -1,18 +1,17 @@
 <?xml version="1.0"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"> 
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="128px" height="128px" id="RSSicon" viewBox="0 0 256 256">
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="128px" height="128px" id="RDRSicon" viewBox="0 0 256 256">
 <defs>
-<linearGradient x1="0.085" y1="0.085" x2="0.915" y2="0.915" id="RSSg">
-<stop  offset="0.0" stop-color="#E3702D"/><stop  offset="0.1071" stop-color="#EA7D31"/>
-<stop  offset="0.3503" stop-color="#F69537"/><stop  offset="0.5" stop-color="#FB9E3A"/>
-<stop  offset="0.7016" stop-color="#EA7C31"/><stop  offset="0.8866" stop-color="#DE642B"/>
-<stop  offset="1.0" stop-color="#D95B29"/>
+<linearGradient x1="0.085" y1="0.085" x2="0.915" y2="0.915" id="RustG">
+<stop offset="0.0" stop-color="#D95B29"/>
+<stop offset="0.5" stop-color="#F49C52"/>
+<stop offset="1.0" stop-color="#FB9E3A"/>
 </linearGradient>
 </defs>
-<rect width="256" height="256" rx="55" ry="55" x="0"  y="0"  fill="#CC5D15"/>
-<rect width="246" height="246" rx="50" ry="50" x="5"  y="5"  fill="#F49C52"/>
-<rect width="236" height="236" rx="47" ry="47" x="10" y="10" fill="url(#RSSg)"/>
-<circle cx="68" cy="189" r="24" fill="#FFF"/>
-<path d="M160 213h-34a82 82 0 0 0 -82 -82v-34a116 116 0 0 1 116 116z" fill="#FFF"/>
-<path d="M184 213A140 140 0 0 0 44 73 V 38a175 175 0 0 1 175 175z" fill="#FFF"/>
+<rect width="256" height="256" rx="55" ry="55" x="0"  y="0"  fill="#1A0E08"/>
+<rect width="246" height="246" rx="50" ry="50" x="5"  y="5"  fill="#2B1810"/>
+<rect width="236" height="236" rx="47" ry="47" x="10" y="10" fill="#3D2418"/>
+<circle cx="68" cy="189" r="24" fill="url(#RustG)"/>
+<path d="M160 213h-34a82 82 0 0 0 -82 -82v-34a116 116 0 0 1 116 116z" fill="url(#RustG)"/>
+<path d="M184 213A140 140 0 0 0 44 73 V 38a175 175 0 0 1 175 175z" fill="url(#RustG)"/>
 </svg>


### PR DESCRIPTION
## Summary
- Replace the generic RSS icon (orange square with white waves) with an RDRS-branded favicon: deep rust-brown rounded square background and rust-orange gradient RSS waves.
- Distinguishes the project from generic RSS readers in browser tabs/bookmarks while signalling its Rust origin.
- Only `favicon.svg` is changed; `build.rs` regenerates `favicon.ico`, `favicon-16x16.png`, `favicon-32x32.png`, and `apple-touch-icon.png` at compile time.

## Test plan
- [x] `cargo build` succeeds and regenerates derived assets
- [x] `cargo nextest run --test handlers_test favicon` (4/4 passed)
- [ ] Visually inspect the new favicon in a browser tab at 16px, 32px, and 180px
- [ ] Verify rendering on both light and dark OS themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)