### PR TITLE
fix(flash): clear banners on navigation-like reading-pane swap

### DIFF
--- a/e2e/features/reading.feature
+++ b/e2e/features/reading.feature
@@ -91,3 +91,20 @@ Feature: Reading entries
     And I press the "Escape" key
     Then the reading pane is empty
     And the URL has no ?entry= parameter
+
+  Scenario: Opening a different entry clears flash banners from prior actions
+    When I open the inbox
+    And I click the entry titled "Test Entry 1"
+    And I press the "u" key
+    Then I see a success flash "Marked as unread"
+    When I click the entry titled "Test Entry 2"
+    Then the reading pane shows the title "Test Entry 2"
+    And I see no flash message
+
+  Scenario: Acting on the same entry preserves an earlier flash banner
+    When I open the inbox
+    And I click the entry titled "Test Entry 1"
+    And I press the "u" key
+    Then I see a success flash "Marked as unread"
+    When I press the "s" key
+    Then I see a success flash "Marked as unread"

--- a/e2e/steps/entries.steps.js
+++ b/e2e/steps/entries.steps.js
@@ -340,3 +340,7 @@ Then("the entry row for {string} shows as read", async ({ page }, title) => {
   const row = page.getByTestId("entry-item").filter({ hasText: title }).first();
   await expect(row).toHaveClass(/entry-read/);
 });
+
+Then("I see no flash message", async ({ page }) => {
+  await expect(page.getByTestId("flash-message")).toHaveCount(0);
+});

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -131,6 +131,14 @@ async function performSwap(url, init, defaultTarget, options) {
     // history doesn't accumulate per click.
     const paneBefore = document.getElementById('reading-pane');
     const paneWasEmpty = !!paneBefore?.classList.contains('reading-pane-empty');
+    // Captured pre-mutation so the navigation-vs-action detection below
+    // can compare against what was in the pane, not what we just swapped
+    // in. A swap that lands a different entry id is treated as navigation
+    // and clears any pre-existing flash banners; action-result swaps
+    // (Save / Fetch-Full-Content) re-target the same entry and keep their
+    // own `<template data-flash>` toast.
+    const paneEntryIdBefore = currentPaneEntryId();
+    const incomingEntryId = entryIdFromSwapUrl(url);
 
     let swappedReadingPane = false;
     const templates = parsed.querySelectorAll('template[data-swap-target]');
@@ -153,6 +161,9 @@ async function performSwap(url, init, defaultTarget, options) {
             }
             parent.removeChild(dst);
         }
+        if (swappedReadingPane && incomingEntryId && incomingEntryId !== paneEntryIdBefore) {
+            window.flash?.clear?.();
+        }
         if (swappedReadingPane && !skipHistory) syncEntryParamFromSwapUrl(url, { push: paneWasEmpty });
         applyFlashTemplates(parsed);
         document.dispatchEvent(new CustomEvent('rdrs:swap-complete'));
@@ -164,9 +175,20 @@ async function performSwap(url, init, defaultTarget, options) {
     const incoming = parsed.body.firstElementChild;
     if (!incoming) return;
     dst.outerHTML = incoming.outerHTML;
+    if (defaultTarget === '#reading-pane' && incomingEntryId && incomingEntryId !== paneEntryIdBefore) {
+        window.flash?.clear?.();
+    }
     if (defaultTarget === '#reading-pane' && !skipHistory) syncEntryParamFromSwapUrl(url, { push: paneWasEmpty });
     applyFlashTemplates(parsed);
     document.dispatchEvent(new CustomEvent('rdrs:swap-complete'));
+}
+
+// Extract the entry id embedded in a swap URL like `/entries/123/fragment`
+// or `/entries/123/save`. Returns null when the URL doesn't address an
+// entry (e.g. `/sidebar/unread`, `/entries?after=…`).
+function entryIdFromSwapUrl(url) {
+    const m = (url || '').match(/\/entries\/(\d+)(?:\/|$|\?)/);
+    return m ? m[1] : null;
 }
 
 // Mirror the entry id from a `#reading-pane` swap URL into the address-bar
@@ -178,9 +200,9 @@ async function performSwap(url, init, defaultTarget, options) {
 // leaving the list entirely. Subsequent entry switches replace in place
 // so history doesn't accumulate one slot per click.
 function syncEntryParamFromSwapUrl(swapUrl, options) {
-    const m = (swapUrl || '').match(/\/entries\/(\d+)(?:\/|$|\?)/);
-    if (!m) return;
-    setEntryParam(m[1], options);
+    const id = entryIdFromSwapUrl(swapUrl);
+    if (!id) return;
+    setEntryParam(id, options);
 }
 
 function setEntryParam(entryId, options) {
@@ -213,6 +235,11 @@ function currentPaneEntryId() {
 // links, status-filter, 1-4 keys) reloads the page and SSR consumes
 // `?entry=` server-side, so popstate doesn't fire for those.
 window.addEventListener('popstate', () => {
+    // Back/forward is a navigation in user terms — clear any toasts left
+    // over from the previous view so they don't follow the user across
+    // history slots. performSwap below would clear too on entry mismatch,
+    // but doing it upfront also covers the close-pane branch.
+    window.flash?.clear?.();
     const u = new URL(window.location.href);
     const entryId = u.searchParams.get('entry');
     if (!entryId) {

--- a/static/js/components/rdrs-flash.js
+++ b/static/js/components/rdrs-flash.js
@@ -103,6 +103,15 @@ class RdrsFlash extends HTMLElement {
     info(message) { this.show('info', message); }
     warning(message) { this.show('warning', message); }
 
+    /** Remove every currently-displayed banner from the stack. Used by
+     *  navigation-like partial swaps (opening a different entry,
+     *  back/forward) so stale toasts don't follow the user across views. */
+    clear() {
+        for (const banner of Array.from(this.querySelectorAll('.banner'))) {
+            banner.remove();
+        }
+    }
+
     redirect(url, level, message) {
         this.set(level, message);
         window.location.href = url;
@@ -126,5 +135,6 @@ window.flash = {
     error(message) { this._el.error(message); },
     info(message) { this._el.info(message); },
     warning(message) { this._el.warning(message); },
+    clear() { this._el.clear(); },
     redirect(url, level, message) { this._el.redirect(url, level, message); },
 };


### PR DESCRIPTION
## Summary
- Flash banners persisted across partial swaps that opened a different entry but were wiped by every full document navigation, making the dismiss timing feel inconsistent. Treat an entry-switch swap (and `popstate`) as a navigation: clear the banner stack before applying the new response.
- Action-result swaps (Save / Fetch Full Content / mark-unread / star) re-target the same entry id, so their inline `<template data-flash>` toast continues to append without being clobbered.
- Adds `RdrsFlash.clear()` + `window.flash.clear()` and two BDD scenarios covering the navigation-clears vs. same-entry-preserves behaviors.

## Test plan
- [x] `cargo nextest run flash` — 29 passed
- [x] `npx playwright test` — 68 passed
- [x] Manual smoke: cookie-based flash on `/categories` CRUD still shows once and clears on reload
- [x] Manual smoke: inline flash on `u` (Mark Unread) appears
- [x] Manual smoke: opening a different entry after a `u`-triggered flash clears the banner
- [x] Manual smoke: pressing `s` (star) on the same entry preserves the prior flash
- [x] Manual smoke: browser back from an entry closes the pane and clears the banner
- [x] Manual smoke: full-nav (sidebar link, status-filter `<select>`) still clears the banner