### PR TITLE
test(e2e): expand organizing.feature BDD coverage to 6 scenarios

### DIFF
--- a/e2e/features/organizing.feature
+++ b/e2e/features/organizing.feature
@@ -10,3 +10,37 @@ Feature: Organizing feeds and categories
     When I add a feed from the mock RSS server under "My Category"
     Then I see a success flash "Feed added"
     And the feeds table contains "Test Feed"
+
+  Scenario: Creating a category via the form adds it to the categories table
+    Given I am on the categories page
+    When I create a category named "Tech News"
+    Then I see a success flash "Category created."
+    And the categories table contains "Tech News"
+
+  Scenario: Renaming a category inline persists the new name
+    Given I am on the categories page
+    When I rename category "My Category" to "Renamed Category"
+    Then I see a success flash "Category renamed."
+    And the categories table contains "Renamed Category"
+
+  Scenario: Deleting a category removes it from the categories table
+    Given I am on the categories page
+    When I confirm the next dialog
+    And I delete category "My Category"
+    Then I see a success flash "Category deleted."
+    And the categories table does not contain "My Category"
+
+  Scenario: Filtering feeds by category narrows the visible rows
+    Given I have a category named "Other Category"
+    And I have a feed "Cat A Feed" in category "My Category"
+    And I have a feed "Cat B Feed" in category "Other Category"
+    And I am on the feeds page
+    When I filter feeds by category "Other Category"
+    Then the feeds table contains "Cat B Feed"
+    And the feeds table does not contain "Cat A Feed"
+
+  Scenario: Refreshing a feed shows a success flash
+    Given I have a feed from the mock RSS server in category "My Category"
+    And I am on the feeds page
+    When I refresh the feed "Test Feed"
+    Then I see a success flash "Refreshed:"

--- a/e2e/steps/organize.steps.js
+++ b/e2e/steps/organize.steps.js
@@ -8,9 +8,36 @@ Given("I have a category named {string}", async ({ seed, currentUser }, name) =>
   seed.createCategory(userId, name);
 });
 
+Given(
+  "I have a feed {string} in category {string}",
+  async ({ seed, currentUser }, feedTitle, categoryName) => {
+    const userId = seed.getUserId(currentUser.username);
+    const categoryId = seed.createCategory(userId, categoryName);
+    seed.createFeed(
+      categoryId,
+      `https://example.com/${currentUser.username}-${feedTitle}.xml`,
+      feedTitle
+    );
+  }
+);
+
+Given(
+  "I have a feed from the mock RSS server in category {string}",
+  async ({ seed, currentUser, feedServerUrl }, categoryName) => {
+    const userId = seed.getUserId(currentUser.username);
+    const categoryId = seed.createCategory(userId, categoryName);
+    seed.createFeed(categoryId, `${feedServerUrl}/feed.xml`, "Test Feed");
+  }
+);
+
 Given("I am on the feeds page", async ({ page, serverUrl }) => {
   await page.goto(`${serverUrl}/feeds`);
   await expect(page.getByTestId("feed-category-select")).not.toContainText("Loading");
+});
+
+Given("I am on the categories page", async ({ page, serverUrl }) => {
+  await page.goto(`${serverUrl}/categories`);
+  await expect(page.getByTestId("category-name-input")).toBeVisible();
 });
 
 When("I add a feed from the mock RSS server under {string}", async ({ page, feedServerUrl }, category) => {
@@ -19,10 +46,73 @@ When("I add a feed from the mock RSS server under {string}", async ({ page, feed
   await page.getByTestId("add-feed-btn").click();
 });
 
+When("I create a category named {string}", async ({ page }, name) => {
+  await page.getByTestId("category-name-input").fill(name);
+  await page.getByTestId("add-category-btn").click();
+});
+
+When("I rename category {string} to {string}", async ({ page }, oldName, newName) => {
+  // The <input> `value` attribute reflects the server-rendered initial state, not
+  // the live `.value` property — so scope to the row by the original name BEFORE
+  // filling, then click save within that same row.
+  const row = page
+    .getByTestId("categories-table")
+    .locator(`tr:has(input[value="${oldName}"])`);
+  await row.locator("input[type='text']").fill(newName);
+  await row.locator("button.cat-rename-save").click();
+});
+
+When("I delete category {string}", async ({ page }, name) => {
+  await page
+    .getByTestId("categories-table")
+    .locator(`tr:has(input[value="${name}"]) button.action-link-danger`)
+    .click();
+});
+
+When("I filter feeds by category {string}", async ({ page }, name) => {
+  // Option labels carry a count suffix like "Other Category (1)", so we can't
+  // pass an exact label. Look up the matching option's value via DOM, then
+  // selectOption(value). onchange auto-submits — waitForURL settles on the
+  // filtered URL before subsequent assertions.
+  const value = await page.locator("#filter-category").evaluate((sel, prefix) => {
+    const opt = Array.from(sel.options).find((o) => o.text.startsWith(prefix + " ("));
+    return opt ? opt.value : "";
+  }, name);
+  await page.locator("#filter-category").selectOption(value);
+  await page.waitForURL(/\?.*category=\d+/);
+});
+
+When("I refresh the feed {string}", async ({ page }, title) => {
+  await page
+    .getByTestId("feeds-table")
+    .locator("tr")
+    .filter({ hasText: title })
+    .locator("form[action$='/refresh'] button")
+    .click();
+});
+
 Then("I see a success flash {string}", async ({ page }, message) => {
   await expect(page.getByTestId("flash-message")).toContainText(message);
 });
 
 Then("the feeds table contains {string}", async ({ page }, text) => {
   await expect(page.getByTestId("feeds-table")).toContainText(text);
+});
+
+Then("the feeds table does not contain {string}", async ({ page }, text) => {
+  await expect(page.getByTestId("feeds-table")).not.toContainText(text);
+});
+
+Then("the categories table contains {string}", async ({ page }, text) => {
+  // Category names live in <input value="..."> within the rename form; their
+  // text doesn't appear as DOM text content. Match the attribute directly.
+  await expect(
+    page.getByTestId("categories-table").locator(`input[value="${text}"]`)
+  ).toBeVisible();
+});
+
+Then("the categories table does not contain {string}", async ({ page }, text) => {
+  await expect(
+    page.getByTestId("categories-table").locator(`input[value="${text}"]`)
+  ).toHaveCount(0);
 });


### PR DESCRIPTION
## Summary

- Adds 5 BDD scenarios to `organizing.feature` covering the rest of the `/categories` and `/feeds` organizing surface that the single existing scenario was missing:
  - Create a category via the form
  - Rename a category inline (sibling save button submits the rename form)
  - Delete a category through the confirm dialog
  - Filter feeds by category via the toolbar dropdown (auto-submit on change)
  - Refresh a single feed via the row's refresh button (asserts "Refreshed: …" flash)
- Adds the supporting step definitions, including a `Given I have a feed "X" in category "Y"` shape for direct seed setup and a mock-RSS-server variant for the refresh scenario.
- Coverage round-out before the v0.30.0 release.

## Test plan

- [x] `npx playwright test organizing` — 6/6 pass
- [x] `npx playwright test` — full suite 60/60 pass (5 net-new scenarios, no regressions)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)