### PR TITLE
refactor(reading-pane): drop redundant "View Original" button

### DIFF
--- a/templates/_reading_pane.html
+++ b/templates/_reading_pane.html
@@ -44,7 +44,6 @@
                 <button type="submit" class="btn-secondary btn-sm">Save</button>
             </form>
             {% endif %}
-            <a href="{{ link }}" target="_blank" rel="noopener noreferrer" class="btn btn-secondary btn-sm">View Original</a>
             {% endif %}
         </div>
         {# Always render the wrapper so `POST /entries/{id}/summarize` can


### PR DESCRIPTION
## Summary
- The reading-pane title already wraps `pane.title` in an `<a>` pointing at the same URL with identical `target="_blank" rel="noopener noreferrer"` attributes, so the separate `View Original` button was duplicate UI.
- The inner anchor inherits accent-color styling via the global `a { color: var(--color-accent); }` rule, so external navigability stays visually obvious without the standalone button.
- Trims one item from the `reading-pane-actions` row, leaving more breathing room for Star / Mark Unread / Fetch Full Content / Summarize / Save.

## Test plan
- [ ] Open an entry in the reading pane and confirm the title still opens the original article in a new tab.
- [ ] Confirm the `View Original` button no longer renders in `reading-pane-actions`.
- [ ] Sanity-check that the actions row layout still wraps correctly with the remaining buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)