### PR TITLE
fix(reading-pane): restore ?entry= deep link end-to-end

### DIFF
--- a/e2e/features/reading.feature
+++ b/e2e/features/reading.feature
@@ -72,3 +72,22 @@ Feature: Reading entries
     And I click the entry titled "Test Entry 1"
     And I click the "Fetch Full Content" button
     Then the reading pane shows the original feed body
+
+  Scenario: Clicking an entry syncs ?entry= into the URL and survives a reload
+    When I open the inbox
+    And I click the entry titled "Test Entry 1"
+    Then the URL has the ?entry= parameter for "Test Entry 1"
+    When I reload the page
+    Then the reading pane shows the title "Test Entry 1"
+
+  Scenario: Visiting /?entry={id} directly opens that entry's reading pane
+    When I open the inbox deep-linked to entry titled "Test Entry 2"
+    Then the reading pane shows the title "Test Entry 2"
+    And the reading pane shows the content "Content for test entry 2"
+
+  Scenario: Pressing Esc clears the reading pane and drops ?entry= from the URL
+    When I open the inbox
+    And I click the entry titled "Test Entry 1"
+    And I press the "Escape" key
+    Then the reading pane is empty
+    And the URL has no ?entry= parameter

--- a/e2e/steps/entries.steps.js
+++ b/e2e/steps/entries.steps.js
@@ -238,6 +238,36 @@ Then("the reading pane is empty", async ({ page }) => {
   await expect(page.locator("#reading-pane.reading-pane-empty")).toBeAttached();
 });
 
+When("I reload the page", async ({ page }) => {
+  await page.reload();
+});
+
+When(
+  "I open the inbox deep-linked to entry titled {string}",
+  async ({ page, serverUrl, seed, currentUser }, title) => {
+    const id = entryIdByTitle(seed, currentUser, title);
+    await page.goto(`${serverUrl}/?entry=${id}`);
+  }
+);
+
+Then(
+  "the URL has the ?entry= parameter for {string}",
+  async ({ page, seed, currentUser }, title) => {
+    const id = entryIdByTitle(seed, currentUser, title);
+    // performSwap rewrites the URL via replaceState after a #reading-pane swap;
+    // wait until the address-bar `entry` query matches the clicked entry's id.
+    await expect
+      .poll(() => new URL(page.url()).searchParams.get("entry"))
+      .toBe(String(id));
+  }
+);
+
+Then("the URL has no ?entry= parameter", async ({ page }) => {
+  await expect
+    .poll(() => new URL(page.url()).searchParams.has("entry"))
+    .toBe(false);
+});
+
 Then("I am on the unread inbox", async ({ page, serverUrl }) => {
   await page.waitForURL(`${serverUrl}/`);
 });

--- a/src/handlers/pages.rs
+++ b/src/handlers/pages.rs
@@ -225,6 +225,45 @@ pub struct EntriesQuery {
     /// path-based modes). Any other value (or absence) is treated as
     /// "no filter" (show all).
     pub status: Option<String>,
+    /// Deep-link target: when present, the list handler pre-populates the
+    /// reading pane with this entry. Honored by every list page (unread,
+    /// /entries, read/starred/summarized, /feeds/{id}/entries,
+    /// /categories/{id}/entries). Read-only: does not mark the entry read
+    /// (use POST /entries/{id}/read for that). Silently ignored when the
+    /// entry doesn't exist or belongs to another user.
+    pub entry: Option<i64>,
+}
+
+/// Best-effort builder for the `?entry={id}` deep-link reading pane.
+///
+/// Looks up the entry, verifies ownership (`find_by_id_for_user` enforces
+/// the join on `user_id`), reads the save / Kagi flags, and renders a
+/// `ReadingPaneView`. Any failure (entry missing, wrong owner, DB / sanitize
+/// hiccup) returns `None` so the list page still renders with an empty
+/// pane — mirroring the page's normal "no entry selected" state.
+///
+/// Read-only by design: deep links do NOT mark the entry as read. The
+/// canonical mark-as-read path remains the entry-row click, which fetches
+/// `GET /entries/{id}/fragment` and runs the write transaction inside
+/// `entry_fragment`.
+async fn maybe_build_reading_pane(
+    state: &AppState,
+    user_id: i64,
+    entry_id: Option<i64>,
+) -> Option<ReadingPaneView> {
+    let entry_id = entry_id?;
+    let ewf = state
+        .db
+        .read_user(move |conn| entry::find_by_id_for_user(conn, user_id, entry_id))
+        .await
+        .ok()?
+        .ok()??;
+    let (has_save, has_kagi) = crate::handlers::entries::load_pane_action_flags(state, user_id)
+        .await
+        .ok()?;
+    crate::handlers::entries::build_reading_pane_view(state, user_id, &ewf, has_save, has_kagi)
+        .await
+        .ok()
 }
 
 /// Fragment template for the Load-More response.
@@ -543,6 +582,7 @@ pub async fn unread_page(
         0,
     )
     .await;
+    let reading_pane = maybe_build_reading_pane(&state, user_id, query.entry).await;
 
     (
         flash,
@@ -551,7 +591,7 @@ pub async fn unread_page(
             git_version: crate::GIT_VERSION,
             layout,
             entries,
-            reading_pane: None,
+            reading_pane,
             next_cursor,
             entries_layout: EntriesLayoutContext {
                 active: "unread",
@@ -1040,6 +1080,7 @@ pub async fn entries_page(
         0,
     )
     .await;
+    let reading_pane = maybe_build_reading_pane(&state, user_id, query.entry).await;
 
     (
         flash,
@@ -1048,7 +1089,7 @@ pub async fn entries_page(
             git_version: crate::GIT_VERSION,
             layout,
             entries,
-            reading_pane: None,
+            reading_pane,
             next_cursor,
             entries_layout: EntriesLayoutContext {
                 active: "all",
@@ -1191,6 +1232,7 @@ pub async fn read_entries_page(
         0,
     )
     .await;
+    let reading_pane = maybe_build_reading_pane(&state, user_id, query.entry).await;
 
     (
         flash,
@@ -1199,7 +1241,7 @@ pub async fn read_entries_page(
             git_version: crate::GIT_VERSION,
             layout,
             entries,
-            reading_pane: None,
+            reading_pane,
             next_cursor,
             entries_layout: EntriesLayoutContext {
                 active: "read",
@@ -1271,6 +1313,7 @@ pub async fn starred_entries_page(
         0,
     )
     .await;
+    let reading_pane = maybe_build_reading_pane(&state, user_id, query.entry).await;
 
     (
         flash,
@@ -1279,7 +1322,7 @@ pub async fn starred_entries_page(
             git_version: crate::GIT_VERSION,
             layout,
             entries,
-            reading_pane: None,
+            reading_pane,
             next_cursor,
             entries_layout: EntriesLayoutContext {
                 active: "starred",
@@ -1351,6 +1394,7 @@ pub async fn summarized_entries_page(
         0,
     )
     .await;
+    let reading_pane = maybe_build_reading_pane(&state, user_id, query.entry).await;
 
     (
         flash,
@@ -1359,7 +1403,7 @@ pub async fn summarized_entries_page(
             git_version: crate::GIT_VERSION,
             layout,
             entries,
-            reading_pane: None,
+            reading_pane,
             next_cursor,
             entries_layout: EntriesLayoutContext {
                 active: "summarized",
@@ -1491,12 +1535,14 @@ pub async fn category_entries_page(
         },
     ];
 
+    let reading_pane = maybe_build_reading_pane(&state, user_id, query.entry).await;
+
     let template = CategoryEntriesTemplate {
         title: category_name,
         git_version: crate::GIT_VERSION,
         layout,
         entries,
-        reading_pane: None,
+        reading_pane,
         next_cursor,
         entries_layout: EntriesLayoutContext {
             active: "",
@@ -1942,12 +1988,14 @@ pub async fn feed_entries_page(
         },
     ];
 
+    let reading_pane = maybe_build_reading_pane(&state, user_id, query.entry).await;
+
     let template = FeedEntriesTemplate {
         title: feed_title,
         git_version: crate::GIT_VERSION,
         layout,
         entries,
-        reading_pane: None,
+        reading_pane,
         next_cursor,
         entries_layout: EntriesLayoutContext {
             active: "",

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -120,10 +120,12 @@ async function performSwap(url, init, defaultTarget) {
     const text = await response.text();
     const parsed = new DOMParser().parseFromString(text, 'text/html');
 
+    let swappedReadingPane = false;
     const templates = parsed.querySelectorAll('template[data-swap-target]');
     if (templates.length > 0) {
         for (const tpl of templates) {
             const sel = tpl.getAttribute('data-swap-target');
+            if (sel === '#reading-pane') swappedReadingPane = true;
             const dst = document.querySelector(sel);
             if (!dst) continue;
             const parent = dst.parentNode;
@@ -139,6 +141,7 @@ async function performSwap(url, init, defaultTarget) {
             }
             parent.removeChild(dst);
         }
+        if (swappedReadingPane) syncEntryParamFromSwapUrl(url);
         applyFlashTemplates(parsed);
         document.dispatchEvent(new CustomEvent('rdrs:swap-complete'));
         return;
@@ -149,8 +152,27 @@ async function performSwap(url, init, defaultTarget) {
     const incoming = parsed.body.firstElementChild;
     if (!incoming) return;
     dst.outerHTML = incoming.outerHTML;
+    if (defaultTarget === '#reading-pane') syncEntryParamFromSwapUrl(url);
     applyFlashTemplates(parsed);
     document.dispatchEvent(new CustomEvent('rdrs:swap-complete'));
+}
+
+// Mirror the entry id from a `#reading-pane` swap URL into the address-bar
+// `?entry={id}` query so a refresh / share / browser-back reproduces the
+// current pane state (the SSR list handlers consume `?entry=` via
+// `maybe_build_reading_pane`). `replaceState` (not `pushState`) — every
+// pane swap rewrites the same entry, never accumulates history entries.
+function syncEntryParamFromSwapUrl(swapUrl) {
+    const m = (swapUrl || '').match(/\/entries\/(\d+)(?:\/|$|\?)/);
+    if (!m) return;
+    setEntryParam(m[1]);
+}
+
+function setEntryParam(entryId) {
+    const u = new URL(window.location.href);
+    if (entryId == null) u.searchParams.delete('entry');
+    else u.searchParams.set('entry', String(entryId));
+    window.history.replaceState({}, '', u);
 }
 
 // Process `<template data-flash data-level="success|error|info|warning">message</template>`
@@ -596,6 +618,7 @@ function installEntriesKeyboard() {
                 e.preventDefault();
                 pane.classList.add('reading-pane-empty');
                 pane.innerHTML = '<p>Select an entry to read.</p>';
+                setEntryParam(null);
                 break;
             }
             case ' ': {

--- a/tests/pages_test.rs
+++ b/tests/pages_test.rs
@@ -171,6 +171,155 @@ async fn test_unread_page_while_masquerading() {
     assert_ne!(admin_id, user_id);
 }
 
+/// Seed a single category + feed + entry owned by `username`. Returns the
+/// entry id. Uses a unique category/feed name per call so tests that share
+/// the in-memory DB don't trip on each other.
+async fn seed_one_entry(db: &DbPool, username: &str, slug: &str) -> i64 {
+    let username = username.to_string();
+    let slug = slug.to_string();
+    db.user(move |conn| {
+        let user_id: i64 = conn
+            .query_row(
+                "SELECT id FROM user WHERE username = ?1",
+                rusqlite::params![username],
+                |row| row.get(0),
+            )
+            .unwrap();
+        conn.execute(
+            "INSERT INTO category (user_id, name) VALUES (?1, ?2)",
+            rusqlite::params![user_id, format!("cat-{}", slug)],
+        )
+        .unwrap();
+        let cat_id = conn.last_insert_rowid();
+        conn.execute(
+            "INSERT INTO feed (category_id, url, title) VALUES (?1, ?2, ?3)",
+            rusqlite::params![
+                cat_id,
+                format!("https://example.com/{}.xml", slug),
+                format!("Feed {}", slug)
+            ],
+        )
+        .unwrap();
+        let feed_id = conn.last_insert_rowid();
+        conn.execute(
+            "INSERT INTO entry (feed_id, guid, title, link, content) VALUES (?1, ?2, ?3, ?4, ?5)",
+            rusqlite::params![
+                feed_id,
+                format!("guid-{}", slug),
+                format!("Title for {}", slug),
+                format!("https://example.com/{}", slug),
+                format!("<p>Body for {}.</p>", slug)
+            ],
+        )
+        .unwrap();
+        conn.last_insert_rowid()
+    })
+    .await
+    .unwrap()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_unread_page_entry_query_populates_reading_pane() {
+    let app = create_test_app_named(default_test_config(), "test_unread_entry_query_ok");
+    setup_users(&app.db).await;
+    let entry_id = seed_one_entry(&app.db, "admin", "deep-link-ok").await;
+    login(&app.server, "admin").await;
+
+    let response = app.server.get(&format!("/?entry={}", entry_id)).await;
+    response.assert_status_ok();
+    let body = response.text();
+
+    // Reading pane is rendered with the deep-linked entry, not the empty state.
+    assert!(
+        !body.contains("reading-pane-empty"),
+        "deep link must NOT render the empty reading pane"
+    );
+    assert!(
+        body.contains(r#"data-testid="reading-pane-title""#),
+        "deep link must render the populated reading pane"
+    );
+    assert!(
+        body.contains("Title for deep-link-ok"),
+        "reading pane must contain the seeded entry title; body was: {body}"
+    );
+    assert!(
+        body.contains("Body for deep-link-ok"),
+        "reading pane must contain the seeded entry body; body was: {body}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_unread_page_entry_query_invalid_id_falls_back_to_empty_pane() {
+    let app = create_test_app_named(default_test_config(), "test_unread_entry_query_invalid");
+    setup_users(&app.db).await;
+    login(&app.server, "admin").await;
+
+    // No entries seeded, so id 99999 cannot resolve.
+    let response = app.server.get("/?entry=99999").await;
+    response.assert_status_ok();
+    let body = response.text();
+
+    // Invalid deep-link id must silently fall back to the empty pane —
+    // the list page itself must still render.
+    assert!(
+        body.contains("reading-pane-empty"),
+        "invalid entry id must fall back to the empty reading pane"
+    );
+    assert!(
+        !body.contains(r#"data-testid="reading-pane-title""#),
+        "invalid entry id must NOT render a populated pane"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_unread_page_entry_query_other_user_falls_back_to_empty_pane() {
+    let app = create_test_app_named(default_test_config(), "test_unread_entry_query_other_user");
+    setup_users(&app.db).await; // creates `admin` and `user`
+                                // Entry belongs to `user`; we log in as `admin`.
+    let entry_id = seed_one_entry(&app.db, "user", "cross-user").await;
+    login(&app.server, "admin").await;
+
+    let response = app.server.get(&format!("/?entry={}", entry_id)).await;
+    response.assert_status_ok();
+    let body = response.text();
+
+    // Cross-tenant deep link must NOT leak the foreign entry into the pane.
+    assert!(
+        body.contains("reading-pane-empty"),
+        "cross-user entry id must fall back to the empty reading pane (no info disclosure)"
+    );
+    assert!(
+        !body.contains("Title for cross-user"),
+        "cross-user entry title must NOT appear in the response body"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn test_starred_entries_page_entry_query_populates_reading_pane() {
+    // The helper is shared, but exercise one of the non-unread routes too
+    // so the wiring on a second handler is covered.
+    let app = create_test_app_named(default_test_config(), "test_starred_entry_query_ok");
+    setup_users(&app.db).await;
+    let entry_id = seed_one_entry(&app.db, "admin", "starred-deep-link").await;
+    login(&app.server, "admin").await;
+
+    let response = app
+        .server
+        .get(&format!("/entries/starred?entry={}", entry_id))
+        .await;
+    response.assert_status_ok();
+    let body = response.text();
+
+    assert!(
+        !body.contains("reading-pane-empty"),
+        "deep link on /entries/starred must NOT render the empty reading pane"
+    );
+    assert!(
+        body.contains("Title for starred-deep-link"),
+        "/entries/starred deep link must populate the reading pane; body was: {body}"
+    );
+}
+
 #[tokio::test]
 async fn test_admin_page_while_masquerading() {
     let app = create_test_app(default_test_config());


### PR DESCRIPTION
## Summary

Two-commit fix that makes the `?entry=` URL query parameter a real end-to-end deep link for the reading pane.

- **`1900a81`** — server side. After PR #199 deleted the CSR `<rdrs-entry-list>._checkEntryParam`, the `/entries/{id}` → `/?entry={id}` redirect kept emitting URLs that no list handler consumed, so search → click landed on the unread page with an empty pane. Adds `entry: Option<i64>` to `EntriesQuery` plus a shared `maybe_build_reading_pane` helper, wired into all 7 list handlers (unread, `/entries`, read, starred, summarized, `/feeds/{id}/entries`, `/categories/{id}/entries`). Read-only — does not mark-as-read; failures (missing entry, cross-tenant) silently fall back to the empty pane.
- **`fe9afce`** — client side. Clicking an entry from a list page does a `data-swap` into `#reading-pane` that updated DOM but not the address bar. `performSwap()` now mirrors the swap URL's entry id into `?entry={id}` via `history.replaceState` (single- and multi-target responses); the Esc clear path drops it. Uses `replaceState` not `pushState` so back still returns to the previous list/search page.

Now: list-page click writes the URL, refresh keeps the same entry, the URL is shareable, and typing `/?entry={id}` directly opens that entry.

## Test plan

- [x] `cargo nextest run` — 738 / 738 pass (includes 4 new integration tests on the deep-link helper: happy path, invalid id, cross-user fallback, starred page).
- [x] `npx playwright test` — 63 / 63 pass, including 3 new BDD scenarios:
  - click → URL gets `?entry=`, reload preserves the pane
  - typing `/?entry={id}` directly opens that entry
  - Esc clears both pane and `?entry=`
- [x] `cargo fmt --check` — clean.
- [x] Manual: load `/search?q=...`, click a result, verify URL bar shows `/?entry={id}` and the reading pane is populated.
- [x] Manual: open `/`, click an entry, refresh, verify the same entry is still in the pane.
- [x] Manual: press Esc, verify `?entry=` disappears from the URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)