### PR TITLE
fix(spa): persist sidebar across SPA navigation (architectural)

### DIFF
--- a/e2e/tests/spa-router.spec.ts
+++ b/e2e/tests/spa-router.spec.ts
@@ -124,6 +124,45 @@ test.describe("SPA router", () => {
     await expect(page).toHaveURL(`${serverUrl}/`);
   });
 
+  test("sidebar persists across SPA navigation", async ({ page, serverUrl }) => {
+    // Regression: every page-element used to render <rdrs-sidebar> inside
+    // its own innerHTML. The router's host.replaceChildren swap then
+    // unmounted + remounted the sidebar on every nav, which visually
+    // pulled it down/up. Sidebar now lives in app_shell.html outside
+    // #page-host; tag the instance and verify the tag survives several
+    // navs (cross-element, same-element, popstate, statistics-internal
+    // data fetch).
+    await login(page, serverUrl);
+    await expect(page.locator("rdrs-sidebar")).toHaveCount(1);
+
+    // Tag the sidebar.
+    await page.evaluate(() => {
+      document.querySelector("rdrs-sidebar")?.setAttribute("data-spa-marker", "kept");
+    });
+
+    // Cross-element nav.
+    await page.getByTestId("nav-feeds").click();
+    await expect(page.locator("rdrs-feeds-page")).toBeVisible();
+    await expect(page.locator("rdrs-sidebar")).toHaveAttribute("data-spa-marker", "kept");
+
+    // Cross-element to statistics — also exercises the page's internal
+    // re-render after fetchData lands.
+    await page.getByTestId("nav-statistics").click();
+    await expect(page.locator("rdrs-statistics-page")).toBeVisible();
+    await expect(page.locator(".stats-cards").first()).toBeVisible();
+    await expect(page.locator("rdrs-sidebar")).toHaveAttribute("data-spa-marker", "kept");
+
+    // Back into entries — same element shape as the start.
+    await page.goBack();
+    await page.goBack();
+    await expect(page.locator("rdrs-entries-page")).toBeVisible();
+    await expect(page.locator("rdrs-sidebar")).toHaveAttribute("data-spa-marker", "kept");
+
+    // The active highlight on the sidebar must follow the route.
+    // /unread = active='unread'; sidebar should reflect that after popstate.
+    await expect(page.locator("rdrs-sidebar")).toHaveAttribute("active", "unread");
+  });
+
   test("entry-list row links (feed / category) navigate via router", async ({ page, serverUrl }) => {
     // Regression: the row links inside <rdrs-entry-list> used to be
     // <a href="#" data-feed-id="..."> with a JS handler that did

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -213,6 +213,15 @@ code {
     min-height: 100vh;
 }
 
+/* The SPA router mounts <rdrs-X-page> directly inside #page-host
+   (which is the <main class="main-content"> element). Use
+   `display: contents` so the page-element is transparent to layout —
+   its children (.page-content, .split-view, etc.) act as direct
+   children of <main> and inherit its flex / overflow rules. */
+#page-host > * {
+    display: contents;
+}
+
 /* ===== Sidebar ===== */
 .sidebar {
     width: var(--sidebar-width);

--- a/static/js/components/rdrs-sidebar.js
+++ b/static/js/components/rdrs-sidebar.js
@@ -42,6 +42,14 @@ class RdrsSidebar extends HTMLElement {
     static get observedAttributes() { return ['active', 'active-category-id']; }
 
     connectedCallback() {
+        // Sidebar lives in the shell (outside #page-host) so it persists
+        // across SPA navigation. The router fires `rdrs-router:navigated`
+        // after each nav; we recompute the active highlight from
+        // location.pathname.
+        this._syncActiveFromPath();
+        this._navListener = () => this._syncActiveFromPath();
+        window.addEventListener('rdrs-router:navigated', this._navListener);
+
         const initial = readBootstrap() || readCachedSidebar();
         if (initial) {
             this._data = initial;
@@ -52,8 +60,47 @@ class RdrsSidebar extends HTMLElement {
         this.fetchData();
     }
 
+    disconnectedCallback() {
+        if (this._navListener) {
+            window.removeEventListener('rdrs-router:navigated', this._navListener);
+        }
+    }
+
     attributeChangedCallback() {
         if (this._data) this.render(this._data);
+    }
+
+    /// Map location.pathname to (active nav-key, active category id) and
+    /// reflect both as attributes. attributeChangedCallback re-renders
+    /// when the values actually change.
+    _syncActiveFromPath() {
+        const path = location.pathname;
+        let active = '';
+        let categoryId = 0;
+        if (path === '/' || path === '') active = 'unread';
+        else if (path === '/entries/starred') active = 'starred';
+        else if (path === '/entries' || path === '/entries/read' || path === '/entries/summarized') active = 'entries';
+        else if (path === '/search') active = 'search';
+        else if (path === '/feeds') active = 'feeds';
+        else if (path === '/categories') active = 'categories';
+        else if (path === '/admin') active = 'admin';
+        else if (path === '/settings') active = 'settings';
+        else if (path === '/user-settings') active = 'user-settings';
+        else if (path === '/statistics') active = 'statistics';
+        else if (/^\/feeds\/\d+\/entries$/.test(path)) active = 'feeds';
+        else {
+            const m = path.match(/^\/categories\/(\d+)\/entries$/);
+            if (m) categoryId = parseInt(m[1], 10);
+        }
+        if ((this.getAttribute('active') || '') !== active) {
+            if (active) this.setAttribute('active', active);
+            else this.removeAttribute('active');
+        }
+        const catAttr = categoryId ? String(categoryId) : '';
+        if ((this.getAttribute('active-category-id') || '') !== catAttr) {
+            if (categoryId) this.setAttribute('active-category-id', catAttr);
+            else this.removeAttribute('active-category-id');
+        }
     }
 
     async fetchData() {

--- a/static/js/pages/admin.js
+++ b/static/js/pages/admin.js
@@ -14,10 +14,7 @@ class RdrsAdminPage extends HTMLElement {
 
     _renderShell() {
         this.innerHTML = `
-<div class="app-layout">
-<rdrs-sidebar active="admin"></rdrs-sidebar>
-<main class="main-content">
-    <div class="page-content">
+<div class="page-content">
     <rdrs-flash class="flash-container"></rdrs-flash>
     <h1>Admin Panel</h1>
     <table class="mobile-cards">
@@ -28,8 +25,6 @@ class RdrsAdminPage extends HTMLElement {
         </thead>
         <tbody id="users-table"></tbody>
     </table>
-    </div>
-</main>
 </div>`;
         this.querySelector('#users-table').addEventListener('click', (e) => this._onClick(e));
     }

--- a/static/js/pages/categories.js
+++ b/static/js/pages/categories.js
@@ -24,10 +24,7 @@ class RdrsCategoriesPage extends HTMLElement {
     /// the tbody — that way `<rdrs-flash>` and its messages survive reloads.
     _renderShell() {
         this.innerHTML = `
-<div class="app-layout">
-<rdrs-sidebar active="categories"></rdrs-sidebar>
-<main class="main-content">
-    <div class="page-content">
+<div class="page-content">
     <rdrs-flash class="flash-container"></rdrs-flash>
     <h1>Categories</h1>
     <form id="add-form" data-rdrs-add-form>
@@ -48,8 +45,6 @@ class RdrsCategoriesPage extends HTMLElement {
         </thead>
         <tbody id="categories-table" data-testid="categories-table"></tbody>
     </table>
-    </div>
-</main>
 </div>`;
 
         this.querySelector('[data-rdrs-add-form]').addEventListener('submit', (e) => this._onAdd(e));

--- a/static/js/pages/entries.js
+++ b/static/js/pages/entries.js
@@ -281,22 +281,17 @@ class RdrsEntriesPage extends HTMLElement {
         // stream/contents fetch.
         const attrs = { ...cfg.listAttrs, 'no-auto-load': '' };
         this.innerHTML = `
-<div class="app-layout">
-<rdrs-sidebar active="${cfg.navKey}"></rdrs-sidebar>
-<main class="main-content">
-    <rdrs-flash class="flash-container"></rdrs-flash>
-    <div class="split-view">
-        <div class="list-pane">
-            <div class="list-pane-header">${cfg.renderHeader()}</div>
-            <div class="list-pane-body">
-                <rdrs-entry-list ${attrString(attrs)} reading-pane="#reading-pane"></rdrs-entry-list>
-            </div>
-        </div>
-        <div class="reading-pane" id="reading-pane">
-            <div class="reading-pane-empty">Select an entry to read</div>
+<rdrs-flash class="flash-container"></rdrs-flash>
+<div class="split-view">
+    <div class="list-pane">
+        <div class="list-pane-header">${cfg.renderHeader()}</div>
+        <div class="list-pane-body">
+            <rdrs-entry-list ${attrString(attrs)} reading-pane="#reading-pane"></rdrs-entry-list>
         </div>
     </div>
-</main>
+    <div class="reading-pane" id="reading-pane">
+        <div class="reading-pane-empty">Select an entry to read</div>
+    </div>
 </div>`;
 
         this._wireMarkAsRead();
@@ -306,25 +301,20 @@ class RdrsEntriesPage extends HTMLElement {
     }
 
     /// feed/category modes resolve their stream-id and breadcrumb data
-    /// asynchronously. Render a placeholder shell first so sidebar +
-    /// flash paint immediately, then await meta and mount the entry-list.
+    /// asynchronously. Render a placeholder shell first so flash paints
+    /// immediately, then await meta and mount the entry-list.
     async _connectAsync(mode, cfg) {
         const id = pathId();
         this.innerHTML = `
-<div class="app-layout">
-<rdrs-sidebar active="${cfg.navKey}"></rdrs-sidebar>
-<main class="main-content">
-    <rdrs-flash class="flash-container"></rdrs-flash>
-    <div class="split-view">
-        <div class="list-pane">
-            <div class="list-pane-header" id="list-pane-header"><h1>Loading…</h1></div>
-            <div class="list-pane-body" id="list-pane-body"></div>
-        </div>
-        <div class="reading-pane" id="reading-pane">
-            <div class="reading-pane-empty">Select an entry to read</div>
-        </div>
+<rdrs-flash class="flash-container"></rdrs-flash>
+<div class="split-view">
+    <div class="list-pane">
+        <div class="list-pane-header" id="list-pane-header"><h1>Loading…</h1></div>
+        <div class="list-pane-body" id="list-pane-body"></div>
     </div>
-</main>
+    <div class="reading-pane" id="reading-pane">
+        <div class="reading-pane-empty">Select an entry to read</div>
+    </div>
 </div>`;
 
         const initialStatus = new URLSearchParams(location.search).get('status') || 'unread';

--- a/static/js/pages/feeds.js
+++ b/static/js/pages/feeds.js
@@ -29,10 +29,7 @@ class RdrsFeedsPage extends HTMLElement {
 
     _renderShell() {
         this.innerHTML = `
-<div class="app-layout">
-<rdrs-sidebar active="feeds"></rdrs-sidebar>
-<main class="main-content">
-    <div class="page-content">
+<div class="page-content">
     <rdrs-flash class="flash-container"></rdrs-flash>
     <h1>Feeds</h1>
     <div class="feeds-toolbar">
@@ -148,8 +145,6 @@ class RdrsFeedsPage extends HTMLElement {
             </div>
         </form>
     </dialog>
-    </div>
-</main>
 </div>`;
 
         this.addEventListener('click', (e) => this._onClick(e));

--- a/static/js/pages/settings.js
+++ b/static/js/pages/settings.js
@@ -11,17 +11,12 @@ class RdrsSettingsPage extends HTMLElement {
 
     _renderShell() {
         this.innerHTML = `
-<div class="app-layout">
-<rdrs-sidebar active="settings"></rdrs-sidebar>
-<main class="main-content">
-    <div class="page-content">
+<div class="page-content">
     <rdrs-flash class="flash-container"></rdrs-flash>
     <h1>Settings</h1>
     <div id="settings-body">
         <p class="muted">Loading&hellip;</p>
     </div>
-    </div>
-</main>
 </div>`;
     }
 

--- a/static/js/pages/statistics.js
+++ b/static/js/pages/statistics.js
@@ -10,17 +10,32 @@ class RdrsStatisticsPage extends HTMLElement {
         this._period = params.get('period') || '7d';
         this._customFrom = params.get('from') || '';
         this._customTo = params.get('to') || '';
-        this.render();
+        this._renderShell();
+        this._renderHeader();
+        this._renderBody({ loading: true });
         this.fetchData();
     }
 
-    render(data, errorMessage) {
+    /// Render shell + flash once. Subsequent re-renders touch only
+    /// #stats-header and #stats-body — otherwise rebuilding innerHTML
+    /// would unmount <rdrs-flash> on every fetchData(). Sidebar lives
+    /// in app_shell.html outside this element entirely.
+    _renderShell() {
+        this.innerHTML = `
+<div class="page-content">
+    <rdrs-flash class="flash-container"></rdrs-flash>
+    <div id="stats-header"></div>
+    <div id="stats-body"></div>
+</div>`;
+    }
+
+    _renderHeader(data) {
         const active = data ? data.active_period : this._period;
         const customFrom = data ? data.custom_from : this._customFrom;
         const customTo = data ? data.custom_to : this._customTo;
         const isActive = (p) => p === active ? ' active' : '';
 
-        const headerHtml = `
+        this.querySelector('#stats-header').innerHTML = `
         <div class="stats-header">
             <h1>Statistics</h1>
             <form class="stats-period" method="get" action="/statistics">
@@ -37,29 +52,6 @@ class RdrsStatisticsPage extends HTMLElement {
             </form>
         </div>`;
 
-        const sidebarHtml = `<rdrs-sidebar active="statistics"></rdrs-sidebar>`;
-
-        let bodyHtml;
-        if (errorMessage) {
-            bodyHtml = `<p class="muted" data-testid="stats-error">${escapeHtml(errorMessage)}</p>`;
-        } else if (!data) {
-            bodyHtml = `<p class="muted" data-testid="stats-loading">Loading statistics&hellip;</p>`;
-        } else {
-            bodyHtml = this._renderContent(data);
-        }
-
-        this.innerHTML = `
-<div class="app-layout">
-${sidebarHtml}
-<main class="main-content">
-    <div class="page-content">
-    <rdrs-flash class="flash-container"></rdrs-flash>
-    ${headerHtml}
-    ${bodyHtml}
-    </div>
-</main>
-</div>`;
-
         // Intercept the custom-date Apply submit so it goes through the
         // SPA router instead of triggering a full GET reload.
         const form = this.querySelector('form.stats-period');
@@ -69,6 +61,18 @@ ${sidebarHtml}
                 const params = new URLSearchParams(new FormData(form));
                 window.rdrsNavigate('/statistics?' + params.toString());
             });
+        }
+    }
+
+    _renderBody(state) {
+        const target = this.querySelector('#stats-body');
+        if (!target) return;
+        if (state.error) {
+            target.innerHTML = `<p class="muted" data-testid="stats-error">${escapeHtml(state.error)}</p>`;
+        } else if (state.loading) {
+            target.innerHTML = `<p class="muted" data-testid="stats-loading">Loading statistics&hellip;</p>`;
+        } else {
+            target.innerHTML = this._renderContent(state.data);
         }
     }
 
@@ -186,13 +190,14 @@ ${sidebarHtml}
         try {
             const resp = await fetch('/api/statistics' + qs, { credentials: 'same-origin' });
             if (!resp.ok) {
-                this.render(undefined, `Failed to load statistics (${resp.status}).`);
+                this._renderBody({ error: `Failed to load statistics (${resp.status}).` });
                 return;
             }
             const data = await resp.json();
-            this.render(data);
+            this._renderHeader(data);
+            this._renderBody({ data });
         } catch (e) {
-            this.render(undefined, 'Network error while loading statistics.');
+            this._renderBody({ error: 'Network error while loading statistics.' });
         }
     }
 }

--- a/static/js/pages/user-settings.js
+++ b/static/js/pages/user-settings.js
@@ -31,17 +31,12 @@ class RdrsUserSettingsPage extends HTMLElement {
 
     _renderShell() {
         this.innerHTML = `
-<div class="app-layout">
-<rdrs-sidebar active="user-settings"></rdrs-sidebar>
-<main class="main-content">
-    <div class="page-content">
+<div class="page-content">
     <rdrs-flash class="flash-container"></rdrs-flash>
     <h1>User Settings</h1>
     <div id="user-settings-body">
         <p class="muted">Loading&hellip;</p>
     </div>
-    </div>
-</main>
 </div>`;
     }
 

--- a/static/js/router.js
+++ b/static/js/router.js
@@ -78,6 +78,13 @@ async function navigateTo(path, opts = {}) {
         window.scrollTo(0, 0);
     }
     // popstate-driven nav inherits the browser's auto scroll restoration.
+
+    // Notify subscribers (sidebar, anything else that reflects the URL)
+    // that the SPA URL changed. popstate already fires this for back/
+    // forward; we synthesise it for click-driven navigations too.
+    window.dispatchEvent(new CustomEvent('rdrs-router:navigated', {
+        detail: { path: location.pathname + location.search },
+    }));
 }
 
 function shouldIntercept(event, anchor) {

--- a/templates/app_shell.html
+++ b/templates/app_shell.html
@@ -63,7 +63,10 @@
 <body>
     <script type="application/json" id="rdrs-sidebar-bootstrap">{{ sidebar_bootstrap_json|safe }}</script>
     <script type="application/json" id="rdrs-flash-bootstrap">{{ flash_bootstrap_json|safe }}</script>
-    <div id="page-host"><{{ element_tag }}></{{ element_tag }}></div>
+    <div class="app-layout">
+        <rdrs-sidebar></rdrs-sidebar>
+        <main class="main-content" id="page-host"><{{ element_tag }}></{{ element_tag }}></main>
+    </div>
     <rdrs-kb-help></rdrs-kb-help>
     <rdrs-kb-pending></rdrs-kb-pending>
     <script>


### PR DESCRIPTION
## Summary

The user's reported sidebar jump on each SPA navigation traces back to an architectural flaw: every page-element rendered \`<rdrs-sidebar>\` *inside* its own innerHTML, so the router's \`host.replaceChildren()\` swap unmounted + remounted the sidebar on every navigation. Same pattern was the root cause of #181 (statistics sidebar pull-up — closed, superseded by this PR).

## Fix

Move \`<rdrs-sidebar>\` to the shell, *outside* \`#page-host\`. Sidebar mounts once on first paint and persists for the entire SPA session.

\`\`\`html
<div class=\"app-layout\">
  <rdrs-sidebar></rdrs-sidebar>
  <main id=\"page-host\" class=\"main-content\">
    <{{ element_tag }}></{{ element_tag }}>
  </main>
</div>
\`\`\`

Each page-element drops its old \`<div class=\"app-layout\">\` / \`<rdrs-sidebar>\` / \`<main>\` wrapper and renders only its inner content (\`.page-content\` or \`.split-view\`). CSS \`#page-host > * { display: contents }\` keeps the page-element layout-transparent so its children flow as direct flex children of \`<main>\`.

The sidebar self-tracks active state: \`connectedCallback\` and an \`rdrs-router:navigated\` listener compute \`(active, active-category-id)\` from \`location.pathname\` and reflect them as attributes. \`attributeChangedCallback\` re-renders. The router dispatches the event after every successful navigation (push or popstate).

\`statistics.js\` also gets the split-render treatment from #181 (now folded in here): \`_renderShell\` once, \`_renderHeader\` + \`_renderBody\` separately, so the page's internal fetch doesn't wipe its own children either.

## Files

- \`templates/app_shell.html\` — sidebar in shell, page-host wraps \`<main>\`
- \`static/css/app.css\` — \`#page-host > *\` rule
- \`static/js/components/rdrs-sidebar.js\` — self-tracking active
- \`static/js/router.js\` — dispatch nav event
- 7 page modules (admin / categories / feeds / settings / statistics / user-settings / entries) — drop layout wrapper

## Test plan

- [ ] Adds \`spa-router.spec.ts :: sidebar persists across SPA navigation\` — tags \`<rdrs-sidebar>\`, navigates cross-element + popstate + same-element, asserts marker survives all transitions and \`active\` attribute follows the route.
- [ ] \`source /tmp/rdrs-env.sh && cargo nextest run\` — 693 pass.
- [ ] \`source /tmp/rdrs-env.sh && cd e2e && npx playwright test\` — 66 pass; only the documented \`entry-actions :: keyboard s toggles star\` flake fails.
- [ ] Manually click sidebar items (Unread, Categories, Feeds, Statistics, Categories[i]) — sidebar stays put, no flash, active highlight follows.
- [ ] Manually visit \`/statistics\` — no flash between \"Loading…\" and the cards.
- [ ] Manually visit \`/categories/{id}/entries\` — that category is highlighted in the sidebar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)