### PR TITLE
fix(reader): restore summary Copy/Dismiss + DB fallback + isolated summarize swap

### DIFF
--- a/src/handlers/entries.rs
+++ b/src/handlers/entries.rs
@@ -63,6 +63,23 @@ impl IntoResponse for ReadingPaneWithFlash {
     }
 }
 
+/// Multi-target response for `POST /entries/{id}/summarize`. Swaps only
+/// the `#rp-summary-container` block so the reading-pane article body
+/// (which may currently hold an externally-fetched full-content view)
+/// stays put.
+#[derive(Template)]
+#[template(path = "_summarize_pending.html")]
+pub struct SummarizePending;
+
+impl IntoResponse for SummarizePending {
+    fn into_response(self) -> Response {
+        match self.render() {
+            Ok(html) => Html(html).into_response(),
+            Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+        }
+    }
+}
+
 /// `GET /entries/{id}/fragment` — returns the reading-pane HTML fragment for
 /// the given entry. The entry must belong to the authenticated user; otherwise
 /// a 404 is returned (same semantics as the JSON `/api/entries/{id}` endpoint
@@ -97,7 +114,7 @@ pub async fn entry_fragment(
         .await??;
 
     let (has_save, has_kagi) = load_pane_action_flags(&state, user_id).await?;
-    let pane = build_reading_pane_view(&state, user_id, &ewf, has_save, has_kagi);
+    let pane = build_reading_pane_view(&state, user_id, &ewf, has_save, has_kagi).await?;
     let row = row_view_from(&ewf, status);
     let sidebar_unread_payload_json = build_sidebar_unread(&state, user_id).await?;
     Ok(OpenEntryMulti {
@@ -105,25 +122,6 @@ pub async fn entry_fragment(
         r: row,
         sidebar_unread_payload_json,
     })
-}
-
-/// Build a `ReadingPaneView` for the given entry, scoped to `user_id`.
-/// Returns `AppError::EntryNotFound` if the entry does not exist or belongs
-/// to a different user.
-pub(crate) async fn load_reading_pane(
-    state: &AppState,
-    user_id: i64,
-    entry_id: i64,
-) -> AppResult<ReadingPaneView> {
-    let ewf = state
-        .db
-        .read_user(move |conn| entry::find_by_id_for_user(conn, user_id, entry_id))
-        .await??
-        .ok_or(AppError::EntryNotFound)?;
-    let (has_save, has_kagi) = load_pane_action_flags(state, user_id).await?;
-    Ok(build_reading_pane_view(
-        state, user_id, &ewf, has_save, has_kagi,
-    ))
 }
 
 /// Read the user's save-services config + Kagi config to drive the
@@ -148,18 +146,24 @@ pub(crate) async fn load_pane_action_flags(
 }
 
 /// Build a `ReadingPaneView` from an already-loaded `EntryWithFeed`. The
-/// content sanitizer + summary-cache lookup happen here so callers that
-/// already have the entry (e.g. `entry_fragment`, which loads it inside its
-/// write transaction) don't re-hit the DB. `has_save` / `has_kagi` come
-/// from `load_pane_action_flags`. Save / Fetch action feedback is delivered
-/// via flash (see `ReadingPaneWithFlash`), not inline status text.
-pub(crate) fn build_reading_pane_view(
+/// content sanitizer + summary lookup happen here so callers that already
+/// have the entry (e.g. `entry_fragment`, which loads it inside its write
+/// transaction) don't re-hit the DB for the entry itself. `has_save` /
+/// `has_kagi` come from `load_pane_action_flags`. Save / Fetch action
+/// feedback is delivered via flash (see `ReadingPaneWithFlash`), not
+/// inline status text.
+///
+/// Summary resolution prefers the in-memory cache and falls back to the
+/// persistent `entry_summary` table so a server restart (or any other
+/// path that bypassed the cache) does not hide an already-completed
+/// summary on the next entry open.
+pub(crate) async fn build_reading_pane_view(
     state: &AppState,
     user_id: i64,
     ewf: &entry::EntryWithFeed,
     has_save: bool,
     has_kagi: bool,
-) -> ReadingPaneView {
+) -> AppResult<ReadingPaneView> {
     let entry_id = ewf.entry.id;
     let raw_content = ewf
         .entry
@@ -184,15 +188,10 @@ pub(crate) fn build_reading_pane_view(
         proxy_base_url,
     );
 
-    let cache_entry = state.summary_cache.get(user_id, entry_id);
-    let (summary_text, summary_in_flight) = match cache_entry.as_ref().map(|e| &e.status) {
-        Some(SummaryStatus::Completed) => (cache_entry.and_then(|e| e.summary_text.clone()), false),
-        Some(SummaryStatus::Pending) | Some(SummaryStatus::Processing) => (None, true),
-        _ => (None, false),
-    };
+    let (summary_text, summary_in_flight) = resolve_summary(state, user_id, entry_id).await?;
 
     let published_at = ewf.entry.published_at;
-    ReadingPaneView {
+    Ok(ReadingPaneView {
         id: entry_id,
         title: ewf
             .entry
@@ -212,6 +211,39 @@ pub(crate) fn build_reading_pane_view(
         has_kagi,
         has_save,
         is_full_content: false,
+    })
+}
+
+/// Resolve `(summary_text, summary_in_flight)` for an entry. Reads the
+/// in-memory cache first; on miss or terminal-failed state falls back to
+/// the `entry_summary` table so a completed summary persisted in a
+/// previous session is still surfaced.
+async fn resolve_summary(
+    state: &AppState,
+    user_id: i64,
+    entry_id: i64,
+) -> AppResult<(Option<String>, bool)> {
+    if let Some(cached) = state.summary_cache.get(user_id, entry_id) {
+        match cached.status {
+            SummaryStatus::Completed => return Ok((cached.summary_text, false)),
+            SummaryStatus::Pending | SummaryStatus::Processing => return Ok((None, true)),
+            SummaryStatus::Failed => {
+                // Fall through to DB — the DB row may have been refreshed
+                // by a retry that hasn't been written into the cache yet.
+            }
+        }
+    }
+    let db_entry = state
+        .db
+        .read_user(move |conn| entry_summary::find_by_user_and_entry(conn, user_id, entry_id))
+        .await??;
+    match db_entry {
+        Some(s) => match s.status {
+            SummaryStatus::Completed => Ok((s.summary_text, false)),
+            SummaryStatus::Pending | SummaryStatus::Processing => Ok((None, true)),
+            SummaryStatus::Failed => Ok((None, false)),
+        },
+        None => Ok((None, false)),
     }
 }
 
@@ -442,7 +474,7 @@ pub async fn summarize_entry_form(
     auth_user: PageAuthUser,
     State(state): State<AppState>,
     AxumPath(entry_id): AxumPath<i64>,
-) -> AppResult<ReadingPaneFragment> {
+) -> AppResult<SummarizePending> {
     let user_id = auth_user.user.id;
 
     // Fetch the entry and extract the link needed by SummaryJob. Ownership is
@@ -469,7 +501,7 @@ pub async fn summarize_entry_form(
     state.summary_cache.set_pending(user_id, entry_id);
 
     // Best-effort enqueue: if the channel is full or closed, we still return
-    // the in-flight reading pane (the DB record is already pending).
+    // the in-flight pending fragment (the DB record is already pending).
     let _ = state
         .summary_tx
         .send(SummaryJob {
@@ -479,8 +511,7 @@ pub async fn summarize_entry_form(
         })
         .await;
 
-    let pane = load_reading_pane(&state, user_id, entry_id).await?;
-    Ok(ReadingPaneFragment { pane })
+    Ok(SummarizePending)
 }
 
 /// `POST /entries/{id}/fetch-full-content` — fetch the source article from
@@ -518,7 +549,8 @@ pub async fn fetch_full_content_form(
                 ewf.custom_referrer.as_deref(),
                 None,
             );
-            let mut pane = build_reading_pane_view(&state, user_id, &ewf, has_save, has_kagi);
+            let mut pane =
+                build_reading_pane_view(&state, user_id, &ewf, has_save, has_kagi).await?;
             pane.content_html = sanitized;
             pane.is_full_content = true;
             (
@@ -530,7 +562,7 @@ pub async fn fetch_full_content_form(
             )
         }
         Err(e) => (
-            build_reading_pane_view(&state, user_id, &ewf, has_save, has_kagi),
+            build_reading_pane_view(&state, user_id, &ewf, has_save, has_kagi).await?,
             FlashPayload {
                 level: "error",
                 message: format!("Failed to fetch full content: {e}"),
@@ -617,7 +649,7 @@ pub async fn save_entry_form(
     };
 
     let (has_save, has_kagi) = load_pane_action_flags(&state, user_id).await?;
-    let pane = build_reading_pane_view(&state, user_id, &ewf, has_save, has_kagi);
+    let pane = build_reading_pane_view(&state, user_id, &ewf, has_save, has_kagi).await?;
     Ok(ReadingPaneWithFlash {
         pane,
         flash: Some(flash),

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -521,6 +521,65 @@ function installEntriesKeyboard() {
 }
 installEntriesKeyboard();
 
+// Reading-pane summary controls (Kagi Universal Summarizer output).
+// Copy is a clipboard write; Dismiss DELETEs the cached summary and
+// strips the summary block + the entry row's summary badge so the
+// state matches what `/sidebar/unread` will report on the next mount.
+function installSummaryActions() {
+    document.addEventListener('click', async (e) => {
+        const copyBtn = e.target.closest('[data-summary-copy]');
+        if (copyBtn) {
+            const pane = document.getElementById('reading-pane');
+            if (!pane) return;
+            const titleEl = pane.querySelector('.reading-pane-title');
+            const summaryEl = pane.querySelector('.rp-summary-content');
+            if (!summaryEl) return;
+            const title = (titleEl?.textContent || '').trim();
+            const link = titleEl?.querySelector('a')?.getAttribute('href') || '';
+            const summary = summaryEl.textContent.trim();
+            const text = link
+                ? `${title}\n\n${link}\n\n${summary}`
+                : `${title}\n\n${summary}`;
+            try {
+                await navigator.clipboard.writeText(text);
+                const original = copyBtn.textContent;
+                copyBtn.textContent = 'Copied!';
+                setTimeout(() => { copyBtn.textContent = original; }, 2000);
+            } catch {
+                window.flash?.error('Failed to copy to clipboard');
+            }
+            return;
+        }
+        const dismissBtn = e.target.closest('[data-summary-dismiss]');
+        if (!dismissBtn) return;
+        const entryId = dismissBtn.getAttribute('data-entry-id');
+        if (!entryId) return;
+        dismissBtn.disabled = true;
+        try {
+            const r = await fetch(`/api/entries/${entryId}/summary`, {
+                method: 'DELETE',
+                credentials: 'same-origin',
+            });
+            if (!r.ok) throw new Error('delete failed');
+            // Clear the inner `.summary-box` but leave the wrapper in
+            // place — the swap target for a later summarize click is
+            // `#rp-summary-container`, so the wrapper has to stay.
+            const container = document.querySelector('[data-summary-container]');
+            if (container) container.replaceChildren();
+            const row = document.querySelector(
+                `[data-entry-row][data-entry-id="${entryId}"]`
+            );
+            row?.querySelector(
+                '.summary-badge, .summary-badge-pending, .summary-badge-processing, .summary-badge-failed'
+            )?.remove();
+        } catch {
+            window.flash?.error('Failed to dismiss summary');
+            dismissBtn.disabled = false;
+        }
+    });
+}
+installSummaryActions();
+
 // "Mark as Read..." dropdown on /unread + /entries pages. Posts to the
 // GReader bulk-mark endpoint with an optional `ts=` cutoff in
 // microseconds, then full-reloads so the SSR row list refreshes. The

--- a/templates/_reading_pane.html
+++ b/templates/_reading_pane.html
@@ -35,7 +35,7 @@
             </form>
             {% endif %}
             {% if pane.has_kagi || pane.summary_in_flight %}
-            <form method="post" action="/entries/{{ pane.id }}/summarize" data-swap="#reading-pane">
+            <form method="post" action="/entries/{{ pane.id }}/summarize" data-swap="#rp-summary-container">
                 <button type="submit" class="btn-secondary btn-sm"{% if pane.summary_in_flight %} disabled{% endif %}>Summarize</button>
             </form>
             {% endif %}
@@ -47,13 +47,25 @@
             <a href="{{ link }}" target="_blank" rel="noopener noreferrer" class="btn btn-secondary btn-sm">View Original</a>
             {% endif %}
         </div>
-        {% if let Some(summary) = pane.summary_text.as_ref() %}
-        <div class="rp-summary-container">
+        {# Always render the wrapper so `POST /entries/{id}/summarize` can
+           swap into `#rp-summary-container` without touching the article
+           body — keeps a Fetch-Full-Content view from being reset back to
+           the feed-supplied content when the user kicks off a summary. #}
+        <div class="rp-summary-container" id="rp-summary-container" data-summary-container>
+            {% if pane.summary_in_flight %}
             <div class="summary-box">
+                <p class="muted">Summarizing… (refresh to see the result)</p>
+            </div>
+            {% else if let Some(summary) = pane.summary_text.as_ref() %}
+            <div class="summary-box">
+                <div class="summary-actions">
+                    <button type="button" class="btn-secondary btn-sm" data-summary-copy>Copy</button>
+                    <button type="button" class="btn-secondary btn-sm" data-summary-dismiss data-entry-id="{{ pane.id }}">Dismiss</button>
+                </div>
                 <blockquote class="rp-summary-content">{{ summary|safe }}</blockquote>
             </div>
+            {% endif %}
         </div>
-        {% endif %}
         <article class="reading-pane-article">{{ pane.content_html|safe }}</article>
     </div>
 </div>

--- a/templates/_summarize_pending.html
+++ b/templates/_summarize_pending.html
@@ -1,0 +1,12 @@
+{# `POST /entries/{id}/summarize` response. Swaps ONLY the summary
+   container so a Fetch-Full-Content view stays put — the reading
+   pane's `<article>` is not touched. The full reading-pane render
+   on next page load will surface the completed summary once the
+   background worker finishes. #}
+<template data-swap-target="#rp-summary-container">
+    <div class="rp-summary-container" id="rp-summary-container" data-summary-container>
+        <div class="summary-box">
+            <p class="muted">Summarizing… (refresh to see the result)</p>
+        </div>
+    </div>
+</template>

--- a/tests/handlers_test.rs
+++ b/tests/handlers_test.rs
@@ -4266,8 +4266,12 @@ async fn test_read_entry_form_404_for_other_user() {
 }
 
 // POST /entries/{id}/summarize — PR-10 T5
+//
+// The handler returns a small multi-target swap that only updates the
+// `#rp-summary-container` block (not the whole reading pane), so a
+// Fetch-Full-Content view keeps its externally-fetched article body.
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
-async fn test_summarize_entry_form_renders_reading_pane() {
+async fn test_summarize_entry_form_renders_summary_pending_fragment() {
     let app = create_test_app_named(default_test_config(), "test_summarize_entry_form");
 
     // Register and log in as alice.
@@ -4321,7 +4325,8 @@ async fn test_summarize_entry_form_renders_reading_pane() {
         .await
         .unwrap();
 
-    // POST /entries/{id}/summarize — should return reading pane with button disabled.
+    // POST /entries/{id}/summarize — should return only the
+    // `#rp-summary-container` swap fragment with a pending state.
     let resp = app
         .server
         .post(&format!("/entries/{}/summarize", entry_id))
@@ -4329,12 +4334,18 @@ async fn test_summarize_entry_form_renders_reading_pane() {
     assert_eq!(resp.status_code(), StatusCode::OK);
     let html = resp.text();
     assert!(
-        html.contains("id=\"reading-pane\""),
-        "response must contain the reading pane element"
+        html.contains("data-swap-target=\"#rp-summary-container\""),
+        "response must target the summary container, not the whole reading pane"
     );
     assert!(
-        html.contains("disabled"),
-        "Summarize button must be disabled while summary is in-flight"
+        html.contains("Summarizing"),
+        "pending fragment must show a 'Summarizing…' message"
+    );
+    // The article body should not be in the response — that is the whole
+    // point of the smaller swap target.
+    assert!(
+        !html.contains("reading-pane-article"),
+        "response must NOT swap the article body (would reset full-content view)"
     );
 }
 


### PR DESCRIPTION
## Summary

Three reader-pane fixes around the Kagi summary surface, all visible to the user as missing-or-wrong behaviors on the summary block.

## Changes

### 1. Restore Copy + Dismiss on the summary block
These existed in the CSR `<rdrs-entry-list>` component but were never carried over when PR-10 rewrote the reading pane server-side. Add them back as plain buttons handled by a delegated click listener (`installSummaryActions` in `app.js`):
- **Copy** — writes `title \n\n link \n\n summary` to the clipboard via `navigator.clipboard.writeText`; flashes "Copied!" on the button for 2s.
- **Dismiss** — DELETEs `/api/entries/{id}/summary` (endpoint already exists), clears the summary box inline, and strips the summary badge off the corresponding entry row.

### 2. Don't reset a Fetch-Full-Content view on summarize
`POST /entries/{id}/summarize` used to return the full reading pane (`ReadingPaneFragment`), which the swap helper installed in place of `#reading-pane` — discarding the externally-fetched article body the user was viewing. Switch the response to a tiny multi-target swap fragment (`_summarize_pending.html`) that only updates the `#rp-summary-container` block. The summary wrapper now always renders (even when empty) so the swap target exists regardless of summary state.

The `Shift+F` Fetch-Full-Content shortcut already toggles back to original content, so users can revert at will.

### 3. DB fallback for summary text
`build_reading_pane_view` used to read from `state.summary_cache` only — a cache miss (e.g. after a server restart or any cold-start open of an entry summarized in a previous session) returned `summary_text: None`, so `/entries/summarized → open entry` would show no summary at all. New `resolve_summary()` helper prefers the cache and falls back to `entry_summary::find_by_user_and_entry`. The function is now async; all three callers (`entry_fragment`, `fetch_full_content_form`, `save_entry_form`) await accordingly.

## Test plan
- [x] `cargo nextest run` — 728/728
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] Manual: summary shows Copy + Dismiss; Copy puts text on clipboard; Dismiss clears box + row badge
- [x] Manual: Fetch Full Content → Summarize → article body stays full (not reset to original)
- [x] Manual: open an already-summarized entry from `/entries/summarized` after server restart — summary renders
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)