### PR TITLE
fix(spa): statistics page no longer remounts sidebar on data load

### DIFF
--- a/e2e/tests/spa-router.spec.ts
+++ b/e2e/tests/spa-router.spec.ts
@@ -181,6 +181,30 @@ test.describe("SPA router", () => {
     }
   });
 
+  test("statistics data fetch doesn't remount sidebar", async ({ page, serverUrl }) => {
+    // Regression: rdrs-statistics-page used to rebuild its entire
+    // innerHTML (incl. <rdrs-sidebar>) on every render() call —
+    // initial "Loading…" + after fetchData() landed. Each rebuild
+    // unmounted/remounted the sidebar, which visually pulled the
+    // sidebar up between the two states. Tag the sidebar after the
+    // first paint and verify the tag survives the loaded-state
+    // re-render.
+    await login(page, serverUrl);
+    await page.goto(`${serverUrl}/statistics`);
+    await expect(page.locator("rdrs-sidebar")).toHaveCount(1);
+
+    await page.evaluate(() => {
+      document.querySelector("rdrs-sidebar")?.setAttribute("data-spa-marker", "kept");
+    });
+
+    // Wait for the loaded state to replace the loading placeholder.
+    await expect(page.getByTestId("stats-loading")).toHaveCount(0);
+    await expect(page.locator(".stats-cards").first()).toBeVisible();
+
+    // Sidebar instance must survive — same node, marker still there.
+    await expect(page.locator("rdrs-sidebar")).toHaveAttribute("data-spa-marker", "kept");
+  });
+
   test("statistics custom-date Apply navigates SPA", async ({ page, serverUrl }) => {
     // Regression: the <form method="get" action="/statistics"> Apply
     // button used to submit normally → full GET reload. Now it's

--- a/static/js/pages/statistics.js
+++ b/static/js/pages/statistics.js
@@ -10,17 +10,37 @@ class RdrsStatisticsPage extends HTMLElement {
         this._period = params.get('period') || '7d';
         this._customFrom = params.get('from') || '';
         this._customTo = params.get('to') || '';
-        this.render();
+        this._renderShell();
+        this._renderHeader();
+        this._renderBody({ loading: true });
         this.fetchData();
     }
 
-    render(data, errorMessage) {
+    /// Render shell + sidebar + flash once. Subsequent re-renders touch
+    /// only #stats-header and #stats-body — otherwise rebuilding innerHTML
+    /// would unmount <rdrs-sidebar> on every fetchData(), causing the
+    /// sidebar to flash / pull-up between loading and loaded states.
+    _renderShell() {
+        this.innerHTML = `
+<div class="app-layout">
+<rdrs-sidebar active="statistics"></rdrs-sidebar>
+<main class="main-content">
+    <div class="page-content">
+    <rdrs-flash class="flash-container"></rdrs-flash>
+    <div id="stats-header"></div>
+    <div id="stats-body"></div>
+    </div>
+</main>
+</div>`;
+    }
+
+    _renderHeader(data) {
         const active = data ? data.active_period : this._period;
         const customFrom = data ? data.custom_from : this._customFrom;
         const customTo = data ? data.custom_to : this._customTo;
         const isActive = (p) => p === active ? ' active' : '';
 
-        const headerHtml = `
+        this.querySelector('#stats-header').innerHTML = `
         <div class="stats-header">
             <h1>Statistics</h1>
             <form class="stats-period" method="get" action="/statistics">
@@ -37,29 +57,6 @@ class RdrsStatisticsPage extends HTMLElement {
             </form>
         </div>`;
 
-        const sidebarHtml = `<rdrs-sidebar active="statistics"></rdrs-sidebar>`;
-
-        let bodyHtml;
-        if (errorMessage) {
-            bodyHtml = `<p class="muted" data-testid="stats-error">${escapeHtml(errorMessage)}</p>`;
-        } else if (!data) {
-            bodyHtml = `<p class="muted" data-testid="stats-loading">Loading statistics&hellip;</p>`;
-        } else {
-            bodyHtml = this._renderContent(data);
-        }
-
-        this.innerHTML = `
-<div class="app-layout">
-${sidebarHtml}
-<main class="main-content">
-    <div class="page-content">
-    <rdrs-flash class="flash-container"></rdrs-flash>
-    ${headerHtml}
-    ${bodyHtml}
-    </div>
-</main>
-</div>`;
-
         // Intercept the custom-date Apply submit so it goes through the
         // SPA router instead of triggering a full GET reload.
         const form = this.querySelector('form.stats-period');
@@ -69,6 +66,18 @@ ${sidebarHtml}
                 const params = new URLSearchParams(new FormData(form));
                 window.rdrsNavigate('/statistics?' + params.toString());
             });
+        }
+    }
+
+    _renderBody(state) {
+        const target = this.querySelector('#stats-body');
+        if (!target) return;
+        if (state.error) {
+            target.innerHTML = `<p class="muted" data-testid="stats-error">${escapeHtml(state.error)}</p>`;
+        } else if (state.loading) {
+            target.innerHTML = `<p class="muted" data-testid="stats-loading">Loading statistics&hellip;</p>`;
+        } else {
+            target.innerHTML = this._renderContent(state.data);
         }
     }
 
@@ -186,13 +195,14 @@ ${sidebarHtml}
         try {
             const resp = await fetch('/api/statistics' + qs, { credentials: 'same-origin' });
             if (!resp.ok) {
-                this.render(undefined, `Failed to load statistics (${resp.status}).`);
+                this._renderBody({ error: `Failed to load statistics (${resp.status}).` });
                 return;
             }
             const data = await resp.json();
-            this.render(data);
+            this._renderHeader(data);
+            this._renderBody({ data });
         } catch (e) {
-            this.render(undefined, 'Network error while loading statistics.');
+            this._renderBody({ error: 'Network error while loading statistics.' });
         }
     }
 }


### PR DESCRIPTION
## Summary

Bug: visiting \`/statistics\` made the sidebar visibly jump / pull up between the initial \"Loading…\" paint and the loaded-data paint.

## Root cause

\`<rdrs-statistics-page>.render()\` rebuilt the **entire** \`innerHTML\` (sidebar, flash, header, body) on every call. \`connectedCallback\` called it once with no data (loading state), then \`fetchData()\` called it again with the loaded data. Each call unmounted \`<rdrs-sidebar>\` and let its \`connectedCallback\` re-run — that's the visible jump.

## Fix

Split \`render()\` into three:
- **\`_renderShell()\`** — called once. Sets up the \`<rdrs-sidebar>\`, \`<rdrs-flash>\`, and the \`#stats-header\` / \`#stats-body\` placeholders.
- **\`_renderHeader(data?)\`** — fills \`#stats-header\` with the period buttons + custom-date form. Called on initial paint (using URL state) and again after data lands (using server-resolved \`active_period\`).
- **\`_renderBody(state)\`** — fills \`#stats-body\` with one of: loading, error, loaded content. Called repeatedly.

Same pattern \`<rdrs-categories-page>\` already uses (\`_renderShell\` + \`_renderRows\`).

## Test plan

- [ ] Adds \`spa-router.spec.ts :: statistics data fetch doesn't remount sidebar\` — tags the sidebar element after first paint, asserts the marker survives the loading→loaded transition.
- [ ] \`source /tmp/rdrs-env.sh && cargo nextest run\` — all pass (handler + page-shell tests untouched).
- [ ] \`source /tmp/rdrs-env.sh && cd e2e && npx playwright test\` — 66 pass; only the documented \`entry-actions :: keyboard s toggles star\` flake fails.
- [ ] Manually visit \`/statistics\` — no visible sidebar jump between \"Loading…\" and the cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)