### PR TITLE
perf(ui): fix Bunny font URL + modulepreload chrome scripts

### DIFF
--- a/templates/app_layout.html
+++ b/templates/app_layout.html
@@ -5,6 +5,10 @@
 {% block title %}{{ title }} - RDRS{% endblock %}
 
 {% block head %}
+    <link rel="modulepreload" href="/static/js/components/rdrs-kb-pending.js?v={{ layout.git_version }}">
+    <link rel="modulepreload" href="/static/js/components/rdrs-kb-help.js?v={{ layout.git_version }}">
+    <link rel="modulepreload" href="/static/js/components/rdrs-sidebar.js?v={{ layout.git_version }}">
+    <link rel="modulepreload" href="/static/js/app.js?v={{ layout.git_version }}">
     <script type="module" src="/static/js/components/rdrs-kb-pending.js?v={{ layout.git_version }}"></script>
     <script type="module" src="/static/js/components/rdrs-kb-help.js?v={{ layout.git_version }}"></script>
     <script type="module" src="/static/js/components/rdrs-sidebar.js?v={{ layout.git_version }}"></script>

--- a/templates/base.html
+++ b/templates/base.html
@@ -8,8 +8,13 @@
     <link rel="icon" href="/favicon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="/apple-touch-icon.png">
     <link rel="preconnect" href="https://fonts.bunny.net">
-    <link href="https://fonts.bunny.net/css2?family=DM+Sans:ital,wght@0,400;0,500;0,600;0,700;1,400&family=JetBrains+Mono:wght@400;500&family=Playfair+Display:ital,wght@0,400;0,500;0,600;0,700;0,800;1,400;1,500&family=Source+Serif+4:ital,opsz,wght@0,8..60,300;0,8..60,400;0,8..60,500;0,8..60,600;0,8..60,700;1,8..60,300;1,8..60,400;1,8..60,500;1,8..60,600&display=swap" rel="stylesheet">
+    {# Bunny doesn't support the `opsz` axis — the previous URL silently
+       returned an API error so every family fell back to OS defaults.
+       Trimmed weight set: DM Sans 400/500/600/700, JetBrains Mono 400,
+       Playfair Display 600/700, Source Serif 4 400/600 + italic 400. #}
+    <link href="https://fonts.bunny.net/css2?family=DM+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400&family=Playfair+Display:wght@600;700&family=Source+Serif+4:ital,wght@0,400;0,600;1,400&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/static/css/app.css?v={{ git_version }}">
+    <link rel="modulepreload" href="/static/js/components/rdrs-flash.js?v={{ git_version }}">
     <script>
         // Theme controller
         window.theme = {


### PR DESCRIPTION
## Summary

While auditing page-load perf I discovered the fonts.bunny.net URL has been broken since forever: Bunny does not support the `opsz` (optical size) axis we were specifying on Source Serif 4, so the entire 4-family request returned an 85-byte API error and every family fell back to OS defaults. The intended design (Playfair headings, Source Serif body, DM Sans UI, JetBrains Mono code) has never actually shipped.

## Changes

### Font URL fix (`templates/base.html`)
- Drop the `opsz` axis from Source Serif 4.
- Trim the weight matrix to what `static/css/app.css` actually uses:
  - **DM Sans**: 400, 500, 600, 700 (no italic — never used on UI selectors)
  - **JetBrains Mono**: 400 only (no 500 — never used on code selectors)
  - **Playfair Display**: 600, 700 (no italic, no 400/500/800 — never used on display selectors)
  - **Source Serif 4**: 400, 600 + italic 400 (no 300/500/700, no 600/500/300 italic)

Before: Bunny returned 85 B error → 0 fonts loaded → all 4 families fell back.
After: Bunny returns 20 KB CSS with 40 `@font-face` rules across the latin / latin-ext / cyrillic subsets. ~462 KB woff2 total across all subsets on first visit (browsers fetch only the subsets matching characters on the page, so per-page is much less).

### Modulepreload (`base.html` + `app_layout.html`)
- Add `<link rel="modulepreload">` for each `<script type="module">` in `<head>`:
  - `base.html`: `rdrs-flash.js`
  - `app_layout.html`: `rdrs-kb-pending.js`, `rdrs-kb-help.js`, `rdrs-sidebar.js`, `app.js`
- Lets the browser start fetching chrome JS in parallel with HTML parsing instead of waiting to encounter the script tag.

## Test plan
- [x] `cargo nextest run` — 728/728 (template-only changes)
- [x] Manual: dev server `/login`, `/`, `/feeds`, `/entries`, `/settings` — Source Serif body, Playfair headings, DM Sans UI, JetBrains Mono code all render correctly
- [x] Verified Bunny URL by curl: 4 families × 40 face rules, CSS validates
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)