### PR TITLE
feat(reading-pane): wire prev/next navigation into the reading pane

### DIFF
--- a/e2e/features/reading.feature
+++ b/e2e/features/reading.feature
@@ -108,3 +108,49 @@ Feature: Reading entries
     Then I see a success flash "Marked as unread"
     When I press the "s" key
     Then I see a success flash "Marked as unread"
+
+  # Uses the All view so reading an entry doesn't drop it from the list —
+  # neighbour membership stays stable while we step through it.
+  Scenario: Reading pane Next and Previous open adjacent entries
+    When I open the all entries page
+    And I click the entry titled "Test Entry 3"
+    And I navigate to the "Next" entry in the reading pane
+    Then the reading pane shows the title "Test Entry 4"
+    When I navigate to the "Previous" entry in the reading pane
+    Then the reading pane shows the title "Test Entry 3"
+    When I navigate to the "Previous" entry in the reading pane
+    Then the reading pane shows the title "Test Entry 2"
+
+  Scenario: With the reading pane open, j and k open adjacent entries
+    When I open the all entries page
+    And I click the entry titled "Test Entry 3"
+    And I press the "j" key
+    Then the reading pane shows the title "Test Entry 4"
+    When I press the "k" key
+    Then the reading pane shows the title "Test Entry 3"
+    When I press the "k" key
+    Then the reading pane shows the title "Test Entry 2"
+
+  # Neighbours honour the active filter: in the Unread inbox, opening an
+  # entry marks it read and so drops it from the unread set. "Previous"
+  # therefore skips the entry just read and lands on the next still-unread
+  # one — the same set the list filters to.
+  Scenario: Reading-pane navigation honours the unread filter
+    When I open the inbox
+    And I click the entry titled "Test Entry 3"
+    And I navigate to the "Next" entry in the reading pane
+    Then the reading pane shows the title "Test Entry 4"
+    When I navigate to the "Previous" entry in the reading pane
+    Then the reading pane shows the title "Test Entry 2"
+
+  Scenario: Previous is disabled on the newest entry
+    When I open the all entries page
+    And I click the entry titled "Test Entry 1"
+    Then the reading-pane "Next" button is enabled
+    And the reading-pane "Previous" button is disabled
+
+  Scenario: Next is disabled on the oldest entry
+    When I open the all entries page
+    And I click the entry titled "Test Entry 5"
+    Then the reading-pane "Previous" button is enabled
+    And the reading-pane "Next" button is disabled

--- a/e2e/steps/entries.steps.js
+++ b/e2e/steps/entries.steps.js
@@ -88,6 +88,10 @@ Given("the feed has {int} entries", async ({ seed, currentUser }, count) => {
   seed.seedTestEntries(feedId, count);
 });
 
+When("I open the all entries page", async ({ page, serverUrl }) => {
+  await page.goto(`${serverUrl}/entries`);
+});
+
 When("I open the read entries page", async ({ page, serverUrl }) => {
   await page.goto(`${serverUrl}/entries/read`);
 });
@@ -153,6 +157,54 @@ When("I click the entry titled {string}", async ({ page }, title) => {
 When("I click {string}", async ({ page }, label) => {
   await page.getByRole("button", { name: label }).click();
 });
+
+// Reading-pane prev/next. The button starts disabled and app.js enables it
+// once `/api/entries/{id}/neighbors` resolves; Playwright's click waits for
+// the actionable (enabled) state, so no explicit wait is needed there.
+function paneNavTestId(direction) {
+  return direction.toLowerCase() === "next"
+    ? "reading-pane-next"
+    : "reading-pane-prev";
+}
+
+// The pane carries no entry id of its own, but every action form targets
+// `/entries/{id}/...` — mirror app.js's currentPaneEntryId() to read it.
+async function paneEntryId(page) {
+  const action = await page
+    .locator('#reading-pane form[action*="/entries/"]')
+    .first()
+    .getAttribute("action")
+    .catch(() => null);
+  const m = action?.match(/\/entries\/(\d+)\//);
+  return m ? m[1] : null;
+}
+
+When(
+  "I navigate to the {string} entry in the reading pane",
+  async ({ page }, direction) => {
+    // Capture the current entry before the click so we can wait until the
+    // pane actually swaps to a different one — guards against a follow-up
+    // navigation firing before this swap (and its neighbour re-resolve)
+    // lands.
+    const before = await paneEntryId(page);
+    await page.getByTestId(paneNavTestId(direction)).click();
+    await expect.poll(() => paneEntryId(page)).not.toBe(before);
+  }
+);
+
+Then(
+  "the reading-pane {string} button is disabled",
+  async ({ page }, direction) => {
+    await expect(page.getByTestId(paneNavTestId(direction))).toBeDisabled();
+  }
+);
+
+Then(
+  "the reading-pane {string} button is enabled",
+  async ({ page }, direction) => {
+    await expect(page.getByTestId(paneNavTestId(direction))).toBeEnabled();
+  }
+);
 
 When("I press the {string} key", async ({ page }, key) => {
   await page.click("body");

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -486,23 +486,43 @@ code {
     font-style: italic;
 }
 
-/* Mobile-only back affordance — hidden on desktop, revealed inside the
-   ≤1024px media query along with the fixed-position pane overlay. */
+/* Reading-pane toolbar. Holds the prev/next nav on every viewport
+   (right-aligned) and, on mobile only, the Back-to-list affordance on the
+   left. Visible on desktop too so the single nav element doesn't have to be
+   duplicated across breakpoints. */
 .reading-pane-back {
-    display: none;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: var(--space-3);
+    padding: var(--space-3) var(--space-6);
+    border-bottom: 1px solid var(--color-border-light);
 }
 
-/* Prev/Next navigation bar at the top of the reading pane, visible on all
-   viewports. Readers navigate with these buttons or the j/k keys while the
-   pane is open; mobile readers get them above the article alongside the
-   Back bar. The
-   buttons render disabled and app.js enables whichever direction has an
-   adjacent entry once `/api/entries/{id}/neighbors` resolves. */
+/* Back-to-list button — mobile-only (the desktop split view never leaves
+   the list). `margin-right: auto` pins it far left so the nav stays right.
+   Revealed in the ≤1024px block. */
+.reading-pane-back-link {
+    display: none;
+    margin-right: auto;
+    background: none;
+    border: 0;
+    padding: 0;
+    font: inherit;
+    color: var(--color-link);
+    cursor: pointer;
+}
+
+.reading-pane-back-link:hover {
+    color: var(--color-link-hover);
+}
+
+/* Prev/Next navigation. Buttons render disabled and app.js enables whichever
+   direction has an adjacent entry once `/api/entries/{id}/neighbors`
+   resolves; readers also navigate with the j/k keys while the pane is open. */
 .reading-pane-nav {
     display: flex;
-    justify-content: space-between;
     gap: var(--space-2);
-    margin-bottom: var(--space-5);
 }
 
 .reading-pane-nav-btn {
@@ -1768,12 +1788,10 @@ summary {
         padding-right: var(--space-4);
     }
 
+    /* Mobile keeps the toolbar (base styles) but makes it a sticky bar over
+       the full-screen pane overlay and reveals the Back button. */
     .reading-pane-back {
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
         padding: var(--space-3) var(--space-4);
-        border-bottom: 1px solid var(--color-border-light);
         font-size: var(--font-sm);
         background: var(--color-bg);
         position: sticky;
@@ -1782,16 +1800,8 @@ summary {
     }
 
     .reading-pane-back-link {
-        background: none;
-        border: 0;
-        padding: 0;
-        font: inherit;
-        color: var(--color-link);
-        cursor: pointer;
-    }
-
-    .reading-pane-back-link:hover {
-        color: var(--color-link-hover);
+        display: inline-flex;
+        align-items: center;
     }
 
     .entry-item {

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -492,6 +492,40 @@ code {
     display: none;
 }
 
+/* Prev/Next navigation bar at the top of the reading pane, visible on all
+   viewports. Readers navigate with these buttons or the j/k keys while the
+   pane is open; mobile readers get them above the article alongside the
+   Back bar. The
+   buttons render disabled and app.js enables whichever direction has an
+   adjacent entry once `/api/entries/{id}/neighbors` resolves. */
+.reading-pane-nav {
+    display: flex;
+    justify-content: space-between;
+    gap: var(--space-2);
+    margin-bottom: var(--space-5);
+}
+
+.reading-pane-nav-btn {
+    background: none;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    color: var(--color-link);
+    cursor: pointer;
+    font-size: var(--font-sm);
+    line-height: 1;
+    padding: var(--space-2) var(--space-4);
+}
+
+.reading-pane-nav-btn:hover:not(:disabled) {
+    background: var(--color-bg-secondary);
+    color: var(--color-link-hover);
+}
+
+.reading-pane-nav-btn:disabled {
+    opacity: 0.3;
+    cursor: default;
+}
+
 .reading-pane-content {
     padding: var(--space-8) var(--space-10);
     max-width: var(--content-max-width);
@@ -1758,32 +1792,6 @@ summary {
 
     .reading-pane-back-link:hover {
         color: var(--color-link-hover);
-    }
-
-    .reading-pane-nav {
-        display: flex;
-        gap: var(--space-2);
-    }
-
-    .reading-pane-nav-btn {
-        background: none;
-        border: 1px solid var(--color-border);
-        border-radius: var(--radius-md);
-        color: var(--color-link);
-        cursor: pointer;
-        font-size: var(--font-lg);
-        line-height: 1;
-        padding: var(--space-1) var(--space-3);
-    }
-
-    .reading-pane-nav-btn:hover:not(:disabled) {
-        background: var(--color-bg-secondary);
-        color: var(--color-link-hover);
-    }
-
-    .reading-pane-nav-btn:disabled {
-        opacity: 0.3;
-        cursor: default;
     }
 
     .entry-item {

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -277,6 +277,131 @@ document.addEventListener('click', (event) => {
     closeReadingPane();
 });
 
+// ── Reading-pane prev/next ("neighbors") navigation ──────────────────
+//
+// The reading pane renders disabled `[data-pane-prev]` / `[data-pane-next]`
+// buttons. After the pane opens we resolve the adjacent entry ids from
+// `GET /api/entries/{id}/neighbors`, scoped to the *current list filter*
+// (so "Next" inside the Unread inbox only walks unread entries, etc.),
+// enable whichever direction has a neighbor, and remember the ids so a
+// click / keypress is an instant swap with no extra round-trip. The
+// endpoint resolves order from the DB, so prev/next also crosses
+// pagination boundaries the in-memory list hasn't loaded yet.
+//
+// "Previous" = newer entry (up the published-desc list); "Next" = older
+// (down) — the same axis as the list's `k`/`j`.
+let neighborState = { entryId: null, prevId: null, nextId: null };
+
+// Translate the current page's list filter into the query params
+// `NeighborsQuery` accepts, mirroring the server-side filter each route
+// builds (see handlers/pages.rs). Returns a query string without the
+// leading `?` (empty for the unfiltered `/entries` "All" view).
+function currentEntryFilterParams() {
+    const { pathname, search } = window.location;
+    const out = new URLSearchParams();
+    const status = new URLSearchParams(search).get('status');
+    const applyStatus = (s) => {
+        // Feed/category default view is Unread when no status is present.
+        if (s === 'read') out.set('read_only', 'true');
+        else if (s === 'starred') out.set('starred_only', 'true');
+        else if (s === 'all') { /* no flag */ }
+        else out.set('unread_only', 'true');
+    };
+    const feed = pathname.match(/^\/feeds\/(\d+)\/entries/);
+    const cat = pathname.match(/^\/categories\/(\d+)\/entries/);
+    if (pathname === '/') out.set('unread_only', 'true');
+    else if (pathname === '/entries') { /* All — no flag */ }
+    else if (pathname === '/entries/read') out.set('read_only', 'true');
+    else if (pathname === '/entries/starred') out.set('starred_only', 'true');
+    else if (pathname === '/entries/summarized') out.set('has_summary', 'true');
+    else if (feed) { out.set('feed_id', feed[1]); applyStatus(status); }
+    else if (cat) { out.set('category_id', cat[1]); applyStatus(status); }
+    return out.toString();
+}
+
+// Reflect the resolved neighbor ids onto the buttons, but only while they
+// still describe the entry currently in the pane (guards against a stale
+// fetch landing after the user moved on). Anything else leaves both
+// buttons disabled.
+function applyNeighborButtons() {
+    const prevBtn = document.querySelector('[data-pane-prev]');
+    const nextBtn = document.querySelector('[data-pane-next]');
+    const open = currentPaneEntryId();
+    const valid = open != null && neighborState.entryId === open;
+    if (prevBtn) prevBtn.disabled = !(valid && neighborState.prevId != null);
+    if (nextBtn) nextBtn.disabled = !(valid && neighborState.nextId != null);
+}
+
+async function resolveNeighbors(entryId) {
+    const params = currentEntryFilterParams();
+    const url = `/api/entries/${entryId}/neighbors${params ? `?${params}` : ''}`;
+    try {
+        const resp = await fetch(url, { credentials: 'same-origin' });
+        if (!resp.ok) return;
+        const data = await resp.json();
+        neighborState = { entryId, prevId: data.prev_id, nextId: data.next_id };
+        applyNeighborButtons();
+    } catch {}
+}
+
+// Re-resolve whenever the pane settles on a different entry. Disable the
+// buttons up-front so a slow fetch never leaves a stale direction live.
+let lastResolvedPaneId = null;
+function maybeResolveNeighbors() {
+    const id = currentPaneEntryId();
+    if (id === lastResolvedPaneId) return;
+    lastResolvedPaneId = id;
+    if (id == null) {
+        neighborState = { entryId: null, prevId: null, nextId: null };
+        applyNeighborButtons();
+        return;
+    }
+    applyNeighborButtons();
+    resolveNeighbors(id);
+}
+
+// Open the neighbor in `direction` ('prev' | 'next'). Prefers clicking the
+// matching list row's link when that entry is already loaded — that path
+// also keeps the keyboard list selection in sync — and falls back to a
+// direct fragment swap for neighbors beyond the loaded page. If the
+// pane's neighbors haven't resolved yet, resolve then navigate.
+function navigateNeighbor(direction) {
+    const open = currentPaneEntryId();
+    if (open == null) return;
+    if (neighborState.entryId !== open) {
+        resolveNeighbors(open).then(() => doNavigateNeighbor(direction));
+        return;
+    }
+    doNavigateNeighbor(direction);
+}
+
+function doNavigateNeighbor(direction) {
+    const id = direction === 'next' ? neighborState.nextId : neighborState.prevId;
+    if (id == null) return;
+    const link = document.querySelector(
+        `[data-entry-row][data-entry-id="${id}"] a[data-swap="#reading-pane"]`
+    );
+    if (link) { link.click(); return; }
+    performSwap(`/entries/${id}/fragment`, { method: 'GET' }, '#reading-pane');
+}
+
+function installNeighborNav() {
+    document.addEventListener('click', (event) => {
+        if (event.button !== 0) return;
+        if (event.target.closest('[data-pane-prev]')) {
+            event.preventDefault();
+            navigateNeighbor('prev');
+        } else if (event.target.closest('[data-pane-next]')) {
+            event.preventDefault();
+            navigateNeighbor('next');
+        }
+    });
+    document.addEventListener('rdrs:swap-complete', maybeResolveNeighbors);
+    // Resolve once on load so a `?entry=` deep-link gets live buttons too.
+    maybeResolveNeighbors();
+}
+installNeighborNav();
+
 // Process `<template data-flash data-level="success|error|info|warning">message</template>`
 // blocks in a swap response. Each one becomes a toast on the page-level
 // `<rdrs-flash>` element (mounted by _entries_layout.html). Used for
@@ -407,8 +532,8 @@ document.addEventListener('rdrs:swap-complete', () => applyTimeTooltips());
 // register additional entries — every shortcut the keyboard handler
 // recognizes is listed here, grouped by where it applies.
 const KB_SHORTCUTS = [
-    { group: 'Entry list', key: 'j', desc: 'Next entry' },
-    { group: 'Entry list', key: 'k', desc: 'Previous entry' },
+    { group: 'Entry list', key: 'j', desc: 'Next entry (opens it when the reading pane is open)' },
+    { group: 'Entry list', key: 'k', desc: 'Previous entry (opens it when the reading pane is open)' },
     { group: 'Entry list', key: 'Enter', desc: 'Open selected entry' },
     { group: 'Entry list', key: 's', desc: 'Toggle star' },
     { group: 'Entry list', key: 'u / r', desc: 'Toggle read / unread' },
@@ -515,8 +640,20 @@ function installEntriesKeyboard() {
         if (e.target.matches('input, textarea, select')) return;
         if (e.metaKey || e.ctrlKey || e.altKey) return;
         switch (e.key) {
-            case 'j': e.preventDefault(); move(1); break;
-            case 'k': e.preventDefault(); move(-1); break;
+            case 'j':
+                e.preventDefault();
+                // With the reading pane open, j/k navigate it (open the
+                // next/previous entry across the current filter, even past
+                // the loaded page) instead of only moving the list cursor;
+                // the list selection follows when the neighbor is loaded.
+                if (currentPaneEntryId() != null) navigateNeighbor('next');
+                else move(1);
+                break;
+            case 'k':
+                e.preventDefault();
+                if (currentPaneEntryId() != null) navigateNeighbor('prev');
+                else move(-1);
+                break;
             case 'Enter': {
                 const current = activeRow();
                 if (!current) return;

--- a/templates/_reading_pane.html
+++ b/templates/_reading_pane.html
@@ -8,10 +8,10 @@
    Empty-state placeholders MUST NOT carry the class, or mobile will
    trap users behind a blank pane. #}
 <div id="reading-pane" class="reading-pane reading-pane-active">
+    {# Pane toolbar. On mobile it also holds the Back affordance (left); the
+       prev/next nav sits at the right on every viewport. #}
     <div class="reading-pane-back">
         <button type="button" class="reading-pane-back-link" data-pane-back data-testid="reading-pane-back">← Back to list</button>
-    </div>
-    <div class="reading-pane-content">
         {# Prev/Next navigation across the current filtered list. Rendered
            disabled; app.js resolves neighbours via
            `GET /api/entries/{id}/neighbors` after the pane opens and enables
@@ -22,6 +22,8 @@
             <button type="button" class="reading-pane-nav-btn" data-pane-prev data-testid="reading-pane-prev" disabled>‹ Previous</button>
             <button type="button" class="reading-pane-nav-btn" data-pane-next data-testid="reading-pane-next" disabled>Next ›</button>
         </nav>
+    </div>
+    <div class="reading-pane-content">
         <h1 class="reading-pane-title" data-testid="reading-pane-title">
             {% if let Some(link) = pane.link.as_ref() %}<a href="{{ link }}" target="_blank" rel="noopener noreferrer">{{ pane.title }}</a>{% else %}{{ pane.title }}{% endif %}
         </h1>

--- a/templates/_reading_pane.html
+++ b/templates/_reading_pane.html
@@ -12,6 +12,16 @@
         <button type="button" class="reading-pane-back-link" data-pane-back data-testid="reading-pane-back">← Back to list</button>
     </div>
     <div class="reading-pane-content">
+        {# Prev/Next navigation across the current filtered list. Rendered
+           disabled; app.js resolves neighbours via
+           `GET /api/entries/{id}/neighbors` after the pane opens and enables
+           whichever direction has an adjacent entry. "Previous" = newer
+           (up the list), "Next" = older (down the list), matching the
+           list's published-desc order. #}
+        <nav class="reading-pane-nav" aria-label="Entry navigation">
+            <button type="button" class="reading-pane-nav-btn" data-pane-prev data-testid="reading-pane-prev" disabled>‹ Previous</button>
+            <button type="button" class="reading-pane-nav-btn" data-pane-next data-testid="reading-pane-next" disabled>Next ›</button>
+        </nav>
         <h1 class="reading-pane-title" data-testid="reading-pane-title">
             {% if let Some(link) = pane.link.as_ref() %}<a href="{{ link }}" target="_blank" rel="noopener noreferrer">{{ pane.title }}</a>{% else %}{{ pane.title }}{% endif %}
         </h1>


### PR DESCRIPTION
## Summary

Reconnects the orphaned `GET /api/entries/{id}/neighbors` endpoint (optimized in #241, but with no frontend caller since the SSR-first redesign) to the UI.

The reading pane now has **Previous / Next** buttons. Once an entry opens, the frontend resolves the adjacent entry ids from the neighbors endpoint — scoped to the **current list filter** — and swaps the pane to them. With the pane open, the existing **`j` / `k`** keys navigate it (open the next/previous entry) instead of only moving the list cursor; the list selection follows when the neighbour is a loaded row.

Keybinding chosen over `n`/`p`: this app already uses `j`/`k` for "next/previous entry", so navigating the open pane with the same keys (NetNewsWire/Reeder-style "selection follows reading") avoids two parallel mechanisms.

## Behaviour notes

- Navigation resolves order from the DB, so it **crosses pagination boundaries** the in-memory list hasn't loaded yet.
- It **honours the active filter**: e.g. in the Unread inbox, opening an entry marks it read, so "Previous" skips it and lands on the next still-unread entry (the same set the list filters to).
- Buttons render disabled and enable per direction once neighbours resolve; the newest entry has Previous disabled, the oldest has Next disabled.

## Changes

- `templates/_reading_pane.html`: disabled prev/next nav buttons with testids.
- `static/css/app.css`: promote `.reading-pane-nav` styles to all viewports; drop the dead mobile-only rules left from the removed CSR nav.
- `static/js/app.js`: filter-aware neighbour resolution, button enable/disable, click + `j`/`k` wiring, keyboard-help text.
- `e2e/features/reading.feature` + `entries.steps.js`: cover button and keyboard navigation, the unread-filter skip behaviour, and the newest/oldest boundary disabled states.

## Testing

- `cargo nextest run` — 742 passed
- `cargo clippy -- -D warnings` — clean
- Full Playwright BDD e2e suite — 73 passed (incl. 5 new scenarios, stress-tested with `--repeat-each=3` in parallel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)