### PR TITLE
feat(reader): toggle between full content and original feed body

### DIFF
--- a/src/handlers/entries.rs
+++ b/src/handlers/entries.rs
@@ -211,6 +211,7 @@ pub(crate) fn build_reading_pane_view(
         summary_in_flight,
         has_kagi,
         has_save,
+        is_full_content: false,
     }
 }
 
@@ -484,8 +485,10 @@ pub async fn summarize_entry_form(
 
 /// `POST /entries/{id}/fetch-full-content` — fetch the source article from
 /// the entry's `link`, sanitize, and return the reading pane with the
-/// article body replaced by the new HTML. No toggle-back behavior; refresh
-/// the page to restore the original feed body.
+/// article body replaced by the new HTML. The response sets
+/// `pane.is_full_content = true` so the template swaps "Fetch Full
+/// Content" for a "Show Original" link; clicking it re-renders the pane
+/// via `GET /entries/{id}/fragment` which restores the feed-supplied body.
 pub async fn fetch_full_content_form(
     auth_user: PageAuthUser,
     State(state): State<AppState>,
@@ -517,6 +520,7 @@ pub async fn fetch_full_content_form(
             );
             let mut pane = build_reading_pane_view(&state, user_id, &ewf, has_save, has_kagi);
             pane.content_html = sanitized;
+            pane.is_full_content = true;
             (
                 pane,
                 FlashPayload {

--- a/src/handlers/pages.rs
+++ b/src/handlers/pages.rs
@@ -73,6 +73,12 @@ pub struct ReadingPaneView {
     pub summary_in_flight: bool,
     pub has_kagi: bool,
     pub has_save: bool,
+    /// `true` after `POST /entries/{id}/fetch-full-content` succeeds —
+    /// the `content_html` field then holds the externally-fetched
+    /// article body instead of the feed-supplied content. The reading
+    /// pane swaps "Fetch Full Content" for a "Show Original" link in
+    /// this case so the user can revert.
+    pub is_full_content: bool,
 }
 
 /// One segment of a breadcrumb trail rendered above the page `<h1>`. `href =

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -251,7 +251,7 @@ const KB_SHORTCUTS = [
     { group: 'Entry list', key: 'Shift+Space', desc: 'Scroll reading pane up' },
     { group: 'Entry actions', key: 'v', desc: 'View original (new tab)' },
     { group: 'Entry actions', key: 'u', desc: 'Mark unread' },
-    { group: 'Entry actions', key: 'Shift+F', desc: 'Fetch full content' },
+    { group: 'Entry actions', key: 'Shift+F', desc: 'Fetch full content (toggle with original)' },
     { group: 'Entry actions', key: 'b', desc: 'Save (Linkding)' },
     { group: 'Entry actions', key: 'm', desc: 'Summarize (Kagi)' },
     { group: 'List filters', key: '1', desc: 'All' },
@@ -447,11 +447,16 @@ function installEntriesKeyboard() {
                 break;
             }
             case 'F': {
-                // Fetch Full Content. Reading-pane only.
+                // Toggle between feed-supplied and externally-fetched
+                // article body. When the pane already shows the full
+                // content the Fetch button is replaced by a "Show
+                // Original" link — fall through to that.
                 const form = paneForm('/fetch-full-content');
-                if (!form) return;
-                e.preventDefault();
-                form.requestSubmit();
+                if (form) { e.preventDefault(); form.requestSubmit(); break; }
+                const pane = document.getElementById('reading-pane');
+                if (!pane || pane.classList.contains('reading-pane-empty')) return;
+                const showOriginal = pane.querySelector('a[data-swap="#reading-pane"]');
+                if (showOriginal) { e.preventDefault(); showOriginal.click(); }
                 break;
             }
             case 'b': {

--- a/templates/_reading_pane.html
+++ b/templates/_reading_pane.html
@@ -23,9 +23,17 @@
                 <button type="submit" class="btn-secondary btn-sm">Mark Unread</button>
             </form>
             {% if let Some(link) = pane.link.as_ref() %}
+            {% if pane.is_full_content %}
+            {# `GET /entries/{id}/fragment` returns the original feed-supplied
+               reading pane (plus row + sidebar-unread, which are already in
+               their post-open state, so the swap is effectively a no-op for
+               them). Lets the user revert from a Fetch-Full-Content view. #}
+            <a href="/entries/{{ pane.id }}/fragment" data-swap="#reading-pane" class="btn btn-secondary btn-sm">Show Original</a>
+            {% else %}
             <form method="post" action="/entries/{{ pane.id }}/fetch-full-content" data-swap="#reading-pane">
                 <button type="submit" class="btn-secondary btn-sm">Fetch Full Content</button>
             </form>
+            {% endif %}
             {% if pane.has_kagi || pane.summary_in_flight %}
             <form method="post" action="/entries/{{ pane.id }}/summarize" data-swap="#reading-pane">
                 <button type="submit" class="btn-secondary btn-sm"{% if pane.summary_in_flight %} disabled{% endif %}>Summarize</button>


### PR DESCRIPTION
## Summary

Fetch Full Content used to be a one-way replacement — once you'd clicked it, the only way back to the feed-supplied entry content was a full page reload. Make it a proper toggle.

## Changes

- `ReadingPaneView` gains `is_full_content: bool`, set to `true` only on a successful `POST /entries/{id}/fetch-full-content` (error branch leaves it `false`).
- `_reading_pane.html` renders:
  - `is_full_content: false` → existing "Fetch Full Content" form
  - `is_full_content: true`  → "Show Original" link (`GET /entries/{id}/fragment`). Clicking re-renders the pane with the feed-supplied content; `build_reading_pane_view()` defaults the flag back to false.
- `Shift+F` keyboard shortcut now toggles too: when the Fetch-Full-Content form is gone (pane is in full-content mode), the handler falls through to the Show-Original link.

## Test plan
- [x] `cargo nextest run` — 728/728
- [x] `cargo fmt --check`
- [x] Manual: Fetch Full Content → button label swaps to "Show Original"; clicking it (or pressing `Shift+F`) restores the feed-supplied content and brings the Fetch button back
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)