### PR TITLE
test(e2e): cover remaining keyboard shortcuts in BDD

### DIFF
--- a/e2e/features/keyboard_shortcuts.feature
+++ b/e2e/features/keyboard_shortcuts.feature
@@ -28,3 +28,42 @@ Feature: Keyboard shortcut overhaul (toggle read, mark all, rebinds)
     And I confirm the next dialog
     And I press the "o" key
     Then I see 0 entries in the entry list
+
+  Scenario: Enter opens the selected entry into the reading pane
+    When I open the inbox
+    And I press the "j" key
+    And I press the "Enter" key
+    Then the reading pane shows the title "Test Entry 1"
+
+  Scenario: Esc clears the reading pane back to empty
+    When I open the inbox
+    And I click the entry titled "Test Entry 1"
+    And I press the "Escape" key
+    Then the reading pane is empty
+
+  Scenario: f jumps to the selected entry's feed page
+    When I open the inbox
+    And I press the "j" key
+    And I press the "f" key
+    Then I am on the entries page for feed "Shortcut Feed"
+
+  Scenario: c jumps to the selected entry's category page
+    When I open the inbox
+    And I press the "j" key
+    And I press the "c" key
+    Then I am on the entries page for category "Shortcut Category"
+
+  Scenario: x returns to the unread inbox from a category page
+    When I open the entries page for category "Shortcut Category"
+    And I press the "x" key
+    Then I am on the unread inbox
+
+  Scenario: 3 jumps to the Read filter on a feed page
+    When I open the entries page for feed "Shortcut Feed"
+    And I press the "3" key
+    Then I am on the Read filter for feed "Shortcut Feed"
+
+  Scenario: b opens the active entry's original URL in a new tab
+    When I open the inbox
+    And I press the "j" key
+    Then pressing the "b" key opens a new tab at "/entry/1"

--- a/e2e/steps/entries.steps.js
+++ b/e2e/steps/entries.steps.js
@@ -234,6 +234,59 @@ When("the sidebar shows no unread for category {string}", async ({ page }, name)
   await expect(link.locator('.sidebar-badge')).toHaveCount(0);
 });
 
+Then("the reading pane is empty", async ({ page }) => {
+  await expect(page.locator("#reading-pane.reading-pane-empty")).toBeAttached();
+});
+
+Then("I am on the unread inbox", async ({ page, serverUrl }) => {
+  await page.waitForURL(`${serverUrl}/`);
+});
+
+Then("I am on the entries page for feed {string}", async ({ page, seed, currentUser, serverUrl }, feedTitle) => {
+  const userId = seed.getUserId(currentUser.username);
+  const db = new Database(seed.dbPath);
+  let feedId;
+  try {
+    const row = db
+      .prepare(`SELECT f.id FROM feed f JOIN category c ON f.category_id = c.id WHERE c.user_id = ? AND f.title = ?`)
+      .get(userId, feedTitle);
+    if (!row) throw new Error(`Feed '${feedTitle}' not found`);
+    feedId = row.id;
+  } finally {
+    db.close();
+  }
+  await page.waitForURL(`${serverUrl}/feeds/${feedId}/entries`);
+});
+
+Then("I am on the Read filter for feed {string}", async ({ page, seed, currentUser, serverUrl }, feedTitle) => {
+  const userId = seed.getUserId(currentUser.username);
+  const db = new Database(seed.dbPath);
+  let feedId;
+  try {
+    const row = db
+      .prepare(`SELECT f.id FROM feed f JOIN category c ON f.category_id = c.id WHERE c.user_id = ? AND f.title = ?`)
+      .get(userId, feedTitle);
+    if (!row) throw new Error(`Feed '${feedTitle}' not found`);
+    feedId = row.id;
+  } finally {
+    db.close();
+  }
+  await page.waitForURL(`${serverUrl}/feeds/${feedId}/entries?status=read`);
+});
+
+Then("pressing the {string} key opens a new tab at {string}", async ({ page }, key, urlSubstring) => {
+  // Popup capture must be armed BEFORE the keystroke that triggers it —
+  // waitForEvent is a one-shot listener that misses already-fired events.
+  await page.click("body");
+  const popupPromise = page.context().waitForEvent("page", { timeout: 5000 });
+  await page.keyboard.press(key);
+  const popup = await popupPromise;
+  // popup.url() reflects the navigation target as soon as the popup event
+  // fires; no need to wait for the (external) URL to actually load.
+  expect(popup.url()).toContain(urlSubstring);
+  await popup.close().catch(() => {});
+});
+
 Then("I am on the entries page for category {string}", async ({ page, seed, currentUser, serverUrl }, name) => {
   const userId = seed.getUserId(currentUser.username);
   const db = new Database(seed.dbPath);


### PR DESCRIPTION
## Summary

Adds 7 BDD scenarios for shortcuts that landed in #214 but weren't yet covered by playwright-bdd, so future regressions get caught by CI.

| Scenario | Shortcut |
|---|---|
| Enter opens the selected entry into the reading pane | `Enter` |
| Esc clears the reading pane back to empty | `Esc` |
| f jumps to the selected entry's feed page | `f` |
| c jumps to the selected entry's category page | `c` |
| x returns to the unread inbox from a category page | `x` |
| 3 jumps to the Read filter on a feed page | `1`/`2`/`3`/`4` |
| b opens the active entry's original URL in a new tab | `b` |

Adds matching step definitions:
- `Then the reading pane is empty`
- `Then I am on the unread inbox`
- `Then I am on the entries page for feed "X"`
- `Then I am on the Read filter for feed "X"`
- `Then pressing the "X" key opens a new tab at "Y"` — uses `page.context().waitForEvent("page")` to capture the popup; asserts `popup.url()` without waiting for the (external) URL to actually load

## Test plan

- [ ] CI: e2e shards green (47 → 55 passing scenarios)
- [ ] Local: `cd e2e && npx playwright test --grep "Keyboard shortcut overhaul"` passes 11/11

🤖 Generated with [Claude Code](https://claude.com/claude-code)