### PR TITLE
refactor(flash): replace floating toast with accessible banner-stack

### DIFF
--- a/src/middleware/flash.rs
+++ b/src/middleware/flash.rs
@@ -61,10 +61,29 @@ impl FlashMessage {
 
     pub fn level_class(&self) -> &'static str {
         match self.level {
-            FlashLevel::Success => "flash-success",
-            FlashLevel::Error => "flash-error",
-            FlashLevel::Info => "flash-info",
-            FlashLevel::Warning => "flash-warning",
+            FlashLevel::Success => "banner--success",
+            FlashLevel::Error => "banner--error",
+            FlashLevel::Info => "banner--info",
+            FlashLevel::Warning => "banner--warning",
+        }
+    }
+
+    /// ARIA role for live-region announcement.
+    /// `status` (polite) for non-blocking info; `alert` (assertive) for problems.
+    pub fn aria_role(&self) -> &'static str {
+        match self.level {
+            FlashLevel::Success | FlashLevel::Info => "status",
+            FlashLevel::Warning | FlashLevel::Error => "alert",
+        }
+    }
+
+    /// Human-readable level name announced by screen readers (visually hidden).
+    pub fn level_name(&self) -> &'static str {
+        match self.level {
+            FlashLevel::Success => "Success",
+            FlashLevel::Error => "Error",
+            FlashLevel::Info => "Info",
+            FlashLevel::Warning => "Warning",
         }
     }
 
@@ -238,10 +257,26 @@ mod tests {
 
     #[test]
     fn test_flash_level_class() {
-        assert_eq!(FlashMessage::success("").level_class(), "flash-success");
-        assert_eq!(FlashMessage::error("").level_class(), "flash-error");
-        assert_eq!(FlashMessage::info("").level_class(), "flash-info");
-        assert_eq!(FlashMessage::warning("").level_class(), "flash-warning");
+        assert_eq!(FlashMessage::success("").level_class(), "banner--success");
+        assert_eq!(FlashMessage::error("").level_class(), "banner--error");
+        assert_eq!(FlashMessage::info("").level_class(), "banner--info");
+        assert_eq!(FlashMessage::warning("").level_class(), "banner--warning");
+    }
+
+    #[test]
+    fn test_flash_aria_role() {
+        assert_eq!(FlashMessage::success("").aria_role(), "status");
+        assert_eq!(FlashMessage::info("").aria_role(), "status");
+        assert_eq!(FlashMessage::warning("").aria_role(), "alert");
+        assert_eq!(FlashMessage::error("").aria_role(), "alert");
+    }
+
+    #[test]
+    fn test_flash_level_name() {
+        assert_eq!(FlashMessage::success("").level_name(), "Success");
+        assert_eq!(FlashMessage::error("").level_name(), "Error");
+        assert_eq!(FlashMessage::info("").level_name(), "Info");
+        assert_eq!(FlashMessage::warning("").level_name(), "Warning");
     }
 
     #[test]

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -859,104 +859,112 @@ td input[type="text"] {
     font-size: var(--font-sm);
 }
 
-/* ===== Flash Messages ===== */
-.flash-container {
-    position: fixed;
-    top: var(--space-3);
-    right: var(--space-3);
-    z-index: 200;
-    max-width: 480px;
+/* ===== Banner Stack (accessible flash messages) =====
+   Inline, persistent notifications anchored to the top of `<main>`.
+   Replaces the prior floating-toast pattern to satisfy Primer / WCAG
+   1.3.2 (sequence), 2.1.1 (keyboard), 2.2.1 (timing), 4.1.3 (status).
+   Compact style: faint tinted bg, 8px coloured dot, no visible timestamp.
+   Per-message role=status (success/info) or role=alert (warning/error)
+   is set in JS; the dismiss control is a real <button>. */
+.banner-stack {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
     width: 100%;
 }
+.banner-stack:empty {
+    display: none;
+}
+.banner-stack:focus { outline: none; }
 
-.flash {
-    margin-bottom: var(--space-2);
-    padding: var(--space-3) var(--space-4);
-    border-radius: var(--radius-md);
-    display: flex;
-    align-items: center;
-    gap: var(--space-3);
-    font-size: var(--font-sm);
-    background: var(--color-bg-secondary);
+.banner {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: start;
+    column-gap: var(--space-2);
+    padding: var(--space-2) var(--space-3);
+    border-radius: var(--radius-sm);
+    background: transparent;
     border: 1px solid var(--color-border-light);
+    border-left-width: 3px;
+    font-size: var(--font-sm);
+    line-height: 1.45;
 }
 
-.flash-success {
-    background: #e8f5e9;
-    border-color: #2d7a3a;
+/* 8px coloured dot, vertically aligned with the first line of text. */
+.banner-icon {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    margin-top: 0.45em;
+    flex: none;
+    background: var(--color-text-muted);
 }
 
-.flash-error {
-    background: #fde8e8;
-    border-color: #b91c1c;
+.banner-body {
+    min-width: 0;
+    color: var(--color-text);
+    word-wrap: break-word;
+    overflow-wrap: anywhere;
+}
+.banner-message { color: var(--color-text); }
+
+.banner-dismiss {
+    background: none;
+    border: 1px solid transparent;
+    color: var(--color-text-muted);
+    cursor: pointer;
+    width: 22px;
+    height: 22px;
+    border-radius: var(--radius-sm);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: var(--font-base);
+    line-height: 1;
+    padding: 0;
+    margin-top: 1px;
+}
+.banner-dismiss:hover {
+    background: var(--color-bg-tertiary);
+    color: var(--color-text);
+}
+.banner-dismiss:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 2px;
 }
 
-.flash-warning {
-    background: #fef3e2;
-    border-color: #92610e;
-}
+.banner--success { background: rgba(45, 122, 58, 0.06); border-color: rgba(45, 122, 58, 0.20); border-left-color: var(--color-success); }
+.banner--success .banner-icon { background: var(--color-success); }
+.banner--error   { background: rgba(185, 28, 28, 0.06); border-color: rgba(185, 28, 28, 0.20); border-left-color: var(--color-error); }
+.banner--error   .banner-icon { background: var(--color-error); }
+.banner--warning { background: rgba(146, 97, 14, 0.06); border-color: rgba(146, 97, 14, 0.20); border-left-color: var(--color-warning); }
+.banner--warning .banner-icon { background: var(--color-warning); }
+.banner--info    { background: rgba(184, 134, 11, 0.05); border-color: rgba(184, 134, 11, 0.20); border-left-color: var(--color-accent); }
+.banner--info    .banner-icon { background: var(--color-accent); }
 
-[data-theme="dark"] .flash-success {
-    background: #1a2b1a;
-    border-color: #4ADE80;
-}
-[data-theme="dark"] .flash-error {
-    background: #2b1a1a;
-    border-color: #F87171;
-}
-[data-theme="dark"] .flash-warning {
-    background: #2b2516;
-    border-color: #FBBF24;
-}
+[data-theme="dark"] .banner--success { background: rgba(74, 222, 128, 0.08); border-color: rgba(74, 222, 128, 0.25); border-left-color: #4ADE80; }
+[data-theme="dark"] .banner--error   { background: rgba(248, 113, 113, 0.08); border-color: rgba(248, 113, 113, 0.25); border-left-color: #F87171; }
+[data-theme="dark"] .banner--warning { background: rgba(251, 191, 36, 0.08); border-color: rgba(251, 191, 36, 0.25); border-left-color: #FBBF24; }
+[data-theme="dark"] .banner--info    { background: rgba(184, 134, 11, 0.10); border-color: rgba(184, 134, 11, 0.30); }
 
 @media (prefers-color-scheme: dark) {
-    :root:not([data-theme]) .flash-success {
-        background: #1a2b1a;
-        border-color: #4ADE80;
-    }
-    :root:not([data-theme]) .flash-error {
-        background: #2b1a1a;
-        border-color: #F87171;
-    }
-    :root:not([data-theme]) .flash-warning {
-        background: #2b2516;
-        border-color: #FBBF24;
-    }
+    :root:not([data-theme]) .banner--success { background: rgba(74, 222, 128, 0.08); border-color: rgba(74, 222, 128, 0.25); border-left-color: #4ADE80; }
+    :root:not([data-theme]) .banner--error   { background: rgba(248, 113, 113, 0.08); border-color: rgba(248, 113, 113, 0.25); border-left-color: #F87171; }
+    :root:not([data-theme]) .banner--warning { background: rgba(251, 191, 36, 0.08); border-color: rgba(251, 191, 36, 0.25); border-left-color: #FBBF24; }
+    :root:not([data-theme]) .banner--info    { background: rgba(184, 134, 11, 0.10); border-color: rgba(184, 134, 11, 0.30); }
 }
 
-.flash-success::before { content: "OK "; font-weight: 600; color: var(--color-success); }
-.flash-error::before { content: "ERROR "; font-weight: 600; color: var(--color-error); }
-.flash-info::before { content: "INFO "; font-weight: 600; color: var(--color-accent); }
-.flash-warning::before { content: "WARN "; font-weight: 600; color: var(--color-warning); }
-
-.flash-close {
-    background: none;
-    border: none;
-    cursor: pointer;
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
     padding: 0;
-    margin: 0;
-    font-size: var(--font-lg);
-    color: var(--color-text-muted);
-    line-height: 1;
-    opacity: 0.6;
-}
-
-.flash-close:hover {
-    background: none;
-    opacity: 1;
-}
-
-.flash-right {
-    margin-left: auto;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
     white-space: nowrap;
-    display: flex;
-    align-items: center;
-    gap: var(--space-2);
-}
-
-.flash-time {
-    color: var(--color-text-muted);
-    font-size: var(--font-xs);
+    border: 0;
 }
 
 /* ===== Entry Items (List) ===== */
@@ -965,7 +973,6 @@ td input[type="text"] {
     border-bottom: 1px solid var(--color-border-light);
     cursor: pointer;
     transition: background 0.1s;
-    border-left: var(--border-accent-width) solid transparent;
 }
 
 .entry-item:hover {
@@ -974,7 +981,7 @@ td input[type="text"] {
 
 .entry-item.selected {
     background: var(--color-accent-subtle);
-    border-left-color: var(--color-accent);
+    box-shadow: inset var(--border-accent-width) 0 0 var(--color-accent);
 }
 
 .entry-item.entry-read {
@@ -1742,9 +1749,10 @@ summary {
         padding: 0 var(--space-4);
     }
 
-    /* Flash container: don't exceed viewport */
-    .flash-container {
-        max-width: calc(100% - var(--space-6));
+    /* Banner stack: tighter padding on narrow viewports. */
+    .banner {
+        padding: var(--space-2);
+        column-gap: var(--space-2);
     }
 
     /* Dialog: reduce padding on tablet */

--- a/static/js/components/rdrs-flash.js
+++ b/static/js/components/rdrs-flash.js
@@ -1,17 +1,27 @@
-// <rdrs-flash> — Client-side flash/toast message system (Light DOM)
+// <rdrs-flash> — accessible banner-stack for flash messages (Light DOM).
+//
+// Per-message ARIA role: role="status" (polite) for success/info,
+// role="alert" (assertive) for warning/error. Dismiss is a real <button>;
+// closing it returns focus to the element that triggered the message,
+// or to the stack region as a fallback.
+
+const MAX_MESSAGES = 3;
+
+const LEVEL_META = {
+    success: { role: 'status', label: 'Success' },
+    info:    { role: 'status', label: 'Info' },
+    warning: { role: 'alert',  label: 'Warning' },
+    error:   { role: 'alert',  label: 'Error' },
+};
 
 class RdrsFlash extends HTMLElement {
-    constructor() {
-        super();
-        this._maxMessages = 3;
-    }
-
     connectedCallback() {
-        if (!this.classList.contains('flash-container')) {
-            this.classList.add('flash-container');
-        }
-        // CSR shell pages embed pending flash messages as inline JSON.
-        // Show them on first paint so the flow matches the old SSR macro.
+        this.classList.add('banner-stack');
+        if (!this.hasAttribute('role')) this.setAttribute('role', 'region');
+        if (!this.hasAttribute('aria-label')) this.setAttribute('aria-label', 'Notifications');
+        // Focusable as a fallback target when the trigger element is gone.
+        if (!this.hasAttribute('tabindex')) this.tabIndex = -1;
+
         const node = document.getElementById('rdrs-flash-bootstrap');
         if (node && node.textContent && !this._bootstrapApplied) {
             this._bootstrapApplied = true;
@@ -26,18 +36,6 @@ class RdrsFlash extends HTMLElement {
         }
     }
 
-    _formatTime(date) {
-        return date.toLocaleTimeString('en-US', {
-            hour12: false, hour: '2-digit', minute: '2-digit', second: '2-digit'
-        });
-    }
-
-    _escapeHtml(text) {
-        const div = document.createElement('div');
-        div.textContent = text;
-        return div.innerHTML;
-    }
-
     /** Set a flash message cookie for next page load. */
     set(level, message) {
         const messages = [{ level, message }];
@@ -46,25 +44,58 @@ class RdrsFlash extends HTMLElement {
 
     /** Show a flash message immediately on the page. */
     show(level, message) {
-        // Ensure we're in the DOM
         if (!this.parentNode) {
             document.body.insertBefore(this, document.body.firstChild);
         }
 
-        // Remove oldest messages if we have too many
-        const existing = this.querySelectorAll('.flash');
-        if (existing.length >= this._maxMessages) {
-            for (let i = 0; i <= existing.length - this._maxMessages; i++) {
+        const existing = this.querySelectorAll('.banner');
+        if (existing.length >= MAX_MESSAGES) {
+            for (let i = 0; i <= existing.length - MAX_MESSAGES; i++) {
                 existing[i].remove();
             }
         }
 
-        const div = document.createElement('div');
-        div.className = `flash flash-${level}`;
-        div.setAttribute('data-testid', 'flash-message');
-        const timestamp = this._formatTime(new Date());
-        div.innerHTML = `<span>${this._escapeHtml(message)}</span><span class="flash-right"><span class="flash-time">${timestamp}</span> <a href="#" class="flash-close" data-testid="flash-close" onclick="this.parentElement.parentElement.remove(); return false;">\u00d7</a></span>`;
-        this.appendChild(div);
+        const meta = LEVEL_META[level] || LEVEL_META.info;
+        const trigger = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+
+        const banner = document.createElement('div');
+        banner.className = `banner banner--${level}`;
+        banner.setAttribute('role', meta.role);
+        banner.setAttribute('data-testid', 'flash-message');
+
+        const icon = document.createElement('span');
+        icon.className = 'banner-icon';
+        icon.setAttribute('aria-hidden', 'true');
+
+        const body = document.createElement('div');
+        body.className = 'banner-body';
+        const srLevel = document.createElement('span');
+        srLevel.className = 'sr-only';
+        srLevel.textContent = `${meta.label}: `;
+        const msg = document.createElement('span');
+        msg.className = 'banner-message';
+        msg.textContent = message;
+        body.append(srLevel, msg);
+
+        const dismiss = document.createElement('button');
+        dismiss.type = 'button';
+        dismiss.className = 'banner-dismiss';
+        dismiss.setAttribute('aria-label', 'Dismiss notification');
+        dismiss.setAttribute('data-testid', 'flash-close');
+        dismiss.textContent = '×';
+        dismiss.addEventListener('click', () => {
+            banner.remove();
+            // Return focus to the original trigger if still in the DOM and visible,
+            // otherwise to the stack region (which is tabindex=-1).
+            if (trigger && document.contains(trigger) && typeof trigger.focus === 'function') {
+                trigger.focus();
+            } else {
+                this.focus();
+            }
+        });
+
+        banner.append(icon, body, dismiss);
+        this.appendChild(banner);
     }
 
     success(message) { this.show('success', message); }
@@ -80,7 +111,6 @@ class RdrsFlash extends HTMLElement {
 
 customElements.define('rdrs-flash', RdrsFlash);
 
-// Global proxy for backwards compatibility
 window.flash = {
     get _el() {
         let el = document.querySelector('rdrs-flash');
@@ -97,9 +127,4 @@ window.flash = {
     info(message) { this._el.info(message); },
     warning(message) { this._el.warning(message); },
     redirect(url, level, message) { this._el.redirect(url, level, message); },
-    escapeHtml(text) {
-        const div = document.createElement('div');
-        div.textContent = text;
-        return div.innerHTML;
-    }
 };

--- a/templates/_entries_layout.html
+++ b/templates/_entries_layout.html
@@ -4,7 +4,7 @@
     <div class="app-layout">
         <rdrs-sidebar active="{{ entries_layout.active }}"{% if let Some(cat_id) = entries_layout.active_category_id %} active-category-id="{{ cat_id }}"{% endif %}></rdrs-sidebar>
         <main class="main-content">
-            <rdrs-flash class="flash-container"></rdrs-flash>
+            <rdrs-flash></rdrs-flash>
             <div class="split-view">
                 <div class="list-pane">
                     <div class="list-pane-header">

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -5,7 +5,7 @@
         <rdrs-sidebar active="admin"></rdrs-sidebar>
         <main class="main-content">
             <div class="page-content">
-                <rdrs-flash class="flash-container"></rdrs-flash>
+                <rdrs-flash></rdrs-flash>
                 <h1>Admin Panel</h1>
                 <table class="mobile-cards" data-testid="admin-users-table">
                     <thead>

--- a/templates/categories.html
+++ b/templates/categories.html
@@ -5,7 +5,7 @@
         <rdrs-sidebar active="categories"></rdrs-sidebar>
         <main class="main-content">
             <div class="page-content">
-                <rdrs-flash class="flash-container"></rdrs-flash>
+                <rdrs-flash></rdrs-flash>
                 <h1>Categories</h1>
 
                 <form method="post" action="/categories">

--- a/templates/error.html
+++ b/templates/error.html
@@ -5,7 +5,7 @@
         <rdrs-sidebar></rdrs-sidebar>
         <main class="main-content">
             <div class="page-content">
-                <rdrs-flash class="flash-container"></rdrs-flash>
+                <rdrs-flash></rdrs-flash>
                 <h1>{{ heading }}</h1>
                 <p class="muted">{{ message }}</p>
                 <p><a href="/">Back to Unread</a></p>

--- a/templates/feed_edit.html
+++ b/templates/feed_edit.html
@@ -5,7 +5,7 @@
         <rdrs-sidebar active="feeds"></rdrs-sidebar>
         <main class="main-content">
             <div class="page-content">
-                <rdrs-flash class="flash-container"></rdrs-flash>
+                <rdrs-flash></rdrs-flash>
                 <h1>Edit Feed</h1>
 
                 <form method="post" action="/feeds/{{ feed.id }}/edit">

--- a/templates/feeds.html
+++ b/templates/feeds.html
@@ -5,7 +5,7 @@
         <rdrs-sidebar active="feeds"></rdrs-sidebar>
         <main class="main-content">
             <div class="page-content">
-                <rdrs-flash class="flash-container"></rdrs-flash>
+                <rdrs-flash></rdrs-flash>
                 <h1>Feeds</h1>
 
                 <div class="feeds-toolbar">

--- a/templates/feeds_import.html
+++ b/templates/feeds_import.html
@@ -5,7 +5,7 @@
         <rdrs-sidebar active="feeds"></rdrs-sidebar>
         <main class="main-content">
             <div class="page-content">
-                <rdrs-flash class="flash-container"></rdrs-flash>
+                <rdrs-flash></rdrs-flash>
                 <h1>Import OPML</h1>
 
                 <form method="post" action="/feeds/import" enctype="multipart/form-data">

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -1,10 +1,11 @@
 {% macro flash(messages) %}
 {% if !messages.is_empty() %}
-<div class="flash-container">
+<div class="banner-stack" role="region" aria-label="Notifications" tabindex="-1">
     {% for msg in messages %}
-    <div class="flash {{ msg.level_class() }}" data-testid="flash-message">
-        <span>{{ msg.message }}</span>
-        <span class="flash-right"><span class="flash-time">{{ msg.formatted_time() }}</span> <a href="#" class="flash-close" data-testid="flash-close" onclick="this.parentElement.parentElement.remove(); return false;">&times;</a></span>
+    <div class="banner {{ msg.level_class() }}" role="{{ msg.aria_role() }}" data-testid="flash-message">
+        <span class="banner-icon" aria-hidden="true"></span>
+        <div class="banner-body"><span class="sr-only">{{ msg.level_name() }}: </span><span class="banner-message">{{ msg.message }}</span></div>
+        <button type="button" class="banner-dismiss" aria-label="Dismiss notification" data-testid="flash-close" onclick="this.closest('.banner').remove();">&times;</button>
     </div>
     {% endfor %}
 </div>

--- a/templates/search.html
+++ b/templates/search.html
@@ -5,7 +5,7 @@
         <rdrs-sidebar active="search"></rdrs-sidebar>
         <main class="main-content">
             <div class="page-content">
-                <rdrs-flash class="flash-container"></rdrs-flash>
+                <rdrs-flash></rdrs-flash>
                 <h1>Search</h1>
 
                 <form method="get" action="/search">

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -5,7 +5,7 @@
         <rdrs-sidebar active="settings"></rdrs-sidebar>
         <main class="main-content">
             <div class="page-content">
-                <rdrs-flash class="flash-container"></rdrs-flash>
+                <rdrs-flash></rdrs-flash>
                 <h1>Settings</h1>
                 <div id="settings-body">
                     <p class="muted">Version: <code>{{ git_version }}</code></p>

--- a/templates/statistics.html
+++ b/templates/statistics.html
@@ -5,7 +5,7 @@
         <rdrs-sidebar active="statistics"></rdrs-sidebar>
         <main class="main-content">
             <div class="page-content">
-                <rdrs-flash class="flash-container"></rdrs-flash>
+                <rdrs-flash></rdrs-flash>
                 <div class="stats-header">
                     <h1>Statistics</h1>
                     <form class="stats-period" method="get" action="/statistics">

--- a/templates/user_settings.html
+++ b/templates/user_settings.html
@@ -9,7 +9,7 @@
         <rdrs-sidebar active="user-settings"></rdrs-sidebar>
         <main class="main-content">
             <div class="page-content">
-                <rdrs-flash class="flash-container"></rdrs-flash>
+                <rdrs-flash></rdrs-flash>
                 <h1>User Settings</h1>
 
                 <h2>Account Information</h2>

--- a/tests/auth_test.rs
+++ b/tests/auth_test.rs
@@ -684,7 +684,8 @@ async fn test_flash_message_displayed_on_login_page() {
     response.assert_status_ok();
     let body = response.text();
     assert!(body.contains("Test flash message"));
-    assert!(body.contains("flash-success"));
+    assert!(body.contains("banner--success"));
+    assert!(body.contains(r#"role="status""#));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Replace the floating-toast flash component with an inline, accessible banner-stack. Driven by [Primer's accessibility guidance against toast notifications](https://primer.style/accessibility/patterns/accessible-notifications-and-messages/#toasts) — the previous `.flash-*` overlay had four WCAG issues (DOM placement, keyboard dismiss, focus management, missing live-region semantics).
- Compact visual pass: faint tinted background, 8px coloured dot instead of `OK`/`ERROR` chips, no visible timestamp, tighter padding, full-width inside `<main>`.
- Drive-by fix: `.entry-item` bottom border was visually clipped on the left because a transparent left border (reserving space for the selection accent stripe) was disturbing the bottom-border's corner mitre. Switched the selection stripe to an inset `box-shadow` so the bottom border is flush on both sides.

## What changed

**Behavioural / a11y**

- Per-message ARIA role: `role=\"status\"` (polite) for success/info, `role=\"alert\"` (assertive) for warning/error.
- Dismiss is now a real `<button aria-label=\"Dismiss notification\">`. Closing it returns focus to the element that triggered the message (falls back to the stack region, which is `tabindex=-1`).
- DOM is rendered as the first child of `<main>` in normal flow, not `position: fixed` over `<body>`.
- No `setTimeout`-driven auto-dismiss (already true before, kept).

**Public surface preserved**

- `window.flash.{show,success,error,info,warning,set,redirect}` JS API
- `<rdrs-flash>` custom element name
- `<script id=\"rdrs-flash-bootstrap\">` inline-JSON bootstrap channel
- `data-testid=\"flash-message\"` / `data-testid=\"flash-close\"` selectors

Existing e2e and JS callsites work unchanged.

**Visual changes (compact)**

| Aspect | Before | After |
|---|---|---|
| Background | Saturated tint (`#e8f5e9` etc.) | ~6% opacity tinted bg |
| Icon | `OK`/`ERROR`/`INFO`/`WARN` chip | 8px coloured dot |
| Timestamp | Visible `HH:MM:SS` | Hidden (data still in cookie) |
| Padding | 12/16px | 8/12px |
| Left stripe | 4px | 3px |
| Width | Full | Full (max-width removed after review) |
| Stack gap | 8px | 4px |

**Server-side**

- `FlashMessage::level_class()` now returns `banner--success` etc.
- New `aria_role()` and `level_name()` helpers used by the SSR macro.
- Removed `icon_label()` (became dead code with the dot-style icon).

**Drive-by `.entry-item` fix**

- Removed the `border-left: 3px solid transparent` reservation; the selected-row accent stripe is now an `inset box-shadow`. Eliminates the 3px gap on the left of the bottom border.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo nextest run` — 740 / 740 (was 741; `-1` because `test_flash_icon_label` was removed alongside the now-unused method)
- [x] Updated `tests/auth_test.rs` to assert the new class + role
- [x] e2e: `Authentication › New user can register` (touches both SSR-rendered banner on /login and JS-rendered banner during registration) — passes
- [x] e2e: `Organizing › Creating a category` (touches JS-rendered post-action banner via the swap helper) — passes
- [x] Manual: `curl -b 'flash=...' /login` confirms compact banner DOM with correct `role`, `sr-only` level prefix, and empty `banner-icon` span

## Files changed

- `src/middleware/flash.rs` — level_class returns `banner--*`, new `aria_role()`/`level_name()` helpers + unit tests
- `static/css/app.css` — `.flash-*` → `.banner-*` rewrite, compact tokens; `.entry-item` border fix
- `static/js/components/rdrs-flash.js` — banner DOM, ARIA roles, focus restore
- `templates/macros.html` — SSR macro emits banner DOM (login/register path)
- `templates/{_entries_layout,admin,categories,error,feed_edit,feeds,feeds_import,search,settings,statistics,user_settings}.html` — strip dead `class=\"flash-container\"` from `<rdrs-flash>` (JS auto-adds `.banner-stack` on connect)
- `tests/auth_test.rs` — assert new class + role