### PR TITLE
refactor: remove dead code with no production callers

### DIFF
--- a/src/models/entry.rs
+++ b/src/models/entry.rs
@@ -438,16 +438,6 @@ pub fn count_unread_by_category(
     Ok(map)
 }
 
-pub fn count_by_feed(conn: &Connection, feed_id: i64) -> AppResult<i64> {
-    let count: i64 = conn.query_row(
-        "SELECT COUNT(*) FROM entry WHERE feed_id = ?1",
-        params![feed_id],
-        |row| row.get(0),
-    )?;
-
-    Ok(count)
-}
-
 #[allow(clippy::too_many_arguments)]
 pub fn upsert_entry(
     conn: &Connection,

--- a/src/models/entry_summary.rs
+++ b/src/models/entry_summary.rs
@@ -191,17 +191,6 @@ pub fn delete(conn: &Connection, user_id: i64, entry_id: i64) -> AppResult<bool>
     Ok(rows > 0)
 }
 
-/// Check if an entry has a completed summary
-pub fn has_completed_summary(conn: &Connection, user_id: i64, entry_id: i64) -> AppResult<bool> {
-    let count: i64 = conn.query_row(
-        "SELECT COUNT(*) FROM entry_summary WHERE user_id = ?1 AND entry_id = ?2 AND status = 'completed'",
-        params![user_id, entry_id],
-        |row| row.get(0),
-    )?;
-
-    Ok(count > 0)
-}
-
 /// Get summary statuses for multiple entries (batch query for list display)
 pub fn get_statuses_for_entries(
     conn: &Connection,
@@ -248,19 +237,6 @@ pub fn get_statuses_for_entries(
     }
 
     Ok(map)
-}
-
-/// Get entry IDs that have completed summaries
-pub fn get_completed_entry_ids(conn: &Connection, user_id: i64) -> AppResult<Vec<i64>> {
-    let mut stmt = conn.prepare(
-        "SELECT entry_id FROM entry_summary WHERE user_id = ?1 AND status = 'completed'",
-    )?;
-
-    let ids = stmt
-        .query_map(params![user_id], |row| row.get(0))?
-        .collect::<Result<Vec<_>, _>>()?;
-
-    Ok(ids)
 }
 
 /// Find incomplete summaries (pending or processing) for recovery on startup
@@ -430,21 +406,6 @@ mod tests {
         let deleted = delete(&conn, user_id, entry_id).unwrap();
         assert!(deleted);
         assert!(!exists(&conn, user_id, entry_id).unwrap());
-    }
-
-    #[test]
-    fn test_has_completed_summary() {
-        let conn = setup_db();
-        let user_id = create_test_user(&conn, "testuser");
-        let entry_id = create_test_entry(&conn, user_id);
-
-        assert!(!has_completed_summary(&conn, user_id, entry_id).unwrap());
-
-        upsert_pending(&conn, user_id, entry_id).unwrap();
-        assert!(!has_completed_summary(&conn, user_id, entry_id).unwrap());
-
-        set_completed(&conn, user_id, entry_id, "Summary text").unwrap();
-        assert!(has_completed_summary(&conn, user_id, entry_id).unwrap());
     }
 
     #[test]

--- a/src/models/session.rs
+++ b/src/models/session.rs
@@ -9,7 +9,6 @@ pub const SESSION_ABSOLUTE_MAX_DAYS: i64 = 90;
 const TOKEN_LENGTH: usize = 32;
 
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub struct Session {
     pub id: i64,
     pub user_id: i64,
@@ -164,12 +163,6 @@ pub fn delete_session(conn: &Connection, token: &str) -> AppResult<()> {
 pub fn delete_user_sessions(conn: &Connection, user_id: i64) -> AppResult<()> {
     conn.execute("DELETE FROM session WHERE user_id = ?1", params![user_id])?;
     Ok(())
-}
-
-#[allow(dead_code)]
-pub fn cleanup_expired(conn: &Connection) -> AppResult<usize> {
-    let deleted = conn.execute("DELETE FROM session WHERE expires_at < datetime('now')", [])?;
-    Ok(deleted)
 }
 
 pub fn start_masquerade(conn: &Connection, token: &str, target_user_id: i64) -> AppResult<()> {

--- a/src/models/user_settings.rs
+++ b/src/models/user_settings.rs
@@ -28,11 +28,6 @@ impl UserSettings {
             .and_then(|json| SaveServicesConfig::from_json(json).ok())
             .unwrap_or_default()
     }
-
-    /// Check if any save service is configured
-    pub fn has_save_services(&self) -> bool {
-        self.get_save_services_config().has_any_service()
-    }
 }
 
 fn parse_datetime(s: &str) -> DateTime<Utc> {
@@ -103,12 +98,6 @@ pub fn get_save_services_config(conn: &Connection, user_id: i64) -> AppResult<Sa
         Some(settings) => Ok(settings.get_save_services_config()),
         None => Ok(SaveServicesConfig::default()),
     }
-}
-
-/// Check if user has any save services configured
-pub fn has_save_services(conn: &Connection, user_id: i64) -> AppResult<bool> {
-    let config = get_save_services_config(conn, user_id)?;
-    Ok(config.has_any_service())
 }
 
 /// Update save_services configuration for a user

--- a/src/models/webauthn_challenge.rs
+++ b/src/models/webauthn_challenge.rs
@@ -125,14 +125,6 @@ pub fn find_and_delete_challenge(
     Ok(challenge)
 }
 
-pub fn cleanup_expired(conn: &Connection) -> AppResult<usize> {
-    let deleted = conn.execute(
-        "DELETE FROM webauthn_challenge WHERE expires_at < datetime('now')",
-        [],
-    )?;
-    Ok(deleted)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -224,28 +216,5 @@ mod tests {
             Some(ChallengeType::Authentication)
         );
         assert_eq!(ChallengeType::from_str("invalid"), None);
-    }
-
-    #[test]
-    fn test_cleanup_expired() {
-        let conn = setup_db();
-
-        // Create an expired challenge by inserting directly with past expiry
-        conn.execute(
-            "INSERT INTO webauthn_challenge (challenge, challenge_type, state_data, expires_at) VALUES (?1, ?2, ?3, datetime('now', '-1 hour'))",
-            params![vec![1u8, 2, 3], "registration", "{}"],
-        )
-        .unwrap();
-
-        // Create a valid challenge
-        create_challenge(&conn, &[4, 5, 6], None, ChallengeType::Registration, "{}").unwrap();
-
-        // Cleanup should delete 1 expired challenge
-        let deleted = cleanup_expired(&conn).unwrap();
-        assert_eq!(deleted, 1);
-
-        // Valid challenge should still exist
-        let found = find_and_delete_challenge(&conn, None, ChallengeType::Registration);
-        assert!(found.is_ok());
     }
 }

--- a/src/services/save/linkding.rs
+++ b/src/services/save/linkding.rs
@@ -35,10 +35,6 @@ struct LinkdingBookmarkRequest {
 #[derive(Debug, Deserialize)]
 struct LinkdingBookmarkResponse {
     id: i64,
-    #[allow(dead_code)]
-    url: String,
-    #[allow(dead_code)]
-    title: Option<String>,
 }
 
 /// Save a bookmark to Linkding

--- a/src/services/summary_cache.rs
+++ b/src/services/summary_cache.rs
@@ -112,52 +112,9 @@ impl SummaryCache {
         self.cache.invalidate(&(user_id, entry_id));
     }
 
-    /// Check if an entry has a summary (completed or in progress)
-    pub fn has_summary(&self, user_id: i64, entry_id: i64) -> bool {
-        self.cache.get(&(user_id, entry_id)).is_some()
-    }
-
-    /// Check if an entry has a completed summary
-    pub fn has_completed_summary(&self, user_id: i64, entry_id: i64) -> bool {
-        self.cache
-            .get(&(user_id, entry_id))
-            .map(|e| e.status == SummaryStatus::Completed)
-            .unwrap_or(false)
-    }
-
-    /// Check if a job is in-flight (pending or processing)
-    /// Used to prevent duplicate submissions
-    pub fn is_in_flight(&self, user_id: i64, entry_id: i64) -> bool {
-        self.cache
-            .get(&(user_id, entry_id))
-            .map(|e| e.status == SummaryStatus::Pending || e.status == SummaryStatus::Processing)
-            .unwrap_or(false)
-    }
-
     /// Get the status of a summary if it exists in cache
     pub fn get_status(&self, user_id: i64, entry_id: i64) -> Option<SummaryStatus> {
         self.cache.get(&(user_id, entry_id)).map(|e| e.status)
-    }
-
-    /// List all entry IDs with summaries for a user
-    pub fn list_by_user(&self, user_id: i64) -> Vec<i64> {
-        self.cache
-            .iter()
-            .filter_map(|(key, _)| if key.0 == user_id { Some(key.1) } else { None })
-            .collect()
-    }
-
-    /// Count entries by status for a user
-    pub fn count_by_status(&self, user_id: i64, status: SummaryStatus) -> usize {
-        self.cache
-            .iter()
-            .filter(|(key, entry)| key.0 == user_id && entry.status == status)
-            .count()
-    }
-
-    /// Get cache statistics
-    pub fn entry_count(&self) -> u64 {
-        self.cache.entry_count()
     }
 }
 
@@ -206,55 +163,5 @@ mod tests {
         let entry = cache.get(1, 100).unwrap();
         assert_eq!(entry.status, SummaryStatus::Failed);
         assert_eq!(entry.error_message.as_deref(), Some("Error occurred"));
-    }
-
-    #[test]
-    fn test_has_summary_methods() {
-        let cache = SummaryCache::new(100, 24);
-
-        assert!(!cache.has_summary(1, 100));
-        assert!(!cache.has_completed_summary(1, 100));
-
-        cache.set_pending(1, 100);
-        assert!(cache.has_summary(1, 100));
-        assert!(!cache.has_completed_summary(1, 100));
-
-        cache.set_completed(1, 100, "Summary".to_string());
-        assert!(cache.has_summary(1, 100));
-        assert!(cache.has_completed_summary(1, 100));
-    }
-
-    #[test]
-    fn test_list_by_user() {
-        let cache = SummaryCache::new(100, 24);
-
-        cache.set_completed(1, 100, "a".to_string());
-        cache.set_completed(1, 101, "b".to_string());
-        cache.set_completed(2, 200, "c".to_string());
-
-        let user1_entries = cache.list_by_user(1);
-        assert_eq!(user1_entries.len(), 2);
-        assert!(user1_entries.contains(&100));
-        assert!(user1_entries.contains(&101));
-
-        let user2_entries = cache.list_by_user(2);
-        assert_eq!(user2_entries.len(), 1);
-        assert!(user2_entries.contains(&200));
-    }
-
-    #[test]
-    fn test_count_by_status() {
-        let cache = SummaryCache::new(100, 24);
-
-        cache.set_pending(1, 100);
-        cache.set_processing(1, 101);
-        cache.set_completed(1, 102, "a".to_string());
-        cache.set_completed(1, 103, "b".to_string());
-        cache.set_failed(1, 104, "err".to_string());
-
-        assert_eq!(cache.count_by_status(1, SummaryStatus::Pending), 1);
-        assert_eq!(cache.count_by_status(1, SummaryStatus::Processing), 1);
-        assert_eq!(cache.count_by_status(1, SummaryStatus::Completed), 2);
-        assert_eq!(cache.count_by_status(1, SummaryStatus::Failed), 1);
     }
 }


### PR DESCRIPTION
## Summary
- Drop a handful of `pub` items that are unreachable from production code paths and only kept alive (if at all) by their own tests: `session::cleanup_expired`, `webauthn_challenge::cleanup_expired`, `entry::count_by_feed`, `entry_summary::has_completed_summary` / `get_completed_entry_ids`, `user_settings::has_save_services` (method + standalone fn), and five unused `SummaryCache` methods (`has_summary`, `has_completed_summary`, `is_in_flight`, `list_by_user`, `count_by_status`, `entry_count`).
- Trim unused `url` / `title` fields on `LinkdingBookmarkResponse` — `serde` ignores unknown JSON keys by default.
- Drop a stale `#[allow(dead_code)]` from the `Session` struct (all fields are actually used).
- Tests for the removed items are deleted alongside them; no production behavior changes.

Release binary delta is negligible (~1.9 KiB, 0.012%) because `lto = true` + `strip = true` already discards most of this at link time. The cleanup is primarily about source-code hygiene.

## Test plan
- [x] `cargo fmt -- --check`
- [x] `cargo build --all-targets` (no warnings)
- [x] `cargo nextest run` (735 passed)