### PR TITLE
test(e2e): unskip 9 SSR-now-implemented BDD scenarios

### DIFF
--- a/e2e/features/reading.feature
+++ b/e2e/features/reading.feature
@@ -10,14 +10,12 @@ Feature: Reading entries
     Then I see 5 entries in the entry list
     And the first entry is titled "Test Entry 1"
 
-  @skip
   Scenario: Opening an entry swaps the reading pane to show its title and body
     When I open the inbox
     And I click the entry titled "Test Entry 1"
     Then the reading pane shows the title "Test Entry 1"
     And the reading pane shows the content "Content for test entry 1"
 
-  @skip
   Scenario: Reading pane shows feed title and published time
     When I open the inbox
     And I click the entry titled "Test Entry 1"
@@ -50,16 +48,15 @@ Feature: Reading entries
     When I open the entries page for category "Reading Category"
     Then I see 5 entries in the entry list
 
-  @skip
   Scenario: Load More appends the next page without scroll reset
-    Given the feed has 30 entries
+    Given the feed has 60 entries
     When I open the inbox
     And I click "Load more"
-    Then I see more than 20 entries in the entry list
+    Then I see more than 50 entries in the entry list
 
-  @skip
   Scenario: Keyboard j and k move selection between entries
     When I open the inbox
+    And I press the "j" key
     And I press the "j" key
     Then the second entry is selected
     When I press the "k" key
@@ -70,7 +67,6 @@ Feature: Reading entries
     And I press the "?" key
     Then the keyboard shortcut help overlay is visible
 
-  @skip
   Scenario: Reader can toggle between full content and original feed body
     When I open the inbox
     And I click the entry titled "Test Entry 1"

--- a/e2e/features/triage.feature
+++ b/e2e/features/triage.feature
@@ -5,28 +5,25 @@ Feature: Triage entries (star, mark-read, summarize)
     Given I am signed in
     And I have a feed "Triage Feed" with 3 test entries in category "Triage Category"
 
-  @skip
   Scenario: Starring an entry updates the row and the sidebar starred count
     When I open the inbox
     And I star the entry titled "Test Entry 1"
     Then the entry titled "Test Entry 1" is marked starred
     And the sidebar starred count is at least 1
 
-  @skip
   Scenario: Marking an entry read updates the row and the sidebar unread count
     When I open the inbox
     And I mark the entry titled "Test Entry 1" read
     Then the entry row for "Test Entry 1" shows as read
     And the sidebar unread count decreases by 1
 
-  @skip
   Scenario: Marking all entries read empties the unread list
     When I open the inbox
-    And I click "Mark all read"
+    And I mark all entries as read
     Then I see 0 entries in the entry list
 
-  @skip
   Scenario: Summarizing an entry shows the summary in the reading pane
+    Given the user has Kagi configured
     When I open the inbox
     And I click the entry titled "Test Entry 1"
     And I click the "Summarize" button

--- a/e2e/steps/entries.steps.js
+++ b/e2e/steps/entries.steps.js
@@ -155,8 +155,9 @@ Then("I see {int} entry in the entry list", async ({ page }, count) => {
 });
 
 Then("I see more than {int} entries in the entry list", async ({ page }, count) => {
-  const n = await page.getByTestId("entry-item").count();
-  expect(n).toBeGreaterThan(count);
+  // Use polling so async swaps (e.g. Load More fetch) have a chance to land
+  // before we assert. Plain `count()` snapshots the DOM at one instant.
+  await expect.poll(() => page.getByTestId("entry-item").count()).toBeGreaterThan(count);
 });
 
 Then("the first entry is titled {string}", async ({ page }, title) => {

--- a/e2e/steps/triage.steps.js
+++ b/e2e/steps/triage.steps.js
@@ -1,7 +1,25 @@
 import { createBdd } from "playwright-bdd";
 import { test, expect } from "../support/fixtures.js";
 
-const { When, Then } = createBdd(test);
+const { Given, When, Then } = createBdd(test);
+
+Given("the user has Kagi configured", async ({ seed, currentUser }) => {
+  // Seeds a fake Kagi session token so the reading-pane Summarize button
+  // is rendered. Actual Kagi requests will fail when fired, which is
+  // acceptable for tests that only assert the in-flight summary placeholder.
+  const userId = seed.getUserId(currentUser.username);
+  seed.configureKagi(userId);
+});
+
+When("I mark all entries as read", async ({ page }) => {
+  // app.js #mark-read-age <select> fires a window.confirm before calling
+  // /reader/api/0/mark-all-as-read. Pre-register the dialog handler so the
+  // prompt auto-accepts, then trigger the dropdown by selecting "all".
+  // On success app.js reloads the page; Playwright's auto-waiting picks up
+  // the post-reload DOM in the subsequent assertion.
+  page.once("dialog", (dialog) => dialog.accept());
+  await page.getByTestId("mark-read-select").selectOption("all");
+});
 
 When("I star the entry titled {string}", async ({ page }, title) => {
   await page

--- a/e2e/support/seed.js
+++ b/e2e/support/seed.js
@@ -117,6 +117,31 @@ export class SeedHelper {
     }
   }
 
+  configureKagi(userId, sessionToken = "e2e-test-token") {
+    // Seeds a fake Kagi config so the reading-pane Summarize button is rendered.
+    // The token is bogus — actual Kagi calls will fail at request time, which
+    // is fine for tests that only assert UI state up through the in-flight
+    // placeholder.
+    const db = new Database(this.dbPath);
+    try {
+      const payload = JSON.stringify({ kagi: { session_token: sessionToken } });
+      const existing = db
+        .prepare(`SELECT id FROM user_settings WHERE user_id = ?`)
+        .get(userId);
+      if (existing) {
+        db.prepare(
+          `UPDATE user_settings SET save_services = ? WHERE user_id = ?`
+        ).run(payload, userId);
+      } else {
+        db.prepare(
+          `INSERT INTO user_settings (user_id, save_services) VALUES (?, ?)`
+        ).run(userId, payload);
+      }
+    } finally {
+      db.close();
+    }
+  }
+
   seedTestEntries(feedId, count) {
     const entries = [];
     for (let i = 1; i <= count; i++) {

--- a/templates/_reading_pane.html
+++ b/templates/_reading_pane.html
@@ -3,13 +3,13 @@
    CSS rules target. `id="reading-pane"` is the swap target. #}
 <div id="reading-pane" class="reading-pane">
     <div class="reading-pane-content">
-        <h1 class="reading-pane-title">
+        <h1 class="reading-pane-title" data-testid="reading-pane-title">
             {% if let Some(link) = pane.link.as_ref() %}<a href="{{ link }}" target="_blank" rel="noopener noreferrer">{{ pane.title }}</a>{% else %}{{ pane.title }}{% endif %}
         </h1>
         <div class="reading-pane-meta">
-            <span>{{ pane.feed_title }}</span>
+            <span data-testid="reading-pane-feed-title">{{ pane.feed_title }}</span>
             {% if let Some(author) = pane.author.as_ref() %}<span>{{ author }}</span>{% endif %}
-            {% if let Some(ts) = pane.published_at_iso.as_ref() %}<time datetime="{{ ts }}">{{ pane.published_relative }}</time>{% endif %}
+            {% if let Some(ts) = pane.published_at_iso.as_ref() %}<time datetime="{{ ts }}" data-testid="reading-pane-published-at">{{ pane.published_relative }}</time>{% endif %}
         </div>
         <div class="reading-pane-actions">
             <form id="reading-pane-star-form-{{ pane.id }}" method="post" action="/entries/{{ pane.id }}/{% if pane.is_starred %}unstar{% else %}star{% endif %}" data-swap="#entry-row-{{ pane.id }}">
@@ -66,6 +66,6 @@
             </div>
             {% endif %}
         </div>
-        <article class="reading-pane-article">{{ pane.content_html|safe }}</article>
+        <article class="reading-pane-article" data-testid="reading-pane-body" data-mode="{% if pane.is_full_content %}full{% else %}original{% endif %}">{{ pane.content_html|safe }}</article>
     </div>
 </div>


### PR DESCRIPTION
## Summary

PR-10/11/12 + post-SSR polish #201-#204 have already shipped, but the BDD scenarios placed as forward-looking `@skip`s in #210 were never re-enabled. This PR closes that gap so the BDD suite covers the SSR'd reading-pane / triage paths that today have no automated regression guard beyond the Rust integration tests.

- **`templates/_reading_pane.html`:** add stable `data-testid` on title, feed-title, published-at, body, plus `data-mode="full|original"` driven by `pane.is_full_content`. These were on the BDD migration's documented carry-forward list.
- **`e2e/features/reading.feature`:** unskip 5 scenarios (reading-pane open, feed-meta, Load More, j/k keyboard, full-content toggle). Seed sizing + j-press count adjusted to match the actual product (page size 50, cold-start j selects row 0).
- **`e2e/features/triage.feature`:** unskip 4 scenarios (star, mark-read, mark-all, summarize). Mark-all uses the actual dropdown UX; Summarize seeds a fake Kagi config so the button renders (real Kagi calls are not asserted).
- **`e2e/steps/entries.steps.js`:** poll on the "more than N entries" assertion so async Load-More swaps have a chance to land.
- **`e2e/steps/triage.steps.js` + `e2e/support/seed.js`:** new `Given the user has Kagi configured` step + `When I mark all entries as read` step; SeedHelper gets `configureKagi(userId)`.

Remaining `@skip` (2 scenarios, both genuinely absent product features — not addressed here):
- `admin.feature` admin create-user form: registration is `/register` only.
- `preferences.feature` display_name: not in the schema.

## Test plan

- [x] `cargo nextest run` — 728/728 (no regression from the testid additions).
- [x] `npx playwright test --grep-invert "@skip"` — 39/39 (up from 30).
- [ ] CI green on push.