### PR TITLE
feat(summary): show title + link inside the summary box

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -1576,6 +1576,15 @@ summary {
     border: 1px solid var(--color-border-light);
     border-radius: var(--radius-md);
     padding: var(--space-5);
+    margin-bottom: var(--space-5);
+}
+
+/* In-flight status line ("Summarizing… (refresh to see the result)") —
+   only direct <p> child of the box, smaller than the eventual summary
+   body so the transient state doesn't dominate the pane. */
+.summary-box > p {
+    margin: 0;
+    font-size: var(--font-sm);
 }
 
 .summary-actions {
@@ -1583,6 +1592,29 @@ summary {
     gap: var(--space-2);
     margin-bottom: var(--space-3);
 }
+
+/* Caption-style title + link, mirrors what the Copy button writes. */
+.summary-header {
+    margin-bottom: var(--space-3);
+    padding-bottom: var(--space-3);
+    border-bottom: 1px dashed var(--color-border-light);
+}
+.summary-title {
+    font-weight: 600;
+    color: var(--color-text);
+    font-size: var(--font-base);
+    line-height: 1.4;
+    margin-bottom: var(--space-1);
+}
+.summary-link {
+    display: inline-block;
+    color: var(--color-accent);
+    font-size: var(--font-sm);
+    font-family: var(--font-mono);
+    word-break: break-all;
+    text-decoration: none;
+}
+.summary-link:hover { text-decoration: underline; }
 
 .summary-box blockquote {
     border-left: var(--border-accent-width) solid var(--color-accent);

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -652,17 +652,20 @@ function installSummaryActions() {
     document.addEventListener('click', async (e) => {
         const copyBtn = e.target.closest('[data-summary-copy]');
         if (copyBtn) {
-            const pane = document.getElementById('reading-pane');
-            if (!pane) return;
-            const titleEl = pane.querySelector('.reading-pane-title');
-            const summaryEl = pane.querySelector('.rp-summary-content');
+            // Read from inside the summary box only, so what the user copies
+            // matches the visible content of the box (title + link + summary).
+            const box = copyBtn.closest('.summary-box');
+            if (!box) return;
+            const summaryEl = box.querySelector('.rp-summary-content');
             if (!summaryEl) return;
-            const title = (titleEl?.textContent || '').trim();
-            const link = titleEl?.querySelector('a')?.getAttribute('href') || '';
+            const title = (box.querySelector('[data-summary-title]')?.textContent || '').trim();
+            const link = (box.querySelector('[data-summary-link]')?.getAttribute('href') || '').trim();
             const summary = summaryEl.textContent.trim();
-            const text = link
-                ? `${title}\n\n${link}\n\n${summary}`
-                : `${title}\n\n${summary}`;
+            const parts = [];
+            if (title) parts.push(title);
+            if (link) parts.push(link);
+            parts.push(summary);
+            const text = parts.join('\n\n');
             try {
                 await navigator.clipboard.writeText(text);
                 const original = copyBtn.textContent;

--- a/templates/_reading_pane.html
+++ b/templates/_reading_pane.html
@@ -61,6 +61,14 @@
                     <button type="button" class="btn-secondary btn-sm" data-summary-copy>Copy</button>
                     <button type="button" class="btn-secondary btn-sm" data-summary-dismiss data-entry-id="{{ pane.id }}">Dismiss</button>
                 </div>
+                {# Title + link rendered inside the box so what users see
+                   matches what the Copy button writes to the clipboard. #}
+                <div class="summary-header">
+                    <div class="summary-title" data-summary-title>{{ pane.title }}</div>
+                    {% if let Some(link) = pane.link.as_ref() %}
+                    <a class="summary-link" href="{{ link }}" target="_blank" rel="noopener noreferrer" data-summary-link>{{ link }}</a>
+                    {% endif %}
+                </div>
                 <blockquote class="rp-summary-content">{{ summary|safe }}</blockquote>
             </div>
             {% endif %}


### PR DESCRIPTION
## Summary

Make the reading-pane summary box self-contained: title and link are now rendered **inside** the box, so what users see matches what the Copy button writes to the clipboard.

### Before

```
─── reading pane header ────
Article Title              ← part of .reading-pane-title
feed · author · 2h ago

┌────────────────────────┐
│ [ Copy ] [ Dismiss ]   │
│                        │
│ ▌ Summary body...      │
└────────────────────────┘
```

Clicking **Copy** wrote `{title}\n\n{link}\n\n{summary}` — pulling title/link from the heading above the box. Users had no indication that more than the visible summary would land on the clipboard.

### After

```
─── reading pane header ────
Article Title              ← still here (heading)
feed · author · 2h ago

┌────────────────────────────┐
│ [ Copy ] [ Dismiss ]       │
│ Article Title              │  ← data-summary-title (16px, bold)
│ https://example.com/post   │  ← data-summary-link (14px, mono, accent)
│ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─ ─    │
│ ▌ Summary body...          │
└────────────────────────────┘
```

Copy now reads from `[data-summary-title]` / `[data-summary-link]` inside the box. The clipboard output is identical to what's visible.

## Drive-bys on the summary box

- `.summary-box` now has `margin-bottom: var(--space-5)` so the in-flight `Summarizing…` state and the completed box both get breathing room before the `<article>` body.
- `.summary-box > p` (the in-flight status line) is `--font-sm` so the transient state doesn't dominate the pane.
- Title/link/summary font sizes are within one step of each other (`--font-base` / `--font-sm` / `--font-base`); previous attempt with two-step gaps felt jagged.

## What this PR does NOT touch

- `window.flash` / `<rdrs-flash>` (banner-stack work shipped in #225).
- `_summarize_pending.html` (in-flight swap response) — has no Copy button, so the visible-vs-copied mismatch doesn't apply.
- Selectors that e2e relies on (`.summary-box`, `#rp-summary-container`, `data-summary-copy`, `data-summary-dismiss`) — all unchanged.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo nextest run` — 740 / 740
- [x] e2e: 6 summary-touching scenarios pass (`triage` Summarize / Dismiss, `reading` Summarized filter, star / mark-read)
- [x] Manual: click Copy, paste — output is `Title\n\nLink\n\nSummary` matching the box contents

## Files changed

- `templates/_reading_pane.html` — title + link header inside `.summary-box`
- `static/css/app.css` — `.summary-header` / `.summary-title` / `.summary-link`, plus `.summary-box` margin and `.summary-box > p` font size
- `static/js/app.js` — Copy reads from the box's own data attributes