### PR TITLE
chore(e2e): drop two BDD scenarios for features that won't be built

### DIFF
--- a/e2e/features/admin.feature
+++ b/e2e/features/admin.feature
@@ -8,13 +8,6 @@ Feature: Admin and statistics
     When I open the admin page
     Then I see my username in the users table
 
-  # No admin "create user" form exists in the product — user creation is via /register only.
-  @skip
-  Scenario: Admin creates a new user account
-    When I open the admin page
-    And I create a user with a random username and password "password123"
-    Then the new user appears in the users table
-
   Scenario: Admin disables a user account
     Given there is another registered user
     When I open the admin page

--- a/e2e/features/preferences.feature
+++ b/e2e/features/preferences.feature
@@ -22,8 +22,3 @@ Feature: Preferences
   Scenario: Changing my password lets me sign in with the new password
     When I change my password to "newpassword123"
     Then I can sign in with "newpassword123"
-
-  @skip
-  Scenario: Changing my display name updates the navbar greeting
-    When I change my display name to "Alex"
-    Then the navbar greeting shows "Alex"

--- a/e2e/steps/preferences.steps.js
+++ b/e2e/steps/preferences.steps.js
@@ -40,13 +40,3 @@ Then("I can sign in with {string}", async ({ page, currentUser, serverUrl }, pas
   await page.getByTestId("login-submit").click();
   await page.waitForURL(`${serverUrl}/`);
 });
-
-When("I change my display name to {string}", async ({ page, serverUrl }, displayName) => {
-  await page.getByTestId("display-name-input").fill(displayName);
-  await page.locator('form[action="/user-settings/profile"] button[type=submit]').click();
-  await page.waitForURL(`${serverUrl}/user-settings`);
-});
-
-Then("the navbar greeting shows {string}", async ({ page }, displayName) => {
-  await expect(page.getByTestId("navbar-greeting")).toContainText(displayName);
-});

--- a/static/js/components/rdrs-sidebar.js
+++ b/static/js/components/rdrs-sidebar.js
@@ -225,7 +225,7 @@ class RdrsSidebar extends HTMLElement {
         </div>
     </nav>
     <div class="sidebar-footer">
-        <span class="sidebar-user" data-testid="navbar-greeting">${escapeHtml(username)}</span>
+        <span class="sidebar-user">${escapeHtml(username)}</span>
         <a href="#" data-testid="logout-btn" data-rdrs-logout>Sign Out</a>
     </div>
 </aside>`;


### PR DESCRIPTION
## Summary

Two `@skip` scenarios were placeholders for product features that will not be implemented. The user confirmed they're off the roadmap, so the scenarios + their orphan step impls + an orphan testid are removed.

- `admin.feature`: `Admin creates a new user account` (creation stays `/register` only).
- `preferences.feature`: `Changing my display name updates the navbar greeting` (no `display_name` schema field, no plan to add one).
- `e2e/steps/preferences.steps.js`: drop `I change my display name to {string}` + `the navbar greeting shows {string}` (only used by the dropped scenario).
- `static/js/components/rdrs-sidebar.js`: drop `data-testid="navbar-greeting"` (only existed for the dropped scenario).

After this PR the BDD suite has **zero `@skip`** — every active scenario reflects real product behavior.

## Test plan

- [x] `cargo nextest run` — 728/728 (no Rust touched, sanity check only).
- [x] `npx playwright test --grep-invert "@skip"` — 39/39 (count unchanged; we removed only inactive scenarios).
- [ ] CI green on push.