### PR TITLE
fix(sidebar): don't cache the empty chrome state

### DIFF
--- a/src/handlers/user.rs
+++ b/src/handlers/user.rs
@@ -213,7 +213,16 @@ pub async fn read_chrome_data(
         .await
         .unwrap_or_default();
 
-    state.sidebar_cache.insert(user_id, fresh.clone());
+    // Skip caching the "completely empty" state (no categories, no unread).
+    // Real new accounts pay a trivial extra query per page load until they
+    // add their first feed; cache populates normally after that. The
+    // benefit: the empty state is the most likely-to-go-stale entry —
+    // anything added via a path that bypasses our handler bust hooks (e.g.
+    // E2E tests that seed straight into SQLite) would otherwise be hidden
+    // behind a stale empty cache for up to the 60 s TTL.
+    if !fresh.categories.is_empty() || fresh.total_unread > 0 {
+        state.sidebar_cache.insert(user_id, fresh.clone());
+    }
 
     ChromeData {
         theme: fresh.theme,


### PR DESCRIPTION
## Summary

Fixes 5 deterministically-failing local BDD scenarios in \`category_nav.feature\` that were hidden on CI by Playwright's 2-retry configuration.

## Root cause

When the per-user sidebar cache landed in #218, the bust hooks covered every HTTP write handler. But the E2E test harness seeds categories / feeds / entries by writing **directly to SQLite via \`better-sqlite3\`** — bypassing the handlers entirely, and therefore bypassing the cache bust.

Concretely, every \`category_nav.feature\` scenario reproduces locally:

1. \`Given I am signed in\` → navigates to \`/\` → \`read_chrome_data\` warms the cache with an **empty** entry for the brand-new user.
2. \`And I have a feed ... in category ...\` → \`SeedHelper.createCategory\` + \`createFeed\` → raw SQLite writes; cache **stays empty**.
3. \`When I open the entries page for category "Cat B"\` → cache **hit** → SSR bootstrap and \`/api/sidebar\` both return zero categories.
4. \`And I press the "]" key\` → keyboard handler reads \`sb._data.categories\`, sees \`[]\`, **bails silently**.
5. \`Then I am on the entries page for category "Cat C"\` → \`waitForURL\` times out at 30 s.

CI passes because of \`retries: 2\` under \`process.env.CI\`; local (0 retries, higher workers) fails first try.

## Fix

Skip the \`SidebarCache::insert\` when the result has both \`categories.is_empty()\` AND \`total_unread == 0\`. Anything added by a path that bypasses our handler bust hooks now lands on a cache miss instead of a stale-empty hit.

Real-world cost: a brand-new account pays one extra DB query per page load until it adds its first feed. The moment any actionable state exists, normal caching resumes. The empty state renders nothing but a sidebar shell anyway — sub-millisecond on the read pool.

## Test plan

- [x] \`cargo nextest run\` — 734 tests pass.
- [x] Full \`npx playwright test\` suite — **60/60 scenarios pass locally** with \`--workers=1\` (baseline: 55/60 because of the 5 \`category_nav\` flakies + 0 from this PR — net +5).
- [x] Triage / sidebar live-update scenarios still pass (the #218 + #219 work isn't undone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)