### PR TITLE
fix(sidebar): set active-category-id on category and feed pages

### DIFF
--- a/e2e/tests/sidebar-active-category.spec.ts
+++ b/e2e/tests/sidebar-active-category.spec.ts
@@ -1,0 +1,55 @@
+import { Page } from "@playwright/test";
+import { test, expect } from "../fixtures/rdrs.js";
+
+test.describe("sidebar marks the current category as active", () => {
+  let aId = 0;
+  let bId = 0;
+  let aFeedId = 0;
+
+  test.beforeAll(async ({ api, seed }) => {
+    await api.register("activecatuser", "password123");
+    const userId = seed.getUserId("activecatuser");
+    aId = seed.createCategory(userId, "ActiveCatA");
+    bId = seed.createCategory(userId, "ActiveCatB");
+    aFeedId = seed.createFeed(aId, "https://example.com/a.xml", "Feed A");
+    seed.createFeed(bId, "https://example.com/b.xml", "Feed B");
+  });
+
+  async function login(page: Page, serverUrl: string): Promise<void> {
+    await page.goto(`${serverUrl}/login`);
+    await page.getByTestId("username-input").fill("activecatuser");
+    await page.getByTestId("password-input").fill("password123");
+    await page.getByTestId("login-submit").click();
+    await page.waitForURL(`${serverUrl}/`);
+  }
+
+  test("/categories/{id}/entries highlights the matching category", async ({
+    page,
+    serverUrl,
+  }) => {
+    await login(page, serverUrl);
+
+    await page.goto(`${serverUrl}/categories/${aId}/entries`);
+    await expect(page.locator("rdrs-entries-page")).toBeVisible();
+
+    const aLink = page.locator(`a.sidebar-item[href="/categories/${aId}/entries"]`);
+    const bLink = page.locator(`a.sidebar-item[href="/categories/${bId}/entries"]`);
+    await expect(aLink).toHaveClass(/(^|\s)active(\s|$)/);
+    await expect(bLink).not.toHaveClass(/(^|\s)active(\s|$)/);
+  });
+
+  test("/feeds/{id}/entries highlights the feed's parent category", async ({
+    page,
+    serverUrl,
+  }) => {
+    await login(page, serverUrl);
+
+    await page.goto(`${serverUrl}/feeds/${aFeedId}/entries`);
+    await expect(page.locator("rdrs-entries-page")).toBeVisible();
+
+    const aLink = page.locator(`a.sidebar-item[href="/categories/${aId}/entries"]`);
+    const bLink = page.locator(`a.sidebar-item[href="/categories/${bId}/entries"]`);
+    await expect(aLink).toHaveClass(/(^|\s)active(\s|$)/);
+    await expect(bLink).not.toHaveClass(/(^|\s)active(\s|$)/);
+  });
+});

--- a/static/js/pages/entries.js
+++ b/static/js/pages/entries.js
@@ -321,9 +321,15 @@ class RdrsEntriesPage extends HTMLElement {
     /// flash paint immediately, then await meta and mount the entry-list.
     async _connectAsync(mode, cfg) {
         const id = pathId();
+        // For category mode, the URL id IS the category id — set
+        // active-category-id inline so the matching sidebar entry
+        // highlights on first paint. Feed mode defers (we need
+        // meta.category_id, not the feed id; updated below after
+        // fetchFeedMeta resolves).
+        const sidebarCatAttr = mode === 'category' ? ` active-category-id="${id}"` : '';
         this.innerHTML = `
 <div class="app-layout">
-<rdrs-sidebar active="${cfg.navKey}"></rdrs-sidebar>
+<rdrs-sidebar active="${cfg.navKey}"${sidebarCatAttr}></rdrs-sidebar>
 <main class="main-content">
     <rdrs-flash class="flash-container"></rdrs-flash>
     <div class="split-view">
@@ -349,6 +355,9 @@ class RdrsEntriesPage extends HTMLElement {
             this._categoryId = meta.category_id;
             this._feedUrl = meta.url;
             this._feedTitle = meta.title;
+            // Now that we know the parent category, light it up in the
+            // sidebar so the user sees which section they're inside.
+            this.querySelector('rdrs-sidebar')?.setAttribute('active-category-id', String(meta.category_id));
             streamId = `feed/${meta.url}`;
             const iconImg = meta.has_icon
                 ? `<img src="/api/feeds/${id}/icon" alt="" class="feed-icon" onerror="this.style.display='none'">`


### PR DESCRIPTION
## Summary

`<rdrs-sidebar>` already supports an `active-category-id` attribute that lights up the matching entry in the categories list, but no page module was setting it — so `/categories/{id}/entries` left every category in the sidebar unhighlighted (the bug surfaced during PR-1/PR-2 testing).

- `/categories/{id}/entries`: set the attribute inline at first paint (the URL id IS the category id, no fetch required).
- `/feeds/{id}/entries`: set it after `fetchFeedMeta` resolves (using `meta.category_id`) so the parent category lights up for visual context.

Audit found no other items with similar issues — top-section nav (unread/starred/all) and bottom-section nav (feeds/categories/search/statistics/user-settings/admin) all match against static `active="<key>"` and work correctly.

## Test plan

- [x] `cargo nextest run` — 701/701 pass.
- [x] New e2e `e2e/tests/sidebar-active-category.spec.ts` — 2 tests pass:
  - `/categories/{id}/entries` highlights the matching category and only that one.
  - `/feeds/{id}/entries` highlights the feed's parent category.
- [x] Existing `global-navigation`, `sidebar-flicker`, `spa-router` e2e specs still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)