### PR TITLE
perf(search): SSR /search?q= and add SSR coverage tests for list pages

### DIFF
--- a/e2e/helpers/seed.ts
+++ b/e2e/helpers/seed.ts
@@ -108,6 +108,43 @@ export class SeedHelper {
     }
   }
 
+  /** Mark an entry as read (sets `read_at` to the supplied SQLite-relative time, default now). */
+  markRead(entryId: number, relativeTime: string = "0 seconds"): void {
+    const db = new Database(this.dbPath);
+    try {
+      db.prepare(
+        `UPDATE entry SET read_at = datetime('now', ?) WHERE id = ?`
+      ).run(relativeTime, entryId);
+    } finally {
+      db.close();
+    }
+  }
+
+  /** Mark an entry as starred (sets `starred_at`). */
+  markStarred(entryId: number, relativeTime: string = "0 seconds"): void {
+    const db = new Database(this.dbPath);
+    try {
+      db.prepare(
+        `UPDATE entry SET starred_at = datetime('now', ?) WHERE id = ?`
+      ).run(relativeTime, entryId);
+    } finally {
+      db.close();
+    }
+  }
+
+  /** Insert a `completed` summary row for the given entry. */
+  insertSummary(entryId: number, userId: number, text: string = "summary."): void {
+    const db = new Database(this.dbPath);
+    try {
+      db.prepare(
+        `INSERT OR IGNORE INTO entry_summary (user_id, entry_id, status, summary_text)
+         VALUES (?, ?, 'completed', ?)`
+      ).run(userId, entryId, text);
+    } finally {
+      db.close();
+    }
+  }
+
   /** Generate and insert N test entries for a feed. Returns entry IDs. */
   seedTestEntries(feedId: number, count: number): number[] {
     const entries: SeedEntry[] = [];

--- a/e2e/tests/ssr-no-double-render.spec.ts
+++ b/e2e/tests/ssr-no-double-render.spec.ts
@@ -1,0 +1,95 @@
+import { Page } from "@playwright/test";
+import { test, expect } from "../fixtures/rdrs.js";
+
+const STREAM_CONTENTS_PATH = "/reader/api/0/stream/contents/";
+
+/**
+ * Asserts that SSR-enabled list pages render their first entry directly from
+ * server HTML and skip the redundant `stream/contents` fetch on first paint.
+ * This is the perf goal of issue #148.
+ */
+test.describe("SSR list pages skip first stream/contents fetch", () => {
+  test.beforeAll(async ({ api, seed }) => {
+    await api.register("ssruser", "password123");
+
+    const userId = seed.getUserId("ssruser");
+    const categoryId = seed.createCategory(userId, "SSR Cat");
+    const feedId = seed.createFeed(
+      categoryId,
+      "https://example.com/ssr-feed.xml",
+      "SSR Feed"
+    );
+
+    seed.seedTestEntries(feedId, 5);
+
+    // Extra entry whose title matches the search test query.
+    seed.insertEntries([
+      {
+        feedId,
+        guid: "ssr-search-quokka",
+        title: "Quokka Discovery",
+        link: "https://example.com/quokka",
+        content: "<p>About a quokka.</p>",
+      },
+    ]);
+  });
+
+  async function login(page: Page, serverUrl: string): Promise<void> {
+    await page.goto(`${serverUrl}/login`);
+    await page.getByTestId("username-input").fill("ssruser");
+    await page.getByTestId("password-input").fill("password123");
+    await page.getByTestId("login-submit").click();
+    await page.waitForURL(`${serverUrl}/`);
+  }
+
+  /** Navigate to `path` and return how many `stream/contents` requests fired. */
+  async function gotoCounting(page: Page, fullUrl: string): Promise<number> {
+    let count = 0;
+    const handler = (req: { url(): string }) => {
+      if (req.url().includes(STREAM_CONTENTS_PATH)) count += 1;
+    };
+    page.on("request", handler);
+    try {
+      await page.goto(fullUrl);
+      await expect(page.getByTestId("entry-item").first()).toBeVisible();
+      // Give any deferred fetch from JS hydration time to land.
+      await page.waitForTimeout(300);
+    } finally {
+      page.off("request", handler);
+    }
+    return count;
+  }
+
+  test("/ (unread)", async ({ page, serverUrl }) => {
+    await login(page, serverUrl);
+    const count = await gotoCounting(page, `${serverUrl}/`);
+    expect(count).toBe(0);
+  });
+
+  test("/entries", async ({ page, serverUrl }) => {
+    await login(page, serverUrl);
+    const count = await gotoCounting(page, `${serverUrl}/entries`);
+    expect(count).toBe(0);
+  });
+
+  test("/feeds/:id/entries", async ({ page, serverUrl, seed }) => {
+    const feedId = seed.createFeed(
+      seed.createCategory(seed.getUserId("ssruser"), "SSR Cat"),
+      "https://example.com/ssr-feed.xml",
+      "SSR Feed"
+    );
+    await login(page, serverUrl);
+    const count = await gotoCounting(
+      page,
+      `${serverUrl}/feeds/${feedId}/entries`
+    );
+    expect(count).toBe(0);
+  });
+
+  test("/search?q=Quokka", async ({ page, serverUrl }) => {
+    await login(page, serverUrl);
+    const count = await gotoCounting(page, `${serverUrl}/search?q=Quokka`);
+    expect(count).toBe(0);
+    await expect(page.getByText("Quokka Discovery")).toBeVisible();
+  });
+});

--- a/e2e/tests/ssr-no-double-render.spec.ts
+++ b/e2e/tests/ssr-no-double-render.spec.ts
@@ -94,66 +94,165 @@ test.describe("SSR list pages skip first stream/contents fetch", () => {
   });
 });
 
-test.describe("Load More appends without duplicates after SSR hydration", () => {
-  const TOTAL = 35;
+/**
+ * Comprehensive Load More regression: every SSR-backed list route must let the
+ * client paginate without re-rendering the boundary entry. This catches the
+ * SSR/API continuation mismatch that broke /, /entries, and /categories before.
+ */
+test.describe("Load More appends without duplicates on every list route", () => {
+  // Default entries-per-page is 30; per-feed seed > 30 so Load More has work.
+  const PER_FEED = 35;
 
-  // Use a fresh username so we don't collide with the suite above.
+  // Stash IDs so the test bodies (which take fixtures separately) can reach them.
+  let unreadCategoryId: number;
+  let readCategoryId: number;
+  let unreadFeedId: number;
+  let readFeedId: number;
+
   test.beforeAll(async ({ api, seed }) => {
     await api.register("loadmoreuser", "password123");
-
     const userId = seed.getUserId("loadmoreuser");
-    const categoryId = seed.createCategory(userId, "LoadMore Cat");
-    const feedId = seed.createFeed(
-      categoryId,
-      "https://example.com/loadmore-feed.xml",
-      "LoadMore Feed"
+
+    unreadCategoryId = seed.createCategory(userId, "Unread Cat");
+    unreadFeedId = seed.createFeed(
+      unreadCategoryId,
+      "https://example.com/lm-unread.xml",
+      "Unread Feed"
     );
 
-    // Seed entries so id order matches real usage: lower id = older published_at.
-    // This is the assumption the GReader API pagination relies on (`e.id < continuation`
-    // returning *older* entries when sorting by published_at DESC).
-    const entries = Array.from({ length: TOTAL }, (_, idx) => {
+    readCategoryId = seed.createCategory(userId, "Read Cat");
+    readFeedId = seed.createFeed(
+      readCategoryId,
+      "https://example.com/lm-read.xml",
+      "Read Feed"
+    );
+
+    // Helper: seed N entries with id-correlated published_at (lower id = older).
+    const buildEntries = (
+      feedId: number,
+      prefix: string,
+      titlePrefix: string
+    ) =>
+      Array.from({ length: PER_FEED }, (_, idx) => {
+        const i = idx + 1;
+        return {
+          feedId,
+          guid: `${prefix}-${i}`,
+          title: `${titlePrefix} ${i}`,
+          link: `https://example.com/${prefix}/${i}`,
+          content: `<p>${titlePrefix} ${i}</p>`,
+          publishedOffset: `-${PER_FEED - i + 1} hours`,
+        };
+      });
+
+    seed.insertEntries(buildEntries(unreadFeedId, "lm-unread", "TestEntry"));
+    const readIds = seed.insertEntries(
+      buildEntries(readFeedId, "lm-read", "TestEntry")
+    );
+
+    // For "Read Feed" — mark every entry as read AND starred AND summarized.
+    // Timestamps for read_at / starred_at also correlate with id so each sort
+    // criterion (PublishedAt / ReadAt / StarredAt) yields the same row order
+    // — otherwise the API's `e.id < c` continuation could legitimately skip rows.
+    readIds.forEach((entryId, idx) => {
       const i = idx + 1;
-      return {
-        feedId,
-        guid: `loadmore-guid-${i}`,
-        title: `Test Entry ${i}`,
-        link: `https://example.com/entry/${i}`,
-        content: `<p>Content ${i}</p>`,
-        publishedOffset: `-${TOTAL - i + 1} hours`,
-      };
+      const offset = `-${PER_FEED - i + 1} minutes`;
+      seed.markRead(entryId, offset);
+      seed.markStarred(entryId, offset);
+      seed.insertSummary(entryId, userId, `Summary ${i}`);
     });
-    seed.insertEntries(entries);
   });
 
-  test("clicking Load More yields unique entry ids", async ({
-    page,
-    serverUrl,
-  }) => {
+  async function login(page: Page, serverUrl: string): Promise<void> {
     await page.goto(`${serverUrl}/login`);
     await page.getByTestId("username-input").fill("loadmoreuser");
     await page.getByTestId("password-input").fill("password123");
     await page.getByTestId("login-submit").click();
     await page.waitForURL(`${serverUrl}/`);
+  }
 
-    // Wait for SSR hydration.
+  async function expectNoDuplicatesAfterLoadMore(
+    page: Page,
+    fullUrl: string
+  ): Promise<void> {
+    await page.goto(fullUrl);
     await expect(page.getByTestId("entry-item").first()).toBeVisible();
-    const firstPageIds = await page
+
+    const beforeIds = await page
       .getByTestId("entry-item")
       .evaluateAll((els) => els.map((el) => el.id));
-    expect(new Set(firstPageIds).size).toBe(firstPageIds.length);
+    expect(new Set(beforeIds).size).toBe(beforeIds.length);
 
-    // Click Load More and wait for the second page to land.
-    await expect(page.getByTestId("load-more-btn")).toBeVisible();
-    await page.getByTestId("load-more-btn").click();
-    await expect(page.getByTestId("entry-item")).toHaveCount(TOTAL);
+    const loadMore = page.getByTestId("load-more-btn");
+    await expect(loadMore).toBeVisible();
+    await loadMore.click();
 
-    const allIds = await page
+    // Wait for the second page to land (entry count grows).
+    await expect
+      .poll(() => page.getByTestId("entry-item").count())
+      .toBeGreaterThan(beforeIds.length);
+
+    const afterIds = await page
       .getByTestId("entry-item")
       .evaluateAll((els) => els.map((el) => el.id));
-    expect(allIds).toHaveLength(TOTAL);
-    // Failure here means the SSR continuation off-by-one came back: the boundary entry
-    // got re-fetched on Load More and rendered twice.
-    expect(new Set(allIds).size).toBe(TOTAL);
+
+    // No duplicates — primary regression assertion.
+    expect(new Set(afterIds).size).toBe(afterIds.length);
+    // Initial entries are still present (Load More appended, didn't reset).
+    for (const id of beforeIds) {
+      expect(afterIds).toContain(id);
+    }
+  }
+
+  test("/ (unread)", async ({ page, serverUrl }) => {
+    await login(page, serverUrl);
+    await expectNoDuplicatesAfterLoadMore(page, `${serverUrl}/`);
+  });
+
+  test("/entries", async ({ page, serverUrl }) => {
+    await login(page, serverUrl);
+    await expectNoDuplicatesAfterLoadMore(page, `${serverUrl}/entries`);
+  });
+
+  test("/entries/read", async ({ page, serverUrl }) => {
+    await login(page, serverUrl);
+    await expectNoDuplicatesAfterLoadMore(page, `${serverUrl}/entries/read`);
+  });
+
+  test("/entries/starred", async ({ page, serverUrl }) => {
+    await login(page, serverUrl);
+    await expectNoDuplicatesAfterLoadMore(page, `${serverUrl}/entries/starred`);
+  });
+
+  test("/entries/summarized", async ({ page, serverUrl }) => {
+    await login(page, serverUrl);
+    await expectNoDuplicatesAfterLoadMore(
+      page,
+      `${serverUrl}/entries/summarized`
+    );
+  });
+
+  test("/categories/:id/entries", async ({ page, serverUrl }) => {
+    await login(page, serverUrl);
+    await expectNoDuplicatesAfterLoadMore(
+      page,
+      `${serverUrl}/categories/${unreadCategoryId}/entries`
+    );
+  });
+
+  test("/feeds/:id/entries", async ({ page, serverUrl }) => {
+    await login(page, serverUrl);
+    await expectNoDuplicatesAfterLoadMore(
+      page,
+      `${serverUrl}/feeds/${unreadFeedId}/entries`
+    );
+  });
+
+  test("/search?q=TestEntry", async ({ page, serverUrl }) => {
+    await login(page, serverUrl);
+    await expectNoDuplicatesAfterLoadMore(
+      page,
+      `${serverUrl}/search?q=TestEntry`
+    );
   });
 });

--- a/e2e/tests/ssr-no-double-render.spec.ts
+++ b/e2e/tests/ssr-no-double-render.spec.ts
@@ -93,3 +93,67 @@ test.describe("SSR list pages skip first stream/contents fetch", () => {
     await expect(page.getByText("Quokka Discovery")).toBeVisible();
   });
 });
+
+test.describe("Load More appends without duplicates after SSR hydration", () => {
+  const TOTAL = 35;
+
+  // Use a fresh username so we don't collide with the suite above.
+  test.beforeAll(async ({ api, seed }) => {
+    await api.register("loadmoreuser", "password123");
+
+    const userId = seed.getUserId("loadmoreuser");
+    const categoryId = seed.createCategory(userId, "LoadMore Cat");
+    const feedId = seed.createFeed(
+      categoryId,
+      "https://example.com/loadmore-feed.xml",
+      "LoadMore Feed"
+    );
+
+    // Seed entries so id order matches real usage: lower id = older published_at.
+    // This is the assumption the GReader API pagination relies on (`e.id < continuation`
+    // returning *older* entries when sorting by published_at DESC).
+    const entries = Array.from({ length: TOTAL }, (_, idx) => {
+      const i = idx + 1;
+      return {
+        feedId,
+        guid: `loadmore-guid-${i}`,
+        title: `Test Entry ${i}`,
+        link: `https://example.com/entry/${i}`,
+        content: `<p>Content ${i}</p>`,
+        publishedOffset: `-${TOTAL - i + 1} hours`,
+      };
+    });
+    seed.insertEntries(entries);
+  });
+
+  test("clicking Load More yields unique entry ids", async ({
+    page,
+    serverUrl,
+  }) => {
+    await page.goto(`${serverUrl}/login`);
+    await page.getByTestId("username-input").fill("loadmoreuser");
+    await page.getByTestId("password-input").fill("password123");
+    await page.getByTestId("login-submit").click();
+    await page.waitForURL(`${serverUrl}/`);
+
+    // Wait for SSR hydration.
+    await expect(page.getByTestId("entry-item").first()).toBeVisible();
+    const firstPageIds = await page
+      .getByTestId("entry-item")
+      .evaluateAll((els) => els.map((el) => el.id));
+    expect(new Set(firstPageIds).size).toBe(firstPageIds.length);
+
+    // Click Load More and wait for the second page to land.
+    await expect(page.getByTestId("load-more-btn")).toBeVisible();
+    await page.getByTestId("load-more-btn").click();
+    await expect(page.getByTestId("entry-item")).toHaveCount(TOTAL);
+
+    const allIds = await page
+      .getByTestId("entry-item")
+      .evaluateAll((els) => els.map((el) => el.id));
+    expect(allIds).toHaveLength(TOTAL);
+    // Failure here means the SSR continuation off-by-one came back: the boundary entry
+    // got re-fetched on Load More and rendered twice.
+    expect(new Set(allIds).size).toBe(TOTAL);
+  });
+});

--- a/src/handlers/pages.rs
+++ b/src/handlers/pages.rs
@@ -1534,7 +1534,17 @@ pub async fn starred_entries_page(
         starred_only: true,
         ..Default::default()
     };
-    let cfg = fetch_entry_list_config(&state, auth_user.user.id, filter, query.entry).await;
+    // Match the GReader `stream/contents` API which sorts the `starred` stream by `starred_at`.
+    // SSR using `PublishedAt` here would let Load More return entries in a different order than
+    // the SSR-rendered first page.
+    let cfg = fetch_entry_list_config_with_sort(
+        &state,
+        auth_user.user.id,
+        filter,
+        query.entry,
+        entry::EntrySortOrder::StarredAt,
+    )
+    .await;
 
     (
         flash.clone(),

--- a/src/handlers/pages.rs
+++ b/src/handlers/pages.rs
@@ -1727,7 +1727,7 @@ pub async fn category_entries_page(
     ))
 }
 
-// Search page (no SSR entries - loads on user input)
+// Search page: SSR entries on first load when ?q= is provided
 #[derive(Template)]
 #[template(path = "search.html")]
 pub struct SearchTemplate {
@@ -1738,6 +1738,11 @@ pub struct SearchTemplate {
     pub entries_per_page: i64,
     pub has_save_services: bool,
     pub has_kagi_configured: bool,
+    pub search_query: String,
+    pub empty_message: String,
+    pub ssr_entries_json: String,
+    pub ssr_entry_views: Vec<SsrEntryView>,
+    pub ssr_has_continuation: bool,
     pub ssr_reading_pane: Option<SsrReadingPaneEntry>,
     pub ssr_reading_pane_json: String,
     pub theme: Option<String>,
@@ -1755,10 +1760,16 @@ impl IntoResponse for SearchTemplate {
     }
 }
 
+#[derive(serde::Deserialize, Default)]
+pub struct SearchPageQuery {
+    pub q: Option<String>,
+    pub entry: Option<i64>,
+}
+
 pub async fn search_page(
     auth_user: PageAuthUser,
     State(state): State<AppState>,
-    Query(query): Query<EntryQuery>,
+    Query(query): Query<SearchPageQuery>,
     flash: Flash,
 ) -> (Flash, SearchTemplate) {
     let is_masquerading = auth_user.session.is_masquerading();
@@ -1768,9 +1779,93 @@ pub async fn search_page(
         auth_user.user.is_admin()
     };
 
-    // Search doesn't need SSR entries - pass a dummy filter that won't fetch
-    let filter = entry::EntryFilter::default();
-    let cfg = fetch_entry_list_config(&state, auth_user.user.id, filter, query.entry).await;
+    let user_id = auth_user.user.id;
+    let secret = state.config.image_proxy_secret.clone();
+    let proxy_base_url = state.config.public_base_url.clone();
+    let search_query = query
+        .q
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+    let q_for_ssr = search_query.clone();
+    let rp_entry_id = query.entry;
+
+    let cfg = state
+        .db
+        .read_user(move |c| {
+            let epp = user_settings::get_entries_per_page(c, user_id)
+                .unwrap_or(user_settings::DEFAULT_ENTRIES_PER_PAGE);
+            let save_services = user_settings::has_save_services(c, user_id).unwrap_or(false);
+            let save_config =
+                user_settings::get_save_services_config(c, user_id).unwrap_or_default();
+            let kagi_configured = save_config
+                .kagi
+                .as_ref()
+                .map(|k| k.is_configured())
+                .unwrap_or(false);
+            let theme = user_settings::get_theme(c, user_id).unwrap_or(None);
+            let (sidebar_cats, sidebar_unread) = fetch_sidebar_data(c, user_id);
+
+            let (ssr_json, ssr_views, ssr_continuation) = match q_for_ssr {
+                Some(q) => {
+                    let filter = entry::EntryFilter {
+                        search: Some(q),
+                        ..Default::default()
+                    };
+                    let ssr = fetch_entries_for_ssr(c, user_id, &filter, epp);
+                    (ssr.json, ssr.views, ssr.has_continuation)
+                }
+                None => {
+                    // Emit a valid (but empty) SSR payload so the JS component hydrates the
+                    // server-rendered empty placeholder in place rather than re-rendering it.
+                    let json = escape_json_for_script(r#"{"entries":[],"continuation":null}"#);
+                    (json, vec![], false)
+                }
+            };
+
+            let rp = rp_entry_id.and_then(|eid| {
+                fetch_reading_pane_entry(c, user_id, eid, &secret, proxy_base_url.as_deref())
+            });
+            let rp_json = rp
+                .as_ref()
+                .map(|e| escape_json_for_script(&serde_json::to_string(e).unwrap_or_default()))
+                .unwrap_or_default();
+
+            EntryListConfig {
+                entries_per_page: epp,
+                has_save_services: save_services,
+                has_kagi_configured: kagi_configured,
+                ssr_entries_json: ssr_json,
+                ssr_entry_views: ssr_views,
+                ssr_has_continuation: ssr_continuation,
+                ssr_reading_pane: rp,
+                ssr_reading_pane_json: rp_json,
+                theme,
+                sidebar_categories: sidebar_cats,
+                sidebar_unread_count: sidebar_unread,
+            }
+        })
+        .await
+        .unwrap_or(EntryListConfig {
+            entries_per_page: user_settings::DEFAULT_ENTRIES_PER_PAGE,
+            has_save_services: false,
+            has_kagi_configured: false,
+            ssr_entries_json: "null".to_string(),
+            ssr_entry_views: vec![],
+            ssr_has_continuation: false,
+            ssr_reading_pane: None,
+            ssr_reading_pane_json: String::new(),
+            theme: None,
+            sidebar_categories: vec![],
+            sidebar_unread_count: 0,
+        });
+
+    let empty_message = if search_query.is_some() {
+        "No matching entries.".to_string()
+    } else {
+        "Enter a search term and press Enter to search.".to_string()
+    };
 
     (
         flash.clone(),
@@ -1782,6 +1877,11 @@ pub async fn search_page(
             entries_per_page: cfg.entries_per_page,
             has_save_services: cfg.has_save_services,
             has_kagi_configured: cfg.has_kagi_configured,
+            search_query: search_query.unwrap_or_default(),
+            empty_message,
+            ssr_entries_json: cfg.ssr_entries_json,
+            ssr_entry_views: cfg.ssr_entry_views,
+            ssr_has_continuation: cfg.ssr_has_continuation,
             ssr_reading_pane: cfg.ssr_reading_pane,
             ssr_reading_pane_json: cfg.ssr_reading_pane_json,
             theme: cfg.theme,

--- a/src/handlers/pages.rs
+++ b/src/handlers/pages.rs
@@ -431,9 +431,15 @@ fn fetch_entries_for_ssr_with_sort(
     let mut entries = entry::list_by_user_with_continuation(conn, user_id, filter, &pagination)
         .unwrap_or_default();
 
-    let continuation = if entries.len() as i64 > limit {
-        let last = entries.pop().unwrap();
-        Some(last.entry.id.to_string())
+    // The API side (`stream_contents`) defines `continuation` as the ID of the LAST visible
+    // entry on the current page, then queries `e.id < continuation` for the next page. We must
+    // match that convention or "Load More" will refetch the boundary entry and render duplicates.
+    let has_more = entries.len() as i64 > limit;
+    if has_more {
+        entries.pop();
+    }
+    let continuation = if has_more {
+        entries.last().map(|e| e.entry.id.to_string())
     } else {
         None
     };

--- a/static/js/components/rdrs-entry-list.js
+++ b/static/js/components/rdrs-entry-list.js
@@ -129,6 +129,8 @@ class RdrsEntryList extends HTMLElement {
     get readingPaneSelector() { return this.getAttribute('reading-pane') || null; }
     get hasSaveServices() { return this.hasAttribute('has-save-services'); }
     get hasKagiConfigured() { return this.hasAttribute('has-kagi-configured'); }
+    /** True after SSR HTML has been hydrated in place. Lets callers skip a redundant loadEntries(). */
+    get hydrated() { return this._hydrated; }
 
     /** Get the reading pane element, if configured. */
     _getReadingPane() {

--- a/templates/search.html
+++ b/templates/search.html
@@ -19,6 +19,7 @@
                 <div class="filter-bar">
                     <div class="form-group form-group-inline flex-1">
                         <input type="text" id="filter-search" placeholder="Search entries..."
+                               value="{{ search_query }}"
                                autofocus data-testid="search-input">
                     </div>
                     <div>
@@ -34,12 +35,11 @@
                     origin="search"
                     show-feed
                     show-category
-                    empty-message="Enter a search term and press Enter to search."
                     no-auto-load
                     reading-pane="#reading-pane"
                     {% if has_save_services %}has-save-services{% endif %}
                     {% if has_kagi_configured %}has-kagi-configured{% endif %}
-                ></rdrs-entry-list>
+                >{% call macros::entry_list_content(ssr_entry_views, ssr_has_continuation, ssr_entries_json, "search", true, true, false, false, empty_message) %}{% endcall %}</rdrs-entry-list>
             </div>
         </div>
 
@@ -85,7 +85,10 @@
         if (query) {
             searchInput.value = query;
             list.search = query;
-            list.loadEntries();
+            // SSR may have already hydrated entries on first load; skip the API round-trip then.
+            if (!list.hydrated) {
+                list.loadEntries();
+            }
         }
 
         list.registerKeyboardHandlers({

--- a/tests/pages_test.rs
+++ b/tests/pages_test.rs
@@ -963,6 +963,204 @@ async fn test_feed_entries_page_contains_ssr_json() {
 }
 
 #[tokio::test]
+async fn test_read_entries_page_contains_ssr_entries_json() {
+    let app = create_test_app(default_test_config());
+    setup_users(&app.db).await;
+
+    app.db
+        .user(move |conn| {
+            conn.execute(
+                "INSERT INTO category (user_id, name) VALUES (?1, ?2)",
+                rusqlite::params![1, "Read SSR Cat"],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO feed (category_id, url, title) VALUES (?1, ?2, ?3)",
+                rusqlite::params![1, "https://example.com/read-ssr.xml", "Read SSR Feed"],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO entry (feed_id, guid, title, read_at) VALUES (?1, ?2, ?3, datetime('now'))",
+                rusqlite::params![1, "read-ssr-guid", "Read SSR Entry"],
+            )
+            .unwrap();
+        })
+        .await
+        .unwrap();
+
+    login(&app.server, "admin").await;
+
+    let response = app.server.get("/entries/read").await;
+    response.assert_status_ok();
+    let body = response.text();
+
+    assert!(body.contains(r#"<script type="application/json" class="ssr-entries">"#));
+    assert!(body.contains("Read SSR Entry"));
+}
+
+#[tokio::test]
+async fn test_starred_entries_page_contains_ssr_entries_json() {
+    let app = create_test_app(default_test_config());
+    setup_users(&app.db).await;
+
+    app.db
+        .user(move |conn| {
+            conn.execute(
+                "INSERT INTO category (user_id, name) VALUES (?1, ?2)",
+                rusqlite::params![1, "Starred SSR Cat"],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO feed (category_id, url, title) VALUES (?1, ?2, ?3)",
+                rusqlite::params![1, "https://example.com/star-ssr.xml", "Starred SSR Feed"],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO entry (feed_id, guid, title, starred_at) VALUES (?1, ?2, ?3, datetime('now'))",
+                rusqlite::params![1, "star-ssr-guid", "Starred SSR Entry"],
+            )
+            .unwrap();
+        })
+        .await
+        .unwrap();
+
+    login(&app.server, "admin").await;
+
+    let response = app.server.get("/entries/starred").await;
+    response.assert_status_ok();
+    let body = response.text();
+
+    assert!(body.contains(r#"<script type="application/json" class="ssr-entries">"#));
+    assert!(body.contains("Starred SSR Entry"));
+}
+
+#[tokio::test]
+async fn test_summarized_entries_page_contains_ssr_entries_json() {
+    let app = create_test_app(default_test_config());
+    setup_users(&app.db).await;
+
+    app.db
+        .user(move |conn| {
+            conn.execute(
+                "INSERT INTO category (user_id, name) VALUES (?1, ?2)",
+                rusqlite::params![1, "Summary SSR Cat"],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO feed (category_id, url, title) VALUES (?1, ?2, ?3)",
+                rusqlite::params![1, "https://example.com/sum-ssr.xml", "Summary SSR Feed"],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO entry (feed_id, guid, title) VALUES (?1, ?2, ?3)",
+                rusqlite::params![1, "sum-ssr-guid", "Summary SSR Entry"],
+            )
+            .unwrap();
+            // entry_summary table marks the entry as having a summary
+            conn.execute(
+                "INSERT INTO entry_summary (entry_id, user_id, status, summary_text) VALUES (?1, ?2, ?3, ?4)",
+                rusqlite::params![1, 1, "completed", "A short summary."],
+            )
+            .unwrap();
+        })
+        .await
+        .unwrap();
+
+    login(&app.server, "admin").await;
+
+    let response = app.server.get("/entries/summarized").await;
+    response.assert_status_ok();
+    let body = response.text();
+
+    assert!(body.contains(r#"<script type="application/json" class="ssr-entries">"#));
+    assert!(body.contains("Summary SSR Entry"));
+}
+
+#[tokio::test]
+async fn test_search_page_contains_ssr_entries_json_when_query_present() {
+    let app = create_test_app(default_test_config());
+    setup_users(&app.db).await;
+
+    app.db
+        .user(move |conn| {
+            conn.execute(
+                "INSERT INTO category (user_id, name) VALUES (?1, ?2)",
+                rusqlite::params![1, "Search SSR Cat"],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO feed (category_id, url, title) VALUES (?1, ?2, ?3)",
+                rusqlite::params![1, "https://example.com/search-ssr.xml", "Search SSR Feed"],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO entry (feed_id, guid, title) VALUES (?1, ?2, ?3)",
+                rusqlite::params![1, "search-ssr-guid", "Quokka Discovery"],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO entry (feed_id, guid, title) VALUES (?1, ?2, ?3)",
+                rusqlite::params![1, "search-ssr-guid-2", "Unrelated Pelican"],
+            )
+            .unwrap();
+        })
+        .await
+        .unwrap();
+
+    login(&app.server, "admin").await;
+
+    let response = app.server.get("/search?q=Quokka").await;
+    response.assert_status_ok();
+    let body = response.text();
+
+    // SSR script tag must be present and only the matching entry rendered.
+    assert!(body.contains(r#"<script type="application/json" class="ssr-entries">"#));
+    assert!(body.contains("Quokka Discovery"));
+    assert!(!body.contains("Unrelated Pelican"));
+    // Search input should be pre-filled with the query.
+    assert!(body.contains(r#"value="Quokka""#));
+}
+
+#[tokio::test]
+async fn test_search_page_without_query_emits_empty_ssr_payload() {
+    let app = create_test_app(default_test_config());
+    setup_users(&app.db).await;
+
+    app.db
+        .user(move |conn| {
+            conn.execute(
+                "INSERT INTO category (user_id, name) VALUES (?1, ?2)",
+                rusqlite::params![1, "Search Empty Cat"],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO feed (category_id, url, title) VALUES (?1, ?2, ?3)",
+                rusqlite::params![1, "https://example.com/empty.xml", "Empty Feed"],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO entry (feed_id, guid, title) VALUES (?1, ?2, ?3)",
+                rusqlite::params![1, "empty-guid", "Should Not Appear"],
+            )
+            .unwrap();
+        })
+        .await
+        .unwrap();
+
+    login(&app.server, "admin").await;
+
+    let response = app.server.get("/search").await;
+    response.assert_status_ok();
+    let body = response.text();
+
+    // SSR script tag is still present but with empty entries (no DB fetch happened).
+    assert!(body.contains(r#"<script type="application/json" class="ssr-entries">"#));
+    assert!(body.contains(r#"{"entries":[],"continuation":null}"#));
+    assert!(!body.contains("Should Not Appear"));
+    assert!(body.contains("Enter a search term"));
+}
+
+#[tokio::test]
 async fn test_feeds_page_renders_ssr_feed_rows() {
     let app = create_test_app(default_test_config());
     setup_users(&app.db).await;

--- a/tests/pages_test.rs
+++ b/tests/pages_test.rs
@@ -1122,6 +1122,84 @@ async fn test_search_page_contains_ssr_entries_json_when_query_present() {
 }
 
 #[tokio::test]
+async fn test_ssr_continuation_matches_api_convention_no_duplicates_on_load_more() {
+    // Regression test for issue #148 follow-up: SSR's continuation token must be the ID of
+    // the LAST visible entry (matching `stream_contents` API convention), NOT the ID of the
+    // popped boundary entry. Otherwise the next-page query `e.id < c` re-fetches the boundary
+    // entry and the client renders duplicates after Load More.
+    let app = create_test_app(default_test_config());
+    setup_users(&app.db).await;
+
+    app.db
+        .user(move |conn| {
+            conn.execute(
+                "INSERT INTO category (user_id, name) VALUES (?1, ?2)",
+                rusqlite::params![1, "Pag Cat"],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO feed (category_id, url, title) VALUES (?1, ?2, ?3)",
+                rusqlite::params![1, "https://example.com/pag.xml", "Pag Feed"],
+            )
+            .unwrap();
+            // Pin entries-per-page to MIN_ENTRIES_PER_PAGE (10) so we can predict the boundary.
+            conn.execute(
+                "INSERT INTO user_settings (user_id, entries_per_page) VALUES (?1, ?2)",
+                rusqlite::params![1, 10],
+            )
+            .unwrap();
+            // 12 entries; published_at decreasing so newest first ⇒ entry id 12 .. 1 in SSR.
+            for i in 1..=12 {
+                conn.execute(
+                    "INSERT INTO entry (feed_id, guid, title, published_at) VALUES (?1, ?2, ?3, datetime('now', ?4))",
+                    rusqlite::params![
+                        1,
+                        format!("p-{}", i),
+                        format!("E{}", i),
+                        format!("-{} hours", 12 - i)
+                    ],
+                )
+                .unwrap();
+            }
+        })
+        .await
+        .unwrap();
+
+    login(&app.server, "admin").await;
+
+    let response = app.server.get("/").await;
+    response.assert_status_ok();
+    let body = response.text();
+
+    let marker = r#"<script type="application/json" class="ssr-entries">"#;
+    let json_start = body.find(marker).expect("ssr-entries script") + marker.len();
+    let json_end = body[json_start..]
+        .find("</script>")
+        .expect("ssr-entries script close");
+    let json = &body[json_start..json_start + json_end];
+    let value: serde_json::Value = serde_json::from_str(json).expect("valid SSR JSON");
+
+    let entries = value["entries"].as_array().expect("entries array");
+    assert_eq!(
+        entries.len(),
+        10,
+        "first page should have 10 visible entries"
+    );
+
+    let continuation = value["continuation"]
+        .as_str()
+        .expect("continuation present when more pages exist");
+    let last_visible_id = entries[9]["id"].as_i64().expect("last entry id");
+
+    assert_eq!(
+        continuation,
+        last_visible_id.to_string(),
+        "SSR continuation must equal last visible entry id (API convention); off-by-one would \
+         re-render the boundary entry on Load More"
+    );
+}
+
+#[tokio::test]
 async fn test_search_page_without_query_emits_empty_ssr_payload() {
     let app = create_test_app(default_test_config());
     setup_users(&app.db).await;


### PR DESCRIPTION
Closes #148.

## Summary

- Adds SSR support to `/search` when `?q=` is in the URL so deep-linked search results render on first paint without an extra `stream/contents` round-trip.
- Aligns the SSR continuation token with the GReader API's convention (last visible entry id, not the popped boundary) so "Load More" no longer re-fetches the boundary entry and renders duplicates.
- Aligns `/entries/starred` SSR sort with the API (`StarredAt`, not `PublishedAt`) so the SSR first page and Load More pages stay in the same order.
- Exposes `hydrated` on `<rdrs-entry-list>` so the search page's inline JS can skip a redundant `loadEntries()` after SSR hydration.

## Tests

- `tests/pages_test.rs`:
  - SSR JSON payload assertion on `/entries/read`, `/entries/starred`, `/entries/summarized`.
  - `/search?q=` SSR with negative match (unrelated entry not rendered) + search input prefill.
  - `/search` (no query) emits empty SSR payload (no DB fetch, no entries leaked).
  - `test_ssr_continuation_matches_api_convention_no_duplicates_on_load_more` — direct regression for the off-by-one.
- `e2e/tests/ssr-no-double-render.spec.ts`:
  - Asserts zero `/reader/api/0/stream/contents/` requests on first paint of `/`, `/entries`, `/feeds/:id/entries`, and `/search?q=`.
  - Load More uniqueness regression on **every** SSR-backed list route: `/`, `/entries`, `/entries/{read,starred,summarized}`, `/categories/:id/entries`, `/feeds/:id/entries`, `/search?q=`.
- `e2e/helpers/seed.ts`: adds `markRead`, `markStarred`, `insertSummary` helpers so the read/starred/summarized routes can be seeded.

## Out of scope (follow-up)

The `e.id < continuation` cursor scheme is correct only when entry id order correlates with the sort field. With backfilled / out-of-order data it can silently **skip** entries. Tracked separately in #164 — it needs a (sort_ts, id) composite cursor and a wider change.

## Test plan

- [x] `cargo nextest run` — 683 passed
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cd e2e && npx playwright test ssr-no-double-render` — 12/12 passed
- [x] Full e2e — only pre-existing flake on `entry-actions › keyboard s toggles star` (passes solo on retry, unrelated to this change)
- [x] Manual: `/search?q=foo`, `/`, `/categories/:id/entries`, etc. all render server-side with no `stream/contents` request on first paint