### PR TITLE
fix(sidebar): keep unread badge fresh across SPA navigation

### DIFF
--- a/e2e/tests/sidebar-flicker.spec.ts
+++ b/e2e/tests/sidebar-flicker.spec.ts
@@ -1,0 +1,60 @@
+import { Page } from "@playwright/test";
+import { test, expect } from "../fixtures/rdrs.js";
+
+test.describe("sidebar unread badge does not flicker", () => {
+  test.beforeAll(async ({ api, seed }) => {
+    await api.register("flickeruser", "password123");
+    const userId = seed.getUserId("flickeruser");
+    const categoryId = seed.createCategory(userId, "FlickerCat");
+    const feedId = seed.createFeed(
+      categoryId,
+      "https://example.com/flicker.xml",
+      "Flicker Feed"
+    );
+    seed.seedTestEntries(feedId, 3);
+  });
+
+  async function login(page: Page, serverUrl: string): Promise<void> {
+    await page.goto(`${serverUrl}/login`);
+    await page.getByTestId("username-input").fill("flickeruser");
+    await page.getByTestId("password-input").fill("password123");
+    await page.getByTestId("login-submit").click();
+    await page.waitForURL(`${serverUrl}/`);
+  }
+
+  test("after mark-as-read, SPA-nav does not show stale unread count", async ({
+    page,
+    serverUrl,
+  }) => {
+    await login(page, serverUrl);
+
+    // Cold load shows 3 unread.
+    await expect(page.locator("#unread-count")).toHaveText("3");
+
+    // Mark one entry read via the row action; the in-page badge should drop to 2.
+    await page.getByTestId("entry-read-action").first().click();
+    await expect(page.locator("#unread-count")).toHaveText("2");
+
+    // Hold the next /api/sidebar response so the synchronous mount-time render
+    // is the only thing that has run when we sample the badge.
+    await page.route("**/api/sidebar", async (route) => {
+      await new Promise((r) => setTimeout(r, 600));
+      await route.continue();
+    });
+
+    // SPA-navigate to /feeds. New <rdrs-sidebar> mounts and renders synchronously
+    // from whatever client-side cache it picked up.
+    await page.getByTestId("nav-feeds").click();
+    await expect(page.locator("rdrs-feeds-page")).toBeVisible();
+
+    // Sample the badge while /api/sidebar is still in flight. The bug we're
+    // fixing is: the new sidebar paints the *stale* "3" from the bootstrap
+    // <script>, then the API response arrives and corrects it to "2" — the
+    // visible flicker. After the fix, the synchronous paint must already be
+    // the freshest known value.
+    const earlyBadge = await page
+      .locator("#unread-count")
+      .textContent({ timeout: 200 });
+    expect(earlyBadge).not.toBe("3");
+  });
+});

--- a/static/js/components/rdrs-entry-list.js
+++ b/static/js/components/rdrs-entry-list.js
@@ -1047,56 +1047,11 @@ ${this.showMarkAbove ? `<div id="mark-above-read" class="hidden-mt4">
     }
 
     _updateUnreadCount() {
-        // Fetch the actual unread count from GReader API and update sidebar badges
-        fetch('/reader/api/0/unread-count')
-            .then(r => r.json())
-            .then(data => {
-                const counts = data.unreadcounts || [];
-
-                // Update total unread badge
-                const total = counts.find(u => u.id === 'user/-/state/com.google/reading-list');
-                const el = document.getElementById('unread-count');
-                if (el) {
-                    el.textContent = (total && total.count > 0) ? total.count : '';
-                }
-
-                // Update category badges
-                const catContainer = document.getElementById('sidebar-categories');
-                if (!catContainer) return;
-                const catLinks = catContainer.querySelectorAll('a.sidebar-item');
-                // Build a map of category numeric ID -> unread count
-                const countByLabel = {};
-                for (const uc of counts) {
-                    if (uc.id.includes('/label/')) {
-                        countByLabel[uc.id] = uc.count;
-                    }
-                }
-                for (const link of catLinks) {
-                    const badge = link.querySelector('.sidebar-badge');
-                    // Extract category label from link text
-                    const href = link.getAttribute('href') || '';
-                    // Find matching count by checking all label counts
-                    const labelId = Object.keys(countByLabel).find(id => {
-                        const name = id.split('/label/').pop();
-                        const nameSpan = link.querySelector('span:first-child');
-                        return nameSpan && nameSpan.textContent === name;
-                    });
-                    const count = labelId ? countByLabel[labelId] : 0;
-                    if (count > 0) {
-                        if (badge) {
-                            badge.textContent = count;
-                        } else {
-                            const span = document.createElement('span');
-                            span.className = 'sidebar-badge';
-                            span.textContent = count;
-                            link.appendChild(span);
-                        }
-                    } else if (badge) {
-                        badge.remove();
-                    }
-                }
-            })
-            .catch(() => {});
+        // Single source of truth lives in <rdrs-sidebar>. It owns the badge
+        // DOM, the in-memory snapshot, and the sessionStorage cache that the
+        // next SPA-mount reads from — keeping all three in sync from one place
+        // is what prevents the post-action flicker.
+        document.querySelector('rdrs-sidebar')?.refresh();
     }
 
     // --- Entry actions (via Google Reader edit-tag) ---

--- a/static/js/components/rdrs-sidebar.js
+++ b/static/js/components/rdrs-sidebar.js
@@ -3,11 +3,21 @@
 // (sidebar-*, nav-* selectors) keeps working unchanged.
 //
 // Anti-flicker strategy:
-//   1. Read bootstrap JSON embedded in the shell (`<script id="rdrs-sidebar-bootstrap">`)
-//      and render synchronously on connect — zero round trips, zero flash.
-//   2. Mirror the payload to sessionStorage so navigations to non-bootstrapped
-//      pages (e.g. legacy SSR routes that do XHR) still get instant paint.
-//   3. Background-revalidate via /api/sidebar; only re-render if data changed.
+//   1. The shell embeds the initial /api/sidebar payload as a JSON
+//      `<script id="rdrs-sidebar-bootstrap">`. On every mount we read it
+//      synchronously and paint — zero round trips, zero flash.
+//   2. After every successful /api/sidebar fetch we rewrite that <script>'s
+//      textContent and the sessionStorage mirror with the new payload, so
+//      the next SPA-mount reads fresh data. The bootstrap is the single
+//      source of truth shared by <rdrs-sidebar> and pages/entries.js's
+//      category-mode lookup, so we keep it live rather than removing it.
+//   3. Background-revalidate via /api/sidebar after every mount, and surgically
+//      patch the unread badges (full-rerender only if identity / category set
+//      changed).
+//
+// Action paths that mutate unread/category state should call
+// `document.querySelector('rdrs-sidebar')?.refresh()` so the bootstrap, the
+// sessionStorage mirror, and the visible badges all advance together.
 
 const SIDEBAR_CACHE_KEY = 'rdrs.sidebar.v1';
 
@@ -34,8 +44,25 @@ function readCachedSidebar() {
 }
 
 function writeCachedSidebar(data) {
-    try { sessionStorage.setItem(SIDEBAR_CACHE_KEY, JSON.stringify(data)); }
+    const json = JSON.stringify(data);
+    try { sessionStorage.setItem(SIDEBAR_CACHE_KEY, json); }
     catch { /* quota / disabled storage — fine */ }
+    // Keep the embedded bootstrap <script> aligned with the latest payload,
+    // so SPA-mounts (which run after this) and pages/entries.js's category
+    // lookup both read the freshest state from a single source.
+    const node = document.getElementById('rdrs-sidebar-bootstrap');
+    if (node) node.textContent = json;
+}
+
+/// True when the difference between two sidebar payloads can't be expressed
+/// by surgical badge updates alone — identity changed, masquerade/admin role
+/// changed, or the category set was added/removed/renamed.
+function isStructuralChange(prev, next) {
+    if (prev.username !== next.username) return true;
+    if (!!prev.is_admin !== !!next.is_admin) return true;
+    if (!!prev.is_masquerading !== !!next.is_masquerading) return true;
+    const key = (cats) => (cats || []).map((c) => `${c.id}:${c.name}`).join('|');
+    return key(prev.categories) !== key(next.categories);
 }
 
 class RdrsSidebar extends HTMLElement {
@@ -56,16 +83,55 @@ class RdrsSidebar extends HTMLElement {
         if (this._data) this.render(this._data);
     }
 
+    /// Public refresh hook for action paths that mutate state the sidebar
+    /// reflects (mark-as-read, mark-unread, mark-all-as-read, etc). Re-fetches
+    /// /api/sidebar so sessionStorage and the live badges both update.
+    refresh() { return this.fetchData(); }
+
     async fetchData() {
         try {
             const resp = await fetch('/api/sidebar', { credentials: 'same-origin' });
             if (!resp.ok) return;
             const data = await resp.json();
-            const changed = JSON.stringify(data) !== JSON.stringify(this._data);
+            const prev = this._data;
             this._data = data;
             writeCachedSidebar(data);
-            if (changed) this.render(data);
+            if (!prev || isStructuralChange(prev, data)) {
+                this.render(data);
+            } else {
+                this._updateBadges(data);
+            }
         } catch (e) { /* silent */ }
+    }
+
+    /// Surgical badge update — used when only unread counts changed. Avoids a
+    /// full innerHTML rebuild so frequent mark-as-read clicks don't flash the
+    /// whole sidebar.
+    _updateBadges(data) {
+        const totalEl = this.querySelector('#unread-count');
+        if (totalEl) {
+            const total = data.total_unread || 0;
+            totalEl.textContent = total > 0 ? String(total) : '';
+        }
+        const catContainer = this.querySelector('#sidebar-categories');
+        if (!catContainer) return;
+        for (const cat of data.categories || []) {
+            const link = catContainer.querySelector(`a[href="/categories/${cat.id}/entries"]`);
+            if (!link) continue;
+            const existing = link.querySelector('.sidebar-badge');
+            if (cat.unread_count > 0) {
+                if (existing) {
+                    existing.textContent = String(cat.unread_count);
+                } else {
+                    const span = document.createElement('span');
+                    span.className = 'sidebar-badge';
+                    span.textContent = String(cat.unread_count);
+                    link.appendChild(span);
+                }
+            } else if (existing) {
+                existing.remove();
+            }
+        }
     }
 
     render(data) {


### PR DESCRIPTION
## Summary

- The embedded `<script id=\"rdrs-sidebar-bootstrap\">` is rendered once per HTTP response and outlives every SPA navigation. After any state-changing action (mark-as-read, sync, masquerade) it goes stale, so each SPA-mounted `<rdrs-sidebar>` painted the old unread counts and then re-rendered the right ones once `/api/sidebar` returned — the visible flicker.
- `<rdrs-sidebar>` now rewrites the bootstrap script's `textContent` (and the sessionStorage mirror) after every successful `/api/sidebar` fetch, so SPA mounts and `pages/entries.js`'s category-mode lookup both pick up the freshest payload from a single source.
- `fetchData()` distinguishes structural changes (identity / masquerade / category set) from count-only changes; the latter surgically patches badges instead of rebuilding the entire sidebar.
- `rdrs-entry-list._updateUnreadCount()` now delegates to `<rdrs-sidebar>.refresh()` instead of running a parallel `/reader/api/0/unread-count` fetch and ad-hoc DOM mutation, collapsing two divergent badge updaters into one.

## Test plan

- [x] `cargo nextest run` (693 / 693 pass)
- [x] New e2e regression test `e2e/tests/sidebar-flicker.spec.ts` — fails on `main`, passes on this branch
- [x] `npx playwright test sidebar-flicker spa-router global-navigation entry-actions:23 entry-actions:37 ssr-no-double-render` all green
- [x] Full e2e suite (excluding screenshot regen) green except the pre-existing `entry-actions:61 keyboard s toggles star` flake, which fails on `main` too

🤖 Generated with [Claude Code](https://claude.com/claude-code)