### PR TITLE
fix(css): scope article table decoration and fix feed row borders

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -531,16 +531,27 @@ code {
 .reading-pane-article h1,
 .reading-pane-article h2,
 .reading-pane-article h3,
-.reading-pane-article h4 {
+.reading-pane-article h4,
+.reading-pane-article h5,
+.reading-pane-article h6 {
     font-family: var(--font-display);
+    font-weight: 600;
     margin-top: var(--space-8);
     margin-bottom: var(--space-4);
     line-height: 1.3;
 }
 
-.reading-pane-article h1 { font-size: var(--font-2xl); }
-.reading-pane-article h2 { font-size: var(--font-xl); }
-.reading-pane-article h3 { font-size: var(--font-lg); }
+.reading-pane-article h1 { font-size: var(--font-3xl); }
+.reading-pane-article h2 { font-size: var(--font-2xl); }
+.reading-pane-article h3 { font-size: var(--font-xl); }
+.reading-pane-article h4 { font-size: var(--font-lg); }
+.reading-pane-article h5 { font-size: var(--font-base); }
+.reading-pane-article h6 {
+    font-size: var(--font-sm);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--color-text-secondary);
+}
 
 .reading-pane-article a {
     color: var(--color-accent);
@@ -618,22 +629,37 @@ code {
 }
 
 .reading-pane-article table {
+    margin: var(--space-6) 0;
+    max-width: 100%;
+}
+
+/* Reset global row/cell borders and padding so layout tables stay clean. Data
+   tables (with <th>) re-apply decoration via the :has(th) rules below. */
+.reading-pane-article tr,
+.reading-pane-article th,
+.reading-pane-article td {
+    border: 0;
+    padding: 0;
+}
+
+/* Decorate only semantic data tables (those with <th>). Layout tables lacking
+   <th> are left unstyled so feeds that abuse <table> for layout render cleanly. */
+.reading-pane-article table:has(th) {
     width: 100%;
     border-collapse: collapse;
-    margin: var(--space-6) 0;
     font-size: var(--font-base);
     display: block;
     overflow-x: auto;
 }
 
-.reading-pane-article th,
-.reading-pane-article td {
+.reading-pane-article table:has(th) th,
+.reading-pane-article table:has(th) td {
     border: 1px solid var(--color-border-light);
     padding: var(--space-2) var(--space-3);
     text-align: left;
 }
 
-.reading-pane-article th {
+.reading-pane-article table:has(th) th {
     background: var(--color-bg-tertiary);
     font-weight: 600;
 }
@@ -780,10 +806,19 @@ table {
     font-size: var(--font-sm);
 }
 
+/* Row-level border-bottom avoids per-cell segments visually breaking up the
+   horizontal rule when cells have differing content heights or paddings. */
+tr {
+    border-bottom: 1px solid var(--color-border-light);
+}
+
+thead tr {
+    border-bottom-color: var(--color-border);
+}
+
 th, td {
     text-align: left;
     padding: var(--space-3) var(--space-4);
-    border-bottom: 1px solid var(--color-border-light);
 }
 
 th {
@@ -792,7 +827,6 @@ th {
     font-size: var(--font-xs);
     text-transform: uppercase;
     letter-spacing: 0.05em;
-    border-bottom-color: var(--color-border);
 }
 
 td input[type="text"] {


### PR DESCRIPTION
## Summary

- **Article table scoping:** `.reading-pane-article table` decoration (borders, padding, background, forced `width: 100%`) is now scoped to `:has(th)`, so RSS entries that abuse `<table>` purely for layout no longer render with stray borders and big empty cells.
- **Six-level heading scale:** article content now has an explicit scale for all six heading levels (h1=`--font-3xl` down to h6=`--font-sm` with uppercase + letter-spacing), replacing the previous three-level scale where h4/h5/h6 silently fell back to the browser default (and h4 ended up larger than h3).
- **Row-level separators:** moved `border-bottom` from `th, td` to `tr` (with a darker shade on `thead tr`) so the row separator renders as one continuous line instead of per-cell segments on the feeds / settings / admin tables.

## Test plan

- [x] Open a feed whose entries use `<table>` for layout — confirm cells no longer show borders or expanded padding.
- [x] Open an entry with `<h1>` through `<h6>` — confirm clearly descending sizes, h6 styled as a small label.
- [x] Visit `/feeds` — row separators look continuous across a row, including rows with feed-icon + two-line title cells next to short text cells.
- [x] Visit `/settings`, `/admin`, `/categories` — row separators still render.
- [x] Feed with fetch error — error row still visually attaches to its parent row (no separator between them).
- [x] Phone width (<600px) — `mobile-cards` layout unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)