### PR TITLE
fix(reading-pane): open reading pane on mobile after entry click

### DIFF
--- a/e2e/features/responsive.feature
+++ b/e2e/features/responsive.feature
@@ -22,6 +22,31 @@ Feature: Responsive layout
     Then the entry list pane is at least 370px wide
 
   @mobile
+  Scenario: Opening an entry on mobile reveals the reading pane as a full-screen overlay
+    Given I am viewing on a mobile screen
+    And I have a feed with 5 test entries
+    When I open the inbox
+    And I click the entry titled "Test Entry 1"
+    Then the reading pane is visible on mobile
+
+  @mobile
+  Scenario: Tapping back on the reading pane on mobile returns to the entry list
+    Given I am viewing on a mobile screen
+    And I have a feed with 5 test entries
+    When I open the inbox
+    And I click the entry titled "Test Entry 1"
+    And I tap the reading-pane back button
+    Then the reading pane is empty
+    And the URL has no ?entry= parameter
+
+  @mobile
+  Scenario: Deep-linking with ?entry= on mobile shows the reading pane
+    Given I am viewing on a mobile screen
+    And I have a feed "Reading Feed" with 5 test entries in category "Reading Category"
+    When I open the inbox deep-linked to entry titled "Test Entry 2"
+    Then the reading pane is visible on mobile
+
+  @mobile
   Scenario: Categories table renders as cards on mobile
     Given I am viewing on a mobile screen
     And I have a category named "Test Category"

--- a/e2e/steps/responsive.steps.js
+++ b/e2e/steps/responsive.steps.js
@@ -74,3 +74,17 @@ Then("the entry list pane is narrower than the viewport", async ({ page }) => {
   const box = await page.locator(".list-pane").boundingBox();
   expect(box.width).toBeLessThan(viewport.width * 0.9);
 });
+
+Then("the reading pane is visible on mobile", async ({ page }) => {
+  // At ≤1024px width the reading pane is `display: none` by default and only
+  // surfaces when the `.reading-pane-active` overlay class is present. Assert
+  // both the class is applied AND the element is actually visible — class
+  // alone would pass even if a future CSS regression unset `display: block`.
+  const pane = page.locator("#reading-pane");
+  await expect(pane).toHaveClass(/reading-pane-active/);
+  await expect(pane).toBeVisible();
+});
+
+When("I tap the reading-pane back button", async ({ page }) => {
+  await page.getByTestId("reading-pane-back").click();
+});

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -486,6 +486,12 @@ code {
     font-style: italic;
 }
 
+/* Mobile-only back affordance — hidden on desktop, revealed inside the
+   ≤1024px media query along with the fixed-position pane overlay. */
+.reading-pane-back {
+    display: none;
+}
+
 .reading-pane-content {
     padding: var(--space-8) var(--space-10);
     max-width: var(--content-max-width);
@@ -1735,6 +1741,10 @@ summary {
     }
 
     .reading-pane-back-link {
+        background: none;
+        border: 0;
+        padding: 0;
+        font: inherit;
         color: var(--color-link);
         cursor: pointer;
     }

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -175,6 +175,31 @@ function setEntryParam(entryId) {
     window.history.replaceState({}, '', u);
 }
 
+// Reset `#reading-pane` to its empty placeholder. Mirrors the SSR-rendered
+// empty state in `_entries_layout.html` so the @media-driven mobile overlay
+// dismisses (the `.reading-pane-active` class is what reveals the pane at
+// ≤1024px — leaving it on top of empty content traps users on a blank
+// screen). Returns false if the pane was already empty.
+function closeReadingPane() {
+    const pane = document.getElementById('reading-pane');
+    if (!pane || pane.classList.contains('reading-pane-empty')) return false;
+    pane.classList.remove('reading-pane-active');
+    pane.classList.add('reading-pane-empty');
+    pane.innerHTML = '<p>Select an entry to read.</p>';
+    setEntryParam(null);
+    return true;
+}
+
+// Mobile back button inside the reading pane. The button is rendered in
+// `_reading_pane.html` but hidden on desktop via `.reading-pane-back`'s
+// default `display: none` — the @media (≤1024px) block flips it to flex.
+document.addEventListener('click', (event) => {
+    if (event.button !== 0) return;
+    if (!event.target.closest('[data-pane-back]')) return;
+    event.preventDefault();
+    closeReadingPane();
+});
+
 // Process `<template data-flash data-level="success|error|info|warning">message</template>`
 // blocks in a swap response. Each one becomes a toast on the page-level
 // `<rdrs-flash>` element (mounted by _entries_layout.html). Used for
@@ -613,12 +638,7 @@ function installEntriesKeyboard() {
                 // (in its own shadow root), so we yield to it.
                 const help = document.querySelector('rdrs-kb-help');
                 if (help && help.isVisible) return;
-                const pane = document.getElementById('reading-pane');
-                if (!pane || pane.classList.contains('reading-pane-empty')) return;
-                e.preventDefault();
-                pane.classList.add('reading-pane-empty');
-                pane.innerHTML = '<p>Select an entry to read.</p>';
-                setEntryParam(null);
+                if (closeReadingPane()) e.preventDefault();
                 break;
             }
             case ' ': {

--- a/templates/_reading_pane.html
+++ b/templates/_reading_pane.html
@@ -1,7 +1,16 @@
 {# Reading pane content. Matches the pre-SSR `.reading-pane-content` +
    `.reading-pane-article` + `.reading-pane-actions` DOM the existing
-   CSS rules target. `id="reading-pane"` is the swap target. #}
-<div id="reading-pane" class="reading-pane">
+   CSS rules target. `id="reading-pane"` is the swap target.
+
+   `reading-pane-active` is load-bearing on mobile (≤1024px): the
+   media query hides the bare `.reading-pane` and only reveals
+   `.reading-pane.reading-pane-active` as a full-screen overlay.
+   Empty-state placeholders MUST NOT carry the class, or mobile will
+   trap users behind a blank pane. #}
+<div id="reading-pane" class="reading-pane reading-pane-active">
+    <div class="reading-pane-back">
+        <button type="button" class="reading-pane-back-link" data-pane-back data-testid="reading-pane-back">← Back to list</button>
+    </div>
     <div class="reading-pane-content">
         <h1 class="reading-pane-title" data-testid="reading-pane-title">
             {% if let Some(link) = pane.link.as_ref() %}<a href="{{ link }}" target="_blank" rel="noopener noreferrer">{{ pane.title }}</a>{% else %}{{ pane.title }}{% endif %}


### PR DESCRIPTION
## Summary

- On mobile (≤1024px) the reading pane is `display: none` by default and only shows as a full-screen overlay when `.reading-pane-active` is on the element. The SSR template never applied that class, so tapping an entry swapped fresh content in but the pane stayed invisible — the URL silently updated to `?entry=…` while the user appeared stuck on the list.
- Render `_reading_pane.html` with `reading-pane-active` (harmless no-op on desktop) and add a `← Back to list` button in the pane. Default `display: none` on `.reading-pane-back` keeps the button hidden on desktop; the existing `@media (max-width: 1024px)` block flips it to flex.
- Factor a `closeReadingPane()` helper used by both the new back button and the existing Esc handler — single source of truth for toggling the overlay off, restoring the empty placeholder, and clearing `?entry=` from the URL.

## Test plan

- [x] `cargo nextest run` — 735/735 pass
- [x] `cargo fmt --check` — clean
- [x] `npx playwright test` — 66/66 pass (includes 3 new `@mobile` scenarios: open shows overlay, back closes, deep-link surfaces pane)
- [ ] Manual sanity at 375×667 viewport: tap entry → pane covers list; tap back → list restored, URL `?entry=` dropped

🤖 Generated with [Claude Code](https://claude.com/claude-code)