### PR TITLE
fix(settings): reflect runtime config and merge into one table

### DIFF
--- a/src/handlers/pages.rs
+++ b/src/handlers/pages.rs
@@ -1173,10 +1173,13 @@ pub async fn settings_page(
             title: "Settings",
             git_version: crate::GIT_VERSION,
             layout,
+            database_url: state.config.database_url.clone(),
+            server_port: state.config.server_port,
             user_agent: state.config.user_agent.clone(),
             user_agent_is_default,
             signup_enabled: state.config.signup_enabled,
             multi_user_enabled: state.config.multi_user_enabled,
+            image_proxy_secret_generated: state.config.image_proxy_secret_generated,
         },
     )
 }
@@ -2126,10 +2129,13 @@ pub struct SettingsTemplate {
     pub title: &'static str,
     pub git_version: &'static str,
     pub layout: AppLayoutContext,
+    pub database_url: String,
+    pub server_port: u16,
     pub user_agent: String,
     pub user_agent_is_default: bool,
     pub signup_enabled: bool,
     pub multi_user_enabled: bool,
+    pub image_proxy_secret_generated: bool,
 }
 
 impl IntoResponse for SettingsTemplate {

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -11,67 +11,14 @@
                     <p class="muted">Version: <code>{{ git_version }}</code></p>
 
                     <h2>Configuration</h2>
-                    <p class="muted">These settings are configured via environment variables and cannot be changed at runtime.</p>
-
-                    <h3>Server</h3>
-                    <table>
-                        <tbody>
-                            <tr>
-                                <th class="settings-th">Database</th>
-                                <td><code>{{ database_url }}</code></td>
-                            </tr>
-                            <tr>
-                                <th class="settings-th">Port</th>
-                                <td><code>{{ server_port }}</code></td>
-                            </tr>
-                        </tbody>
-                    </table>
-
-                    <h3>HTTP Client</h3>
-                    <table>
-                        <tbody>
-                            <tr>
-                                <th class="settings-th">User Agent</th>
-                                <td>
-                                    <code>{{ user_agent }}</code>
-                                    <span class="muted">({% if user_agent_is_default %}default{% else %}custom{% endif %})</span>
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
-
-                    <h3>User Registration</h3>
-                    <table>
-                        <tbody>
-                            <tr>
-                                <th class="settings-th">Signup Enabled</th>
-                                <td>{% if signup_enabled %}<span class="success-text">Yes</span>{% else %}<span class="muted">No</span>{% endif %}</td>
-                            </tr>
-                            <tr>
-                                <th class="settings-th">Multi-User Mode</th>
-                                <td>{% if multi_user_enabled %}<span class="success-text">Yes</span>{% else %}<span class="muted">No</span>{% endif %}</td>
-                            </tr>
-                        </tbody>
-                    </table>
-
-                    <h3>Image Proxy</h3>
-                    <table>
-                        <tbody>
-                            <tr>
-                                <th class="settings-th">Secret</th>
-                                <td>{% if image_proxy_secret_generated %}<span class="muted">Auto-generated</span>{% else %}<span class="success-text">Configured</span>{% endif %}</td>
-                            </tr>
-                        </tbody>
-                    </table>
-
-                    <h3>Environment Variables</h3>
-                    <p class="muted">Configure these environment variables to customize RDRS:</p>
+                    <p class="muted">These settings are configured via environment variables and cannot be changed at runtime. The current column reflects the running instance.</p>
                     <table class="mobile-cards-settings">
                         <thead>
                             <tr>
                                 <th class="settings-th">Variable</th>
                                 <th class="settings-th">Description</th>
                                 <th class="settings-th">Default</th>
+                                <th class="settings-th">Current</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -79,31 +26,40 @@
                                 <td><code>DATABASE_URL</code></td>
                                 <td data-label="Description">SQLite database file path</td>
                                 <td data-label="Default"><code>rdrs.sqlite3</code></td>
+                                <td data-label="Current"><code>{{ database_url }}</code></td>
                             </tr>
                             <tr>
                                 <td><code>SERVER_PORT</code></td>
                                 <td data-label="Description">HTTP server port</td>
                                 <td data-label="Default"><code>3000</code></td>
+                                <td data-label="Current"><code>{{ server_port }}</code></td>
                             </tr>
                             <tr>
                                 <td><code>USER_AGENT</code></td>
                                 <td data-label="Description">User agent for HTTP requests</td>
                                 <td data-label="Default"><code>RDRS/{version} (...)</code></td>
+                                <td data-label="Current">
+                                    <code>{{ user_agent }}</code>
+                                    <span class="muted">({% if user_agent_is_default %}default{% else %}custom{% endif %})</span>
+                                </td>
                             </tr>
                             <tr>
                                 <td><code>SIGNUP_ENABLED</code></td>
                                 <td data-label="Description">Allow new user registration</td>
                                 <td data-label="Default"><code>false</code></td>
+                                <td data-label="Current">{% if signup_enabled %}<span class="success-text">Yes</span>{% else %}<span class="muted">No</span>{% endif %}</td>
                             </tr>
                             <tr>
                                 <td><code>MULTI_USER_ENABLED</code></td>
                                 <td data-label="Description">Allow multiple users</td>
                                 <td data-label="Default"><code>false</code></td>
+                                <td data-label="Current">{% if multi_user_enabled %}<span class="success-text">Yes</span>{% else %}<span class="muted">No</span>{% endif %}</td>
                             </tr>
                             <tr>
                                 <td><code>IMAGE_PROXY_SECRET</code></td>
                                 <td data-label="Description">Secret key for image proxy URLs</td>
                                 <td data-label="Default"><em>(auto-generated)</em></td>
+                                <td data-label="Current">{% if image_proxy_secret_generated %}<span class="muted">Auto-generated</span>{% else %}<span class="success-text">Configured</span>{% endif %}</td>
                             </tr>
                         </tbody>
                     </table>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -13,6 +13,20 @@
                     <h2>Configuration</h2>
                     <p class="muted">These settings are configured via environment variables and cannot be changed at runtime.</p>
 
+                    <h3>Server</h3>
+                    <table>
+                        <tbody>
+                            <tr>
+                                <th class="settings-th">Database</th>
+                                <td><code>{{ database_url }}</code></td>
+                            </tr>
+                            <tr>
+                                <th class="settings-th">Port</th>
+                                <td><code>{{ server_port }}</code></td>
+                            </tr>
+                        </tbody>
+                    </table>
+
                     <h3>HTTP Client</h3>
                     <table>
                         <tbody>
@@ -36,6 +50,16 @@
                             <tr>
                                 <th class="settings-th">Multi-User Mode</th>
                                 <td>{% if multi_user_enabled %}<span class="success-text">Yes</span>{% else %}<span class="muted">No</span>{% endif %}</td>
+                            </tr>
+                        </tbody>
+                    </table>
+
+                    <h3>Image Proxy</h3>
+                    <table>
+                        <tbody>
+                            <tr>
+                                <th class="settings-th">Secret</th>
+                                <td>{% if image_proxy_secret_generated %}<span class="muted">Auto-generated</span>{% else %}<span class="success-text">Configured</span>{% endif %}</td>
                             </tr>
                         </tbody>
                     </table>

--- a/tests/pages_test.rs
+++ b/tests/pages_test.rs
@@ -390,9 +390,12 @@ async fn test_settings_page_renders_ssr_content() {
 #[tokio::test]
 async fn test_settings_page_reflects_custom_config() {
     let config = Config {
+        database_url: "/data/custom.sqlite3".to_string(),
+        server_port: 8080,
         user_agent: "Custom-Agent/2.0".to_string(),
         signup_enabled: true,
         multi_user_enabled: true,
+        image_proxy_secret_generated: false,
         ..default_test_config()
     };
     let app = create_test_app(config);
@@ -405,11 +408,36 @@ async fn test_settings_page_reflects_custom_config() {
 
     assert!(body.contains("Custom-Agent/2.0"));
     assert!(body.contains("(custom)"));
+    // Server section reflects the actual runtime database path and port.
+    assert!(body.contains("/data/custom.sqlite3"));
+    assert!(body.contains("8080"));
+    // Image proxy secret is configured (not auto-generated).
+    assert!(body.contains("Configured"));
+    assert!(!body.contains(">Auto-generated<"));
     // Both Yes flags rendered for signup + multi-user.
     let yes_count = body
         .matches("<span class=\"success-text\">Yes</span>")
         .count();
     assert!(yes_count >= 2, "expected >=2 Yes badges, got {yes_count}");
+}
+
+#[tokio::test]
+async fn test_settings_page_reflects_auto_generated_image_proxy_secret() {
+    let config = Config {
+        image_proxy_secret_generated: true,
+        ..default_test_config()
+    };
+    let app = create_test_app(config);
+    setup_users(&app.db).await;
+    login(&app.server, "admin").await;
+
+    let response = app.server.get("/settings").await;
+    response.assert_status_ok();
+    let body = response.text();
+
+    // Image proxy secret status reflects the auto-generated runtime state.
+    assert!(body.contains("Auto-generated"));
+    assert!(!body.contains(">Configured<"));
 }
 
 #[tokio::test]

--- a/tests/pages_test.rs
+++ b/tests/pages_test.rs
@@ -379,12 +379,19 @@ async fn test_settings_page_renders_ssr_content() {
     assert!(!body.contains("<rdrs-settings-page>"));
     assert!(!body.contains("/static/js/pages/settings.js"));
 
-    // Server-rendered content from default config.
+    // Server-rendered content from default config: a single Configuration
+    // table listing each env var with its description, default, and current
+    // value (Configuration + Environment Variables sections are merged).
     assert!(body.contains("<h1>Settings</h1>"));
     assert!(body.contains("Configuration"));
-    assert!(body.contains("User Agent"));
-    assert!(body.contains("Signup Enabled"));
-    assert!(body.contains("Environment Variables"));
+    assert!(body.contains("DATABASE_URL"));
+    assert!(body.contains("USER_AGENT"));
+    assert!(body.contains("SIGNUP_ENABLED"));
+    assert!(body.contains("IMAGE_PROXY_SECRET"));
+    // The "Current" column header surfaces the running instance's values.
+    assert!(body.contains("Current"));
+    // The old standalone "Environment Variables" sub-heading is gone.
+    assert!(!body.contains("Environment Variables"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

The settings page had two problems around how it surfaced configuration:

1. **Bug:** `IMAGE_PROXY_SECRET` always rendered `(auto-generated)` even when it was set. That text was a static cell in the documentation table and was never bound to the actual runtime state (`Config::image_proxy_secret_generated`), which `SettingsTemplate` did not carry.
2. **Redundancy:** every env var was presented twice — grouped status sections (Server / HTTP Client / User Registration / Image Proxy) showed live values, while a separate "Environment Variables" table documented the same six variables' descriptions and defaults.

## Changes

- Plumb the real runtime config into `SettingsTemplate` (`database_url`, `server_port`, `image_proxy_secret_generated`).
- Merge both representations into a single **Configuration** table with columns **Variable / Description / Default / Current**. Each variable shows its description, default, and running value in one row:
  - `DATABASE_URL` / `SERVER_PORT` → actual value
  - `USER_AGENT` → actual value + `(default)`/`(custom)`
  - `SIGNUP_ENABLED` / `MULTI_USER_ENABLED` → `Yes`/`No`
  - `IMAGE_PROXY_SECRET` → `Configured`/`Auto-generated` (never the secret itself)
- Reuses the existing `mobile-cards-settings` responsive pattern, so the 4-column table folds into stacked labeled cards on mobile — no new CSS.

## Testing

- Added `test_settings_page_reflects_auto_generated_image_proxy_secret` and extended `test_settings_page_reflects_custom_config` to assert the Current-column values for both secret states plus the database path and port.
- Updated `test_settings_page_renders_ssr_content` for the merged single-table structure.
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and full `cargo nextest run` (743 passed) all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)