### PR TITLE
fix(spa): route in-app navigation through the SPA router

### DIFF
--- a/e2e/tests/spa-router.spec.ts
+++ b/e2e/tests/spa-router.spec.ts
@@ -124,6 +124,32 @@ test.describe("SPA router", () => {
     await expect(page).toHaveURL(`${serverUrl}/`);
   });
 
+  test("entry-list row links (feed / category) navigate via router", async ({ page, serverUrl }) => {
+    // Regression: the row links inside <rdrs-entry-list> used to be
+    // <a href="#" data-feed-id="..."> with a JS handler that did
+    // `window.location.href = ...`. That bypassed the router and
+    // produced a full reload. They now use real <a href="..."> so the
+    // document-level click handler intercepts.
+    await login(page, serverUrl);
+    await page.goto(`${serverUrl}/entries`);
+    await expect(page.getByTestId("entry-item").first()).toBeVisible();
+
+    const tracker = trackDocumentLoads(page);
+    try {
+      // Click the feed link inside the first entry-item meta row.
+      await page
+        .locator("rdrs-entry-list .entry-item .entry-item-meta a")
+        .first()
+        .click();
+      await expect(page).toHaveURL(/\/feeds\/\d+\/entries$/);
+      await expect(page.locator("rdrs-entries-page")).toHaveAttribute("data-mode", "feed");
+      await page.waitForTimeout(200);
+      expect(tracker.count()).toBe(0);
+    } finally {
+      tracker.dispose();
+    }
+  });
+
   test("non-routed link triggers full reload", async ({ page, serverUrl }) => {
     await login(page, serverUrl);
 

--- a/static/js/components/rdrs-entry-list.js
+++ b/static/js/components/rdrs-entry-list.js
@@ -103,19 +103,10 @@ ${this.showMarkAbove ? `<div id="mark-above-read" class="hidden-mt4">
         this.querySelector('#entries-list').addEventListener('click', (e) => {
             const target = e.target;
 
-            // Feed link
-            if (target.matches('[data-feed-id]') && !target.hasAttribute('data-action')) {
-                e.preventDefault();
-                window.location.href = `/feeds/${target.dataset.feedId}/entries`;
-                return;
-            }
-
-            // Category link
-            if (target.matches('[data-category-id]') && !target.hasAttribute('data-action')) {
-                e.preventDefault();
-                window.location.href = `/categories/${target.dataset.categoryId}/entries`;
-                return;
-            }
+            // Feed and category links in the meta row are now real anchors
+            // (`<a href="/feeds/{id}/entries">`); the document-level SPA
+            // router intercepts them, so this handler doesn't need to do
+            // anything for them.
 
             // Actions
             const action = target.dataset.action;
@@ -421,19 +412,16 @@ ${this.showMarkAbove ? `<div id="mark-above-read" class="hidden-mt4">
                 }
             }
 
-            // Meta
+            // Meta — feed/category links use real href so the SPA router
+            // intercepts them at document level. The entry-item-meta a
+            // selector in the row-click handler also keeps these clicks
+            // from triggering reading-pane selection.
             let metaParts = [];
             if (this.showFeed) {
-                const feedLink = origin === 'search'
-                    ? `<a href="/feeds/${entry.feed_id}/entries">${escapeHtml(feedTitle)}</a>`
-                    : `<a href="#" data-feed-id="${entry.feed_id}">${escapeHtml(feedTitle)}</a>`;
-                metaParts.push(feedIconHtml + feedLink);
+                metaParts.push(feedIconHtml + `<a href="/feeds/${entry.feed_id}/entries">${escapeHtml(feedTitle)}</a>`);
             }
             if (this.showCategory) {
-                const catLink = origin === 'search'
-                    ? `<a href="/categories/${entry.category_id}/entries">${escapeHtml(entry.category_name)}</a>`
-                    : `<a href="#" data-category-id="${entry.category_id}">${escapeHtml(entry.category_name)}</a>`;
-                metaParts.push(catLink);
+                metaParts.push(`<a href="/categories/${entry.category_id}/entries">${escapeHtml(entry.category_name)}</a>`);
             }
             if (date) {
                 metaParts.push(`<span title="${dateTitle}">${date}</span>`);
@@ -1484,7 +1472,7 @@ ${this.showMarkAbove ? `<div id="mark-above-read" class="hidden-mt4">
                         if (list.showFeed) {
                             const entryF = list.getSelectedEntry();
                             if (entryF) {
-                                window.location.href = `/feeds/${entryF.feed_id}/entries`;
+                                window.rdrsNavigate(`/feeds/${entryF.feed_id}/entries`);
                             }
                             return true;
                         }
@@ -1514,7 +1502,7 @@ ${this.showMarkAbove ? `<div id="mark-above-read" class="hidden-mt4">
                         if (list.showCategory) {
                             const entryC = list.getSelectedEntry();
                             if (entryC) {
-                                window.location.href = `/categories/${entryC.category_id}/entries`;
+                                window.rdrsNavigate(`/categories/${entryC.category_id}/entries`);
                             }
                             return true;
                         }

--- a/static/js/keyboard.js
+++ b/static/js/keyboard.js
@@ -82,9 +82,9 @@ const keyboard = {
     handleCombo(combo) {
         // Global navigation shortcuts
         switch (combo) {
-            case 'g h': window.location.href = '/'; return true;
-            case 'g e': window.location.href = '/entries'; return true;
-            case 'g s': window.location.href = '/search'; return true;
+            case 'g h': window.rdrsNavigate('/'); return true;
+            case 'g e': window.rdrsNavigate('/entries'); return true;
+            case 'g s': window.rdrsNavigate('/search'); return true;
         }
         // Page-specific combo handlers
         if (this.handlers.handleCombo) {

--- a/static/js/pages/entries.js
+++ b/static/js/pages/entries.js
@@ -101,10 +101,10 @@ function escapeHtmlInline(s) {
 }
 
 const TAB_KB = [
-    { key: '1', desc: 'Go to All entries', handle: () => { location.href = '/entries'; return true; } },
-    { key: '2', desc: 'Go to Read entries', handle: () => { location.href = '/entries/read'; return true; } },
-    { key: '3', desc: 'Go to Starred entries', handle: () => { location.href = '/entries/starred'; return true; } },
-    { key: '4', desc: 'Go to Summarized entries', handle: () => { location.href = '/entries/summarized'; return true; } },
+    { key: '1', desc: 'Go to All entries', handle: () => { window.rdrsNavigate('/entries'); return true; } },
+    { key: '2', desc: 'Go to Read entries', handle: () => { window.rdrsNavigate('/entries/read'); return true; } },
+    { key: '3', desc: 'Go to Starred entries', handle: () => { window.rdrsNavigate('/entries/starred'); return true; } },
+    { key: '4', desc: 'Go to Summarized entries', handle: () => { window.rdrsNavigate('/entries/summarized'); return true; } },
 ];
 
 const MODES = {
@@ -195,8 +195,8 @@ const MODES = {
             { key: '3', desc: 'Show read only', handle: (list, page) => { page._setStatus('read'); return true; } },
             { key: '4', desc: 'Show starred only', handle: (list, page) => { page._setStatus('starred'); return true; } },
             { key: 'A', desc: 'Mark above as read', handle: (list) => { list.markAboveAsRead(); return true; } },
-            { key: 'c', desc: 'Go to category page', handle: (list, page) => { if (page._categoryId) location.href = `/categories/${page._categoryId}/entries`; return true; } },
-            { key: 'x', desc: 'Go to category page', handle: (list, page) => { if (page._categoryId) location.href = `/categories/${page._categoryId}/entries`; return true; } },
+            { key: 'c', desc: 'Go to category page', handle: (list, page) => { if (page._categoryId) window.rdrsNavigate(`/categories/${page._categoryId}/entries`); return true; } },
+            { key: 'x', desc: 'Go to category page', handle: (list, page) => { if (page._categoryId) window.rdrsNavigate(`/categories/${page._categoryId}/entries`); return true; } },
         ],
     },
     category: {
@@ -210,7 +210,7 @@ const MODES = {
             { key: '3', desc: 'Show read only', handle: (list, page) => { page._setStatus('read'); return true; } },
             { key: '4', desc: 'Show starred only', handle: (list, page) => { page._setStatus('starred'); return true; } },
             { key: 'A', desc: 'Mark above as read', handle: (list) => { list.markAboveAsRead(); return true; } },
-            { key: 'x', desc: 'Go to unread page', handle: () => { location.href = '/'; return true; } },
+            { key: 'x', desc: 'Go to unread page', handle: () => { window.rdrsNavigate('/'); return true; } },
         ],
     },
     search: {

--- a/static/js/pages/feeds.js
+++ b/static/js/pages/feeds.js
@@ -289,7 +289,7 @@ class RdrsFeedsPage extends HTMLElement {
     _onChange(e) {
         const target = e.target.closest('[data-rdrs-nav]');
         if (!target) return;
-        if (target.value) window.location.href = target.value;
+        if (target.value) window.rdrsNavigate(target.value);
     }
 
     _onClick(e) {

--- a/static/js/router.js
+++ b/static/js/router.js
@@ -113,3 +113,10 @@ document.addEventListener('click', (event) => {
 window.addEventListener('popstate', () => {
     navigateTo(location.pathname + location.search, { skipPushState: true });
 });
+
+// Programmatic entry point for in-app navigation. Page modules call
+// `window.rdrsNavigate('/path')` from keyboard handlers, dropdown
+// onchange, etc. — anywhere they used to do `window.location.href = ...`
+// for an in-app destination. Falls back to a full reload for paths
+// outside the route table (e.g. /login).
+window.rdrsNavigate = (path, opts) => navigateTo(path, opts);


### PR DESCRIPTION
## Summary

Bug: clicking the **feed / category links inside an entry-list row** bypassed the SPA router (#178) and triggered a full document reload. Same for several keyboard shortcuts (g-prefix global, 1/2/3/4 tab keys, c/x category jumps) and the /feeds page filter dropdown — they all called \`window.location.href = ...\` directly instead of going through the router.

## Root cause

The router (#178) attached a document-level click handler that intercepts \`<a>\` clicks and swaps the page element. Code paths that programmatically navigated via \`window.location.href\` (or rendered \`<a href=\"#\" data-id=\"...\">\` and used a delegate to navigate) bypassed it entirely.

## Fix

1. \`router.js\` exports \`window.rdrsNavigate\` — the programmatic entry point.
2. \`<rdrs-entry-list>\` meta links are now real anchors (\`<a href=\"/feeds/{id}/entries\">\`); the document click handler intercepts them naturally. Removed the matching click-delegate branches.
3. Switched the remaining \`location.href = ...\` in-app sites to \`window.rdrsNavigate\`:
   - \`keyboard.js\` global g-prefix (g h / g e / g s)
   - \`pages/entries.js\` MODES kb (1/2/3/4, c/x within \`<rdrs-entries-page>\`)
   - \`pages/feeds.js\` filter \`<select onchange>\`
   - Two \`<rdrs-entry-list>\` kb shortcuts (feed/category jumps)

\`flash.redirect\` keeps using \`location.href\` — it crosses the SSR boundary (logout → /login).

## Test plan

- [ ] New e2e regression in \`tests/spa-router.spec.ts\`: \"entry-list row links (feed / category) navigate via router\" — clicks the first row's feed link and asserts document-load count stays 0 + URL is \`/feeds/{id}/entries\`.
- [ ] Existing e2e specs unchanged (63/63 minus the documented \`entry-actions :: keyboard s toggles star\` flake).
- [ ] Manually click a feed name on an entry row in \`/\` — page transitions in place, no flash.
- [ ] Manually press \`g h\` / \`g e\` / \`g s\` — same.
- [ ] Manually press \`c\` while on \`/feeds/{id}/entries\` — jumps to category page in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)