### PR TITLE
chore(ssr): SSR-first carry-forward cleanup minors

### DIFF
--- a/src/handlers/feeds.rs
+++ b/src/handlers/feeds.rs
@@ -234,7 +234,10 @@ pub async fn delete_feed_form(
         .await;
     match result {
         Ok(Ok(())) => FlashRedirect::success("/feeds", "Feed deleted.").into_response(),
-        _ => FlashRedirect::error("/feeds", "Failed to delete feed").into_response(),
+        Ok(Err(AppError::FeedNotFound)) => {
+            FlashRedirect::error("/feeds", "Feed not found.").into_response()
+        }
+        _ => FlashRedirect::error("/feeds", "Failed to delete feed.").into_response(),
     }
 }
 

--- a/src/handlers/pages.rs
+++ b/src/handlers/pages.rs
@@ -7,7 +7,7 @@ use axum::{
 
 use std::collections::HashMap;
 
-use crate::error::{AppError, AppResult};
+use crate::error::AppError;
 use crate::middleware::auth::{PageAdminUser, PageAuthUser};
 use crate::middleware::flash::{Flash, FlashMessage};
 use crate::models::user_settings;
@@ -884,7 +884,7 @@ pub async fn feeds_page(
             total_feed_count,
             active_filter,
             active_sort,
-            active_category_id: active_category.unwrap_or(-1),
+            active_category_id: active_category,
             filter_links,
         },
     )
@@ -899,11 +899,10 @@ pub async fn feed_edit_page(
     State(state): State<AppState>,
     flash: Flash,
     Path(id): Path<i64>,
-) -> AppResult<(Flash, FeedEditTemplate)> {
-    let layout = build_app_layout(&state, &auth_user, &flash).await;
+) -> Result<Response, AppError> {
     let user_id = auth_user.user.id;
 
-    let (feed_view, cats) = state
+    let lookup = state
         .db
         .read_user(move |conn| {
             let f = feed::find_by_id(conn, id)?.ok_or(AppError::FeedNotFound)?;
@@ -931,8 +930,25 @@ pub async fn feed_edit_page(
                     .collect::<Vec<_>>(),
             ))
         })
-        .await??;
+        .await?;
 
+    let (feed_view, cats) = match lookup {
+        Ok(v) => v,
+        Err(AppError::FeedNotFound) => {
+            let page = render_not_found(
+                &state,
+                &auth_user,
+                &flash,
+                "Feed not found",
+                "This feed doesn't exist or you don't have access to it.",
+            )
+            .await;
+            return Ok((flash, page).into_response());
+        }
+        Err(e) => return Err(e),
+    };
+
+    let layout = build_app_layout(&state, &auth_user, &flash).await;
     Ok((
         flash,
         FeedEditTemplate {
@@ -942,7 +958,8 @@ pub async fn feed_edit_page(
             feed: feed_view,
             categories: cats,
         },
-    ))
+    )
+        .into_response())
 }
 
 /// Serves `/feeds/import` rendered fully server-side. Multipart form posts to
@@ -1364,14 +1381,30 @@ pub async fn category_entries_page(
     const PAGE_SIZE: i64 = 50;
     let user_id = auth_user.user.id;
 
-    let category_name = state
+    let lookup = state
         .db
         .read_user(move |c| {
             let cat =
                 category::find_by_id_and_user(c, id, user_id)?.ok_or(AppError::CategoryNotFound)?;
             Ok::<_, AppError>(cat.name)
         })
-        .await??;
+        .await?;
+
+    let category_name = match lookup {
+        Ok(name) => name,
+        Err(AppError::CategoryNotFound) => {
+            let page = render_not_found(
+                &state,
+                &auth_user,
+                &flash,
+                "Category not found",
+                "This category doesn't exist or you don't have access to it.",
+            )
+            .await;
+            return Ok((flash, page).into_response());
+        }
+        Err(e) => return Err(e),
+    };
 
     let status = query.status.as_deref();
     let effective_status = status.unwrap_or("unread");
@@ -1779,7 +1812,7 @@ pub async fn feed_entries_page(
     const PAGE_SIZE: i64 = 50;
     let user_id = auth_user.user.id;
 
-    let (feed_title, feed_url, feed_has_icon, cat_id, cat_name) = state
+    let lookup = state
         .db
         .read_user(move |c| {
             let f = feed::find_by_id(c, id)?.ok_or(AppError::FeedNotFound)?;
@@ -1796,7 +1829,23 @@ pub async fn feed_entries_page(
                 cat.name,
             ))
         })
-        .await??;
+        .await?;
+
+    let (feed_title, feed_url, feed_has_icon, cat_id, cat_name) = match lookup {
+        Ok(v) => v,
+        Err(AppError::FeedNotFound) | Err(AppError::CategoryNotFound) => {
+            let page = render_not_found(
+                &state,
+                &auth_user,
+                &flash,
+                "Feed not found",
+                "This feed doesn't exist or you don't have access to it.",
+            )
+            .await;
+            return Ok((flash, page).into_response());
+        }
+        Err(e) => return Err(e),
+    };
 
     // Default status is "unread": the base URL (no `?status=`) shows
     // unread + starred-but-unread entries. `?status=all` explicitly
@@ -1903,6 +1952,48 @@ pub async fn feed_entries_page(
     };
 
     Ok((flash, template).into_response())
+}
+
+/// Shared HTML error page rendered for logged-in routes when a requested
+/// resource is missing (e.g. feed/category not found). Replaces the default
+/// `AppError` JSON 404 with a chrome-wrapped page.
+#[derive(Template)]
+#[template(path = "error.html")]
+pub struct ErrorTemplate {
+    pub title: &'static str,
+    pub git_version: &'static str,
+    pub layout: AppLayoutContext,
+    pub heading: &'static str,
+    pub message: String,
+}
+
+impl IntoResponse for ErrorTemplate {
+    fn into_response(self) -> Response {
+        match self.render() {
+            Ok(html) => (StatusCode::NOT_FOUND, Html(html)).into_response(),
+            Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+        }
+    }
+}
+
+/// Build a chrome-wrapped 404 page for a logged-in route. The caller
+/// supplies a short heading and a longer message; both render inside the
+/// standard sidebar/flash chrome.
+pub async fn render_not_found(
+    state: &AppState,
+    auth_user: &PageAuthUser,
+    flash: &Flash,
+    heading: &'static str,
+    message: impl Into<String>,
+) -> ErrorTemplate {
+    let layout = build_app_layout(state, auth_user, flash).await;
+    ErrorTemplate {
+        title: "Not Found",
+        git_version: crate::GIT_VERSION,
+        layout,
+        heading,
+        message: message.into(),
+    }
 }
 
 /// Shared layout fields embedded in every per-route logged-in
@@ -2162,9 +2253,7 @@ pub struct FeedsTemplate {
     pub total_feed_count: i64,
     pub active_filter: String,
     pub active_sort: String,
-    /// `-1` sentinel for "no category filter" — keeps Askama integer
-    /// comparisons straightforward in the filter dropdown.
-    pub active_category_id: i64,
+    pub active_category_id: Option<i64>,
     pub filter_links: Vec<FeedFilterLink>,
 }
 

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -30,17 +30,17 @@
                                 {% else %}
                                     <form method="post" action="/admin/users/{{ u.id }}/role" style="display:inline">
                                         <input type="hidden" name="role" value="{% if u.role == "admin" %}user{% else %}admin{% endif %}">
-                                        <button type="submit" class="link-button">{% if u.role == "admin" %}demote{% else %}promote{% endif %}</button>
+                                        <button type="submit" class="action-link">{% if u.role == "admin" %}demote{% else %}promote{% endif %}</button>
                                     </form>
                                     <form method="post" action="/admin/users/{{ u.id }}/status" style="display:inline">
                                         <input type="hidden" name="disabled" value="{% if u.disabled %}false{% else %}true{% endif %}">
-                                        <button type="submit" class="link-button">{% if u.disabled %}enable{% else %}disable{% endif %}</button>
+                                        <button type="submit" class="action-link">{% if u.disabled %}enable{% else %}disable{% endif %}</button>
                                     </form>
                                     <form method="post" action="/admin/users/{{ u.id }}/masquerade" style="display:inline">
-                                        <button type="submit" class="link-button">view as</button>
+                                        <button type="submit" class="action-link">view as</button>
                                     </form>
                                     <form method="post" action="/admin/users/{{ u.id }}/delete" style="display:inline" onsubmit="return confirm('Delete user? This cannot be undone.')">
-                                        <button type="submit" class="link-button">delete</button>
+                                        <button type="submit" class="action-link action-link-danger">delete</button>
                                     </form>
                                 {% endif %}
                             </td>

--- a/templates/error.html
+++ b/templates/error.html
@@ -1,0 +1,15 @@
+{% extends "app_layout.html" %}
+
+{% block page %}
+    <div class="app-layout">
+        <rdrs-sidebar></rdrs-sidebar>
+        <main class="main-content">
+            <div class="page-content">
+                <rdrs-flash class="flash-container"></rdrs-flash>
+                <h1>{{ heading }}</h1>
+                <p class="muted">{{ message }}</p>
+                <p><a href="/">Back to Unread</a></p>
+            </div>
+        </main>
+    </div>
+{% endblock %}

--- a/templates/feeds.html
+++ b/templates/feeds.html
@@ -43,7 +43,7 @@
                         <select id="filter-category" name="category" class="select-auto" onchange="this.form.submit()">
                             <option value="">All Categories ({{ total_feed_count }})</option>
                             {% for c in categories %}
-                                <option value="{{ c.id }}"{% if c.id == active_category_id %} selected{% endif %}>{{ c.name }} ({{ c.feed_count }})</option>
+                                <option value="{{ c.id }}"{% if let Some(cid) = active_category_id %}{% if c.id == *cid %} selected{% endif %}{% endif %}>{{ c.name }} ({{ c.feed_count }})</option>
                             {% endfor %}
                         </select>
                     </div>

--- a/templates/user_settings.html
+++ b/templates/user_settings.html
@@ -102,7 +102,7 @@
                 {% if linkding_configured %}
                 <form method="post" action="/user-settings/linkding" style="display:inline-block;margin-top:0.5rem;">
                     <input type="hidden" name="_clear" value="1">
-                    <button type="submit" class="btn-secondary" onclick="return confirm('Clear Linkding settings?')">Clear Linkding</button>
+                    <button type="submit" class="btn btn-secondary" onclick="return confirm('Clear Linkding settings?')">Clear Linkding</button>
                 </form>
                 {% endif %}
 
@@ -137,7 +137,7 @@
                 {% if kagi_configured %}
                 <form method="post" action="/user-settings/kagi" style="display:inline-block;margin-top:0.5rem;">
                     <input type="hidden" name="_clear" value="1">
-                    <button type="submit" class="btn-secondary" onclick="return confirm('Clear Kagi settings?')">Clear Kagi</button>
+                    <button type="submit" class="btn btn-secondary" onclick="return confirm('Clear Kagi settings?')">Clear Kagi</button>
                 </form>
                 {% endif %}
             </div>

--- a/tests/compression_test.rs
+++ b/tests/compression_test.rs
@@ -1,5 +1,5 @@
-//! Verifies that responses are gzip-compressed when the client advertises
-//! `Accept-Encoding: gzip`, and left untouched otherwise.
+//! Verifies that responses are brotli-compressed when the client advertises
+//! `Accept-Encoding: br`, and left untouched otherwise.
 
 use std::sync::Arc;
 

--- a/tests/handlers_test.rs
+++ b/tests/handlers_test.rs
@@ -22,6 +22,17 @@ struct TestApp {
     db: DbPool,
 }
 
+/// Static asset cache-control depends on whether the binary was built from a
+/// clean git tree. PR-9 switched to `no-cache` for `-dirty` builds so dev
+/// iteration sees fresh assets — production builds keep the immutable header.
+fn expected_static_cache_control() -> &'static str {
+    if rdrs::GIT_VERSION.ends_with("-dirty") {
+        "no-cache"
+    } else {
+        "public, max-age=31536000, immutable"
+    }
+}
+
 fn open_shared_memory(name: &str) -> Connection {
     let uri = format!("file:{}?mode=memory&cache=shared", name);
     Connection::open_with_flags(
@@ -2121,7 +2132,7 @@ async fn test_static_js_serves_known_file() {
         .unwrap()
         .to_str()
         .unwrap();
-    assert_eq!(cache_control, "public, max-age=31536000, immutable");
+    assert_eq!(cache_control, expected_static_cache_control());
 
     let body = response.text();
     assert!(!body.is_empty(), "JS file should not be empty");
@@ -2172,7 +2183,7 @@ async fn test_static_css_serves_app_css() {
         .unwrap()
         .to_str()
         .unwrap();
-    assert_eq!(cache_control, "public, max-age=31536000, immutable");
+    assert_eq!(cache_control, expected_static_cache_control());
 
     let body = response.text();
     assert!(!body.is_empty(), "CSS file should not be empty");

--- a/tests/pages_test.rs
+++ b/tests/pages_test.rs
@@ -873,6 +873,15 @@ async fn test_category_entries_page_not_found() {
 
     let resp = app.server.get("/categories/999999/entries").await;
     assert_eq!(resp.status_code(), StatusCode::NOT_FOUND);
+    let body = resp.text();
+    assert!(
+        body.contains("Category not found"),
+        "404 page should render the not-found heading, got: {body}"
+    );
+    assert!(
+        body.contains("rdrs-sidebar"),
+        "404 page should render inside the app chrome (sidebar present), got: {body}"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -1364,6 +1373,15 @@ async fn test_feed_entries_page_not_found() {
 
     let resp = app.server.get("/feeds/999999/entries").await;
     assert_eq!(resp.status_code(), StatusCode::NOT_FOUND);
+    let body = resp.text();
+    assert!(
+        body.contains("Feed not found"),
+        "404 page should render the not-found heading, got: {body}"
+    );
+    assert!(
+        body.contains("rdrs-sidebar"),
+        "404 page should render inside the app chrome (sidebar present), got: {body}"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -1601,6 +1619,25 @@ async fn test_feed_edit_page_renders() {
 }
 
 #[tokio::test]
+async fn test_feed_edit_page_not_found_renders_error_page() {
+    let app = create_test_app(default_test_config());
+    setup_users(&app.db).await;
+    login(&app.server, "admin").await;
+
+    let response = app.server.get("/feeds/999999/edit").await;
+    assert_eq!(response.status_code(), StatusCode::NOT_FOUND);
+    let body = response.text();
+    assert!(
+        body.contains("Feed not found"),
+        "404 page should render the not-found heading, got: {body}"
+    );
+    assert!(
+        body.contains("rdrs-sidebar"),
+        "404 page should render inside the app chrome (sidebar present), got: {body}"
+    );
+}
+
+#[tokio::test]
 async fn test_feeds_import_page_renders() {
     let app = create_test_app(default_test_config());
     setup_users(&app.db).await;
@@ -1781,6 +1818,31 @@ async fn test_feeds_page_filter_by_category_excludes_other_rows() {
     let body = response.text();
     assert!(body.contains("Feed In A"));
     assert!(!body.contains("Feed In B"));
+    // The active category's <option> must carry `selected` so the filter
+    // dropdown reflects the URL query. Regression guard for the
+    // `active_category_id: Option<i64>` rendering branch in feeds.html.
+    assert!(
+        body.contains("value=\"1\" selected>Cat A"),
+        "Cat A option should be selected when ?category=1, got: {body}"
+    );
+    assert!(
+        !body.contains("value=\"2\" selected"),
+        "Cat B option must not be selected when ?category=1"
+    );
+
+    // With no `?category=` query the dropdown defaults to "All Categories" and
+    // no <option> should carry selected.
+    let response_default = app.server.get("/feeds").await;
+    response_default.assert_status_ok();
+    let body_default = response_default.text();
+    assert!(
+        !body_default.contains("value=\"1\" selected"),
+        "no category should be selected when ?category= is absent"
+    );
+    assert!(
+        !body_default.contains("value=\"2\" selected"),
+        "no category should be selected when ?category= is absent"
+    );
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Sweeps the carry-forward minors accumulated across the SSR-first migration (PRs 1-12). Low-risk visual polish + small idiomatic fixes + an HTML 404 page for the three `*entries` / edit routes that previously bubbled `AppError::FeedNotFound` / `AppError::CategoryNotFound` up to the default JSON-404 handler.

### Visual / template fixes
- `admin.html`: replace `.link-button` (no CSS rule, rendered as default dark filled buttons) with `.action-link` / `.action-link-danger` so the promote/demote/disable/view-as/delete buttons match the inline-action-link style used in `feeds.html`.
- `user_settings.html`: add the base `.btn` class to Clear Linkding / Clear Kagi so the `btn-secondary` visuals actually apply.

### Idiomatic Rust / template
- `FeedsTemplate.active_category_id: i64` (`-1` sentinel) → `Option<i64>` with `{% if let Some(cid) = active_category_id %}` in `feeds.html`.
- `feeds.rs delete_feed_form`: distinguish `FeedNotFound` from generic DB errors with a dedicated flash, matching the `categories.rs` pattern.
- `tests/compression_test.rs`: refresh the doc header from `gzip` to `brotli` to match PR-1.

### HTML 404 for page routes
- New `templates/error.html` + `pages::ErrorTemplate` + `render_not_found()` helper rendering a chrome-wrapped 404 page (sidebar + flash present, status 404).
- Wires `feed_edit_page`, `feed_entries_page`, and `category_entries_page` to render the page on `FeedNotFound` / `CategoryNotFound` instead of bubbling to the default `AppError` JSON 404.

### Test fixes
- The two static-asset cache-control tests now branch on `GIT_VERSION.ends_with("-dirty")` (pre-existing PR-9 flake on dev builds).
- Existing not-found page tests now assert the body contains the heading and `rdrs-sidebar` (chrome) — codifies the new HTML behavior.
- New `test_feed_edit_page_not_found_renders_error_page`.
- `test_feeds_page_filter_by_category_excludes_other_rows` gains explicit `selected` assertions to guard the `Option<i64>` rendering.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo nextest run --no-fail-fast` — 728/728
- [x] `cargo clippy --all-targets -- -D warnings`
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)