### PR TITLE
fix(sidebar): live-refresh unread badges after swap actions

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -239,6 +239,18 @@ function installSidebarPolling() {
 }
 installSidebarPolling();
 
+// After every successful partial swap (mark-read, mark-unread, mark-all,
+// batch read, OPML import surface, etc.), ask <rdrs-sidebar> to refetch.
+// `rdrs:swap-complete` fires from performSwap() on both single- and
+// multi-target swaps. Refreshing on every swap over-fetches slightly —
+// star/save/fetch-full-content don't change sidebar state — but the
+// server-side per-user sidebar cache means each /api/sidebar call costs
+// roughly nothing on a hit, so a single broad hook beats a fragile
+// per-action allowlist.
+document.addEventListener('rdrs:swap-complete', () => {
+    document.querySelector('rdrs-sidebar')?.refresh();
+});
+
 // Single source of truth for the in-app shortcut help. Pages don't
 // register additional entries — every shortcut the keyboard handler
 // recognizes is listed here, grouped by where it applies.


### PR DESCRIPTION
## Summary

Sidebar unread badges now update **without a page reload** when entries are marked read/unread, batch-marked, mark-all-as-read'd, etc.

## Background

`<rdrs-sidebar>` only re-fetched `/api/sidebar` on mount, so in-page swap actions left the sidebar badges stale. The mount-time fetch was the only refresh hook — the `rdrs:swap-complete` listener added in #214 was scoped to re-applying the `.selected` class on the active row, not refreshing the sidebar.

Add a second `rdrs:swap-complete` listener that calls `document.querySelector('rdrs-sidebar')?.refresh()`. The listener fires for every successful swap — including ones that don't change sidebar state (star, save, fetch-full-content) — but the per-user sidebar cache landed in #218 means each refresh hits the cache (~0 SQL) on those no-op paths, so the broad hook is cheaper than maintaining a per-action allowlist that would inevitably drift.

## Why broad listener instead of per-action allowlist

- Simpler code, no maintenance burden as new mutation routes get added.
- The server-side per-user sidebar cache makes a `/api/sidebar` fetch on a no-op swap essentially free (cache hit → no DB query).
- A per-action allowlist is the kind of code that silently goes stale when a new mutation handler is added without updating the JS list.

## Test plan

- [x] Pre-existing BDD scenario **`Triage > Marking an entry read updates the row and the sidebar unread count`** failing on main → **passes with this fix**.
- [x] No regression in the 4 passing `category_nav` / `triage` scenarios that currently work.
- [x] 5 `category_nav.feature` scenarios were already failing on main (`]` / `[` / `Shift+]` keyboard nav) — these are pre-existing flakes unrelated to this PR.
- [x] Manual: mark an entry read on `/unread` and confirm the category badge decrements without reloading the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)