### PR TITLE
fix(ui): replace Playfair Display with Source Serif 4 for headings

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -23,7 +23,7 @@
     --font-4xl: 2.25rem;
 
     /* Font families */
-    --font-display: 'Playfair Display', Georgia, serif;
+    --font-display: 'Source Serif 4', Georgia, serif;
     --font-body: 'Source Serif 4', Georgia, serif;
     --font-ui: 'DM Sans', -apple-system, BlinkMacSystemFont, sans-serif;
     --font-mono: 'JetBrains Mono', 'SF Mono', monospace;

--- a/static/js/components/rdrs-kb-help.js
+++ b/static/js/components/rdrs-kb-help.js
@@ -45,7 +45,7 @@ class RdrsKbHelp extends HTMLElement {
                     border-bottom: 1px solid var(--color-border-light, #E5E1DB);
                 }
                 h2 {
-                    font-family: var(--font-display, 'Playfair Display', serif);
+                    font-family: var(--font-display, 'Source Serif 4', serif);
                     font-size: 1.25rem;
                     font-weight: 600;
                     margin: 0;

--- a/templates/base.html
+++ b/templates/base.html
@@ -11,8 +11,9 @@
     {# Bunny doesn't support the `opsz` axis — the previous URL silently
        returned an API error so every family fell back to OS defaults.
        Trimmed weight set: DM Sans 400/500/600/700, JetBrains Mono 400,
-       Playfair Display 600/700, Source Serif 4 400/600 + italic 400. #}
-    <link href="https://fonts.bunny.net/css2?family=DM+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400&family=Playfair+Display:wght@600;700&family=Source+Serif+4:ital,wght@0,400;0,600;1,400&display=swap" rel="stylesheet">
+       Source Serif 4 400/600/700 + italic 400 (covers both --font-body
+       and --font-display, including h1/h2/reading-pane-title bold). #}
+    <link href="https://fonts.bunny.net/css2?family=DM+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400&family=Source+Serif+4:ital,wght@0,400;0,600;0,700;1,400&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/static/css/app.css?v={{ git_version }}">
     <link rel="modulepreload" href="/static/js/components/rdrs-flash.js?v={{ git_version }}">
     <script>


### PR DESCRIPTION
## Summary

- Swap `--font-display` from Playfair Display to Source Serif 4. The Playfair `&` glyph is a flamboyant italic Et-ligature that reads as an unfamiliar symbol in real entry titles like `Ship ESM & CJS in one Package` rendered in `.reading-pane-title`.
- Source Serif 4 is already loaded as `--font-body`, so consolidating onto one serif family lets us drop the Playfair Display request entirely from the bunny.net font CSS. Added the missing `700` weight to Source Serif 4's URL to cover `.reading-pane-title`, `.sidebar-logo`, `.auth-card h1`, and `.stats-card-value`.
- Updated the `rdrs-kb-help` web component's `var(--font-display, ...)` fallback to match.

## Test plan

- [x] Open the app, navigate to any entry list, click an entry to open the reading pane — confirm the title font is now Source Serif 4 and the `&` glyph reads as a normal ampersand.
- [x] Check `h1` / `h2` headings on auth pages and statistics — confirm bold weight (700) renders crisply (i.e., the `700` weight was actually fetched from bunny.net, not synthesized).
- [x] Open the keyboard help modal (`?`) and confirm the heading uses the new font.
- [x] DevTools Network panel: confirm no request for `Playfair+Display` remains; one request for Source Serif 4 with `0,700` in the weights.

🤖 Generated with [Claude Code](https://claude.com/claude-code)