### PR TITLE
refactor(ui): tighten sidebar and align spacing across pages

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -30,7 +30,9 @@
 
     /* Border radius */
     --radius-sm: 3px;
+    --radius-control: 4px;
     --radius-md: 6px;
+    --radius-card: 8px;
     --radius-lg: 10px;
 
     /* Shadows */
@@ -279,7 +281,6 @@ code {
     letter-spacing: 0.08em;
     color: var(--color-text-muted);
     padding: var(--space-2) var(--space-3);
-    margin-bottom: var(--space-1);
 }
 
 .sidebar-item {
@@ -341,12 +342,6 @@ code {
 
 .sidebar-badge:empty {
     display: none;
-}
-
-.sidebar-divider {
-    height: 1px;
-    background: var(--color-border-light);
-    margin: var(--space-2) var(--space-3);
 }
 
 .sidebar-footer {
@@ -1110,6 +1105,22 @@ dialog::backdrop {
     margin-bottom: var(--space-5);
 }
 
+/* Selects inside .filter-bar render at the same height as sibling
+   button-style chips (e.g. .feed-filter-link on /feeds) so the row
+   reads as one control strip rather than mismatched heights. */
+.filter-bar select {
+    padding: var(--space-1) var(--space-3);
+    font-size: var(--font-sm);
+}
+
+/* Top-level forms inside .page-content (e.g. Add Feed on /feeds,
+   Add Category on /categories) need a bottom gap separating them
+   from the next block (filter-bar / table). .filter-bar is itself
+   a form and brings its own margin-bottom, so it's excluded. */
+.page-content > form:not(.filter-bar) {
+    margin-bottom: var(--space-6);
+}
+
 /* ===== Tab Bar ===== */
 .tab-bar {
     display: flex;
@@ -1447,7 +1458,7 @@ mark {
     gap: var(--space-3);
     flex-wrap: wrap;
     align-items: center;
-    margin-bottom: var(--space-4);
+    margin-bottom: var(--space-5);
 }
 
 .feed-edit-url-row {
@@ -1504,7 +1515,7 @@ summary {
     background: var(--color-accent-subtle);
     border: 1px solid var(--color-border-light);
     border-radius: var(--radius-md);
-    margin-bottom: var(--space-4);
+    margin-bottom: var(--space-5);
     font-size: var(--font-sm);
 }
 
@@ -1873,7 +1884,7 @@ summary {
 .stats-period-btn {
     padding: var(--space-1) var(--space-3);
     border: 1px solid var(--color-border);
-    border-radius: 4px;
+    border-radius: var(--radius-control);
     background: transparent;
     color: var(--color-text-secondary);
     text-decoration: none;
@@ -1892,7 +1903,7 @@ summary {
 .stats-date-input {
     padding: var(--space-1) var(--space-2);
     border: 1px solid var(--color-border);
-    border-radius: 4px;
+    border-radius: var(--radius-control);
     background: var(--color-bg);
     color: var(--color-text);
     font-family: var(--font-ui);
@@ -1907,7 +1918,7 @@ summary {
 }
 .stats-card {
     background: var(--color-bg-secondary);
-    border-radius: 8px;
+    border-radius: var(--radius-card);
     padding: var(--space-4);
     text-align: center;
 }
@@ -1957,7 +1968,7 @@ summary {
 .stats-bar {
     width: 100%;
     background: var(--color-accent);
-    border-radius: 3px 3px 0 0;
+    border-radius: var(--radius-sm) var(--radius-sm) 0 0;
     min-height: 2px;
     transition: height 0.2s;
 }
@@ -1991,14 +2002,14 @@ summary {
 }
 .stats-progress {
     background: var(--color-bg);
-    border-radius: 4px;
+    border-radius: var(--radius-control);
     height: 8px;
     overflow: hidden;
 }
 .stats-progress-fill {
     background: var(--color-accent);
     height: 100%;
-    border-radius: 4px;
+    border-radius: var(--radius-control);
     min-width: 4px;
     transition: width 0.2s;
 }
@@ -2030,7 +2041,7 @@ summary {
 .feed-filter-link {
     padding: var(--space-1) var(--space-3);
     border: 1px solid var(--color-border);
-    border-radius: 4px;
+    border-radius: var(--radius-control);
     text-decoration: none;
     font-family: var(--font-ui);
     font-size: var(--font-sm);
@@ -2161,4 +2172,15 @@ summary {
 
 .entry-item-actions .entry-action-btn:hover {
     color: var(--color-accent);
+}
+
+/* Mobile: align load-more / mark-above wrappers with .entry-item, #entries-count
+   et al. (which drop from space-5 to space-4 horizontal padding at this width).
+   Placed here so it follows the base .load-more-form rule in source order. */
+@media (max-width: 1024px) {
+    .load-more-form,
+    .mark-above-form {
+        padding-left: var(--space-4);
+        padding-right: var(--space-4);
+    }
 }

--- a/static/js/components/rdrs-sidebar.js
+++ b/static/js/components/rdrs-sidebar.js
@@ -192,7 +192,6 @@ class RdrsSidebar extends HTMLElement {
             </a>
         </div>
         ${categoriesHtml}
-        <div class="sidebar-divider"></div>
         <div class="sidebar-section">
             <a href="/feeds" class="sidebar-item${isActive('feeds')}" data-testid="nav-feeds">
                 <span class="sidebar-item-icon">&#x1F4E1;&#xFE0F;</span>
@@ -203,7 +202,6 @@ class RdrsSidebar extends HTMLElement {
                 <span>Categories</span>
             </a>
         </div>
-        <div class="sidebar-divider"></div>
         <div class="sidebar-section">
             <a href="/search" class="sidebar-item${isActive('search')}" data-testid="nav-search">
                 <span class="sidebar-item-icon">&#x1F50D;&#xFE0F;</span>

--- a/templates/categories.html
+++ b/templates/categories.html
@@ -16,8 +16,6 @@
                     <button type="submit" data-testid="add-category-btn">Add Category</button>
                 </form>
 
-                <hr>
-
                 <table class="mobile-cards">
                     <thead>
                         <tr>

--- a/templates/feeds.html
+++ b/templates/feeds.html
@@ -13,8 +13,6 @@
                     <a href="/feeds/import" class="btn btn-secondary">Import OPML</a>
                 </div>
 
-                <hr>
-
                 <form method="post" action="/feeds">
                     <div class="form-group">
                         <label for="url">Feed URL</label>
@@ -34,8 +32,6 @@
                     </div>
                     <button type="submit" data-testid="add-feed-btn">Add Feed</button>
                 </form>
-
-                <hr>
 
                 <form method="get" action="/feeds" class="filter-bar">
                     <div class="form-group form-group-inline">


### PR DESCRIPTION
## Summary
- **Sidebar** — remove between-section dividers; drop redundant section/title margins so the nav reads as one rhythm of section gaps
- **Page spacing** — replace decorative `<hr>` on `/feeds` and `/categories` with a bottom margin on top-level forms; unify section-block `margin-bottom` (`.feeds-toolbar`, `#sync-status-bar`) on the `--space-5` baseline already used by `.form-group` / `.sidebar-section` / `.filter-bar`
- **Filter bar** — compact `.filter-bar select` to match `.feed-filter-link` chip height so the row reads as one control strip
- **Mobile alignment fix** — load-more / mark-above wrappers sat 4px right of entry rows at ≤1024px because the base rule appeared *after* the media-query override in source order. Moved the override to the bottom of the file
- **Radius tokens** — add `--radius-control: 4px` and `--radius-card: 8px`; swap out hardcoded radii in stats / feed-filter / progress (no visual change)

## Test plan
- [ ] `/entries`, `/entries/starred`, `/entries/{tab}`: sidebar tighter; no divider lines; mobile width — load-more / mark-above align with entry rows
- [ ] `/feeds`: no `<hr>` between Add Feed and filter row; filter-bar selects match `.feed-filter-link` chip height
- [ ] `/categories`: no `<hr>` between Add Category and the table; clear gap between form and table
- [ ] `/statistics`: cards / progress bars / period buttons look unchanged (radius refactor only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)