### PR TITLE
fix(ui): show loading state instead of empty state during fetch

### DIFF
--- a/static/js/components/rdrs-entry-list.js
+++ b/static/js/components/rdrs-entry-list.js
@@ -56,6 +56,10 @@ class RdrsEntryList extends HTMLElement {
     get search() { return this._search; }
     set search(v) { this._search = v; }
     get emptyMessage() { return this.getAttribute('empty-message') || 'No entries found.'; }
+    /// Initial placeholder before any data is loaded. Defaults to a loading
+    /// spinner; `<rdrs-entry-list>` only shows an empty-state-style message
+    /// when the page explicitly opts in (e.g. `/search` before submission).
+    get placeholderMessage() { return this.getAttribute('placeholder-message') || 'Loading...'; }
     get readingPaneSelector() { return this.getAttribute('reading-pane') || null; }
     get hasSaveServices() { return this.hasAttribute('has-save-services'); }
     get hasKagiConfigured() { return this.hasAttribute('has-kagi-configured'); }
@@ -74,7 +78,7 @@ class RdrsEntryList extends HTMLElement {
 
     // --- Initial render (skeleton) ---
     _render() {
-        const initialMessage = this.hasAttribute('no-auto-load') ? this.emptyMessage : 'Loading...';
+        const initialMessage = this.placeholderMessage;
         this.innerHTML = `
 <div id="entries-list" data-testid="entries-list">
     <p class="muted entries-status-msg">${initialMessage}</p>
@@ -243,8 +247,18 @@ ${this.showMarkAbove ? `<div id="mark-above-read" class="hidden-mt4">
         container.classList.add('entries-list-refreshing');
 
         if (reset) {
+            // When the list is empty (first load, or after switching filters /
+            // submitting a new search from a placeholder), swap the message to
+            // "Loading..." so users don't briefly see an empty-state string
+            // (e.g. "No entries found.") while a fetch is in flight. When
+            // entries are already on screen, keep them — `entries-list-refreshing`
+            // is the visual cue for the in-place refresh.
+            const wasEmpty = this.entries.length === 0;
             this.continuation = null;
             this.entries = [];
+            if (wasEmpty) {
+                container.innerHTML = `<p class="muted entries-status-msg">Loading...</p>`;
+            }
         }
 
         const streamId = this.streamId;

--- a/static/js/pages/entries.js
+++ b/static/js/pages/entries.js
@@ -233,6 +233,7 @@ const MODES = {
             'show-category': '',
             'no-auto-load': '',
             'empty-message': 'Enter a search term and press Enter to search.',
+            'placeholder-message': 'Enter a search term and press Enter to search.',
         },
         kb: [
             { key: '/', desc: 'Focus search box', handle: (list, page) => { const input = page.querySelector('#filter-search'); if (input) input.focus(); return true; } },
@@ -264,6 +265,18 @@ function attrString(attrs) {
         .join(' ');
 }
 
+/// Initial reading-pane content. When the URL carries `?entry=N` we know an
+/// entry will be loaded into the pane shortly after `loadEntries()` resolves
+/// (`<rdrs-entry-list>._checkEntryParam` -> `_loadEntryByIdInPane`), so we
+/// show "Loading..." instead of the "Select an entry" empty state to avoid
+/// telling the user "nothing to read" while a fetch is on its way.
+function readingPaneInitialHtml() {
+    const hasEntry = new URLSearchParams(location.search).has('entry');
+    return hasEntry
+        ? '<div class="reading-pane-content"><p class="muted">Loading...</p></div>'
+        : '<div class="reading-pane-empty">Select an entry to read</div>';
+}
+
 class RdrsEntriesPage extends HTMLElement {
     connectedCallback() {
         const mode = inferMode();
@@ -292,9 +305,7 @@ class RdrsEntriesPage extends HTMLElement {
                 <rdrs-entry-list ${attrString(attrs)} reading-pane="#reading-pane"></rdrs-entry-list>
             </div>
         </div>
-        <div class="reading-pane" id="reading-pane">
-            <div class="reading-pane-empty">Select an entry to read</div>
-        </div>
+        <div class="reading-pane" id="reading-pane">${readingPaneInitialHtml()}</div>
     </div>
 </main>
 </div>`;
@@ -320,9 +331,7 @@ class RdrsEntriesPage extends HTMLElement {
             <div class="list-pane-header" id="list-pane-header"><h1>Loading…</h1></div>
             <div class="list-pane-body" id="list-pane-body"></div>
         </div>
-        <div class="reading-pane" id="reading-pane">
-            <div class="reading-pane-empty">Select an entry to read</div>
-        </div>
+        <div class="reading-pane" id="reading-pane">${readingPaneInitialHtml()}</div>
     </div>
 </main>
 </div>`;


### PR DESCRIPTION
## Summary

Three places in the UI flashed an **empty-state** message while a fetch was actually in flight, telling the user *"nothing here"* before the request had a chance to resolve. This PR routes those code paths through a real **loading state**.

### What was wrong

- `<rdrs-entry-list>` overloaded the \`no-auto-load\` attribute to mean both *"don't auto-fetch"* and *"don't show Loading..."*. Every list-mode page (unread / all / read / starred / summarized / feed / category) sets \`no-auto-load\` so it can configure the list before the first fetch — so they all briefly showed \`empty-message\` (e.g. *"No unread entries."*) until the fetch resolved.
- Deep-linking \`/entries?entry=N\` showed *"Select an entry to read"* in the reading pane until \`loadEntries()\` resolved and \`_checkEntryParam\` swapped in \`Loading...\`.

### What changed

- New \`placeholder-message\` attribute on \`<rdrs-entry-list>\` (defaults to \`Loading...\`) drives the initial paint. Only \`/search\` opts in to an empty-state-style placeholder, since it genuinely doesn't fetch until the user submits.
- \`loadEntries(reset)\` swaps the container to \`Loading...\` when the list was empty (first load, switching filters from a placeholder, submitting a new search). In-place refreshes with entries already on screen continue to rely on the \`entries-list-refreshing\` CSS hook.
- \`entries.js\` reading-pane shell renders \`Loading...\` when the URL carries \`?entry=N\`, otherwise falls back to the existing *"Select an entry to read"* empty state.

### Out of scope

\`feeds.js\`, \`categories.js\`, \`admin.js\`, \`statistics.js\`, \`settings.js\`, \`user-settings.js\` already separated loading / error / empty cleanly — left untouched.

## Test plan

- [ ] Cold-load \`/\`, \`/entries\`, \`/entries/read\`, \`/entries/starred\`, \`/entries/summarized\` — list area shows \`Loading...\` then entries (no flash of *"No ... entries."*)
- [ ] Cold-load \`/feeds/{id}/entries\` and \`/categories/{id}/entries\` — header reads \`Loading…\` and list reads \`Loading...\` until data arrives
- [ ] Cold-load \`/search\` — list area shows *"Enter a search term and press Enter to search."* (unchanged)
- [ ] Submit a search from the placeholder — list switches to \`Loading...\` then results
- [ ] Refresh (\`r\`) on a populated list — entries stay on screen, refresh class is the only visual cue (unchanged)
- [ ] Deep-link \`/entries?entry=N\` — reading pane reads \`Loading...\` immediately (not *"Select an entry to read"*)
- [ ] Cold-load any list page without \`?entry\` — reading pane reads *"Select an entry to read"* (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)