### PR TITLE
feat(empty-state): unify empty states on an editorial-modern style

### DIFF
--- a/docs/superpowers/specs/2026-05-25-unify-empty-state-style-design.md
+++ b/docs/superpowers/specs/2026-05-25-unify-empty-state-style-design.md
@@ -1,0 +1,111 @@
+# Unify empty-state style
+
+Date: 2026-05-25
+Status: Approved
+
+## Problem
+
+Empty states across the app are visually inconsistent. There are effectively
+two styles at three scales:
+
+- **Fancy editorial** (`.search-status`): centered italic Source Serif with an
+  `⁂` asterism mark and generous whitespace — used only on `/search`.
+- **Semi-fancy** (`.reading-pane-empty`): centered italic muted, no mark —
+  reading pane only.
+- **Minimal** (`.muted` plain text, sometimes inside a `<td>`): the entries
+  list, `/feeds`, `/categories`, `/admin`, and `/statistics` sub-sections.
+
+The goal is a single, modern, consistent empty-state language.
+
+## Decision
+
+Adopt the **editorial-modern ("D")** direction: a thin gold accent rule above a
+serif heading with an italic muted subtext. **No icon, no card, no button** —
+simple elements only. The ornate `⁂` asterism is dropped in favor of a clean
+40×3px accent rule.
+
+Two tiers of the same family, so the system reads as one voice across scales:
+
+### Tier 1 — `.empty-state` (full-surface)
+
+Used on the entries-family list pages and `/search`. Structure:
+
+```
+        ▬               accent rule  (40×3px, --color-accent, opacity .8)
+   <heading>            serif, --font-2xl, weight 600
+   <subtext>            italic, muted, --font-lg, line-height 1.6
+```
+
+Centered, `max-width: 30rem`, top whitespace via `margin`/`padding-top`.
+Carries an `.empty-state-kbd` inline element (migrated from `.search-status-kbd`)
+for keyboard hints.
+
+### Tier 2 — `.empty-state-compact` (narrow surfaces)
+
+Used in the reading pane, table cells (`/feeds`, `/categories`, `/admin`), and
+`/statistics` sub-sections — places where a full editorial block would break the
+layout. A single centered italic muted line (`--font-base`), no rule, no heading.
+This is the natural collapse of Tier 1 into tight space.
+
+## Copy
+
+### Tier 1 (heading + subtext)
+
+| Location | Heading | Subtext |
+|----------|---------|---------|
+| Unread cleared | All caught up | You've read every unread entry — new items land here as your feeds refresh. |
+| All entries empty | Nothing to read yet | Subscribe to a few feeds and their entries will gather here. |
+| Read empty | No read entries yet | Entries stay here once you've opened and read them. |
+| Starred empty | No starred entries | Star an entry and it'll wait for you here. |
+| Summarized empty | No summaries yet | Entries you summarize are collected on this page. |
+| Category empty | Nothing in this category | The feeds in this category haven't brought in any entries yet. |
+| Feed empty | Nothing in this feed | This feed hasn't published anything yet, or it's still syncing. |
+| Search — initial | Search your library | Type a keyword and press `Enter` to find entries by title or content. |
+| Search — no results | No matches | Nothing matched "{{ q }}". Try another keyword or check the spelling. |
+
+### Tier 2 (single line)
+
+| Location | Line |
+|----------|------|
+| Reading pane | Select an entry from the list to start reading. |
+| Feeds table | No feeds yet — add one using the form above. |
+| Categories table | No categories yet — create one using the form above. |
+| Admin users | No users found. |
+| Statistics (×2) | No entries in this period. |
+
+## Implementation surface
+
+- **`static/css/app.css`** — replace `.search-status` / `.search-status::before`
+  / `.search-status-kbd` with the generic `.empty-state` / `.empty-state::before`
+  / `.empty-state-kbd`; add `.empty-state-compact`. Fold `.reading-pane-empty`'s
+  text styling onto the compact class (keep its flex vertical-centering wrapper).
+- **`src/handlers/pages.rs`** — split `EntriesLayoutContext.empty_message:
+  &'static str` into `empty_title: &'static str` + `empty_detail: &'static str`.
+  Update all 8 construction sites with the copy above.
+- **Templates**
+  - `_entries_layout.html` — list empty state renders Tier 1
+    (`empty_title` + `empty_detail`); the reading-pane placeholder renders Tier 2.
+  - `search.html` — both states render Tier 1; `.search-status*` → `.empty-state*`.
+  - `feeds.html`, `categories.html`, `admin.html` — `<td colspan>` empty rows
+    render Tier 2.
+  - `statistics.html` — the two `No entries in this period` placeholders render
+    Tier 2.
+- **Tests**
+  - `tests/pages_test.rs` — update assertions tied to old copy / `.search-status`;
+    assert new headings + `.empty-state` markup.
+  - Playwright BDD — the `search-empty` testid stays; update any asserted text
+    (e.g. "Nothing matched") to the new copy.
+
+## Out of scope
+
+- No icons, cards, or CTA buttons.
+- No new build tooling (vanilla CSS only).
+- `IMAGE_PROXY_SECRET` and other settings work is unrelated.
+
+## Testing strategy
+
+- Unit/integration (`cargo nextest run`): each list page renders its heading +
+  detail; search renders both states; `.empty-state` present, old `.search-status`
+  absent.
+- e2e (Playwright BDD): search no-result path shows the new copy under the
+  existing `search-empty` testid.

--- a/docs/superpowers/specs/2026-05-25-unify-empty-state-style-design.md
+++ b/docs/superpowers/specs/2026-05-25-unify-empty-state-style-design.md
@@ -26,9 +26,10 @@ simple elements only. The ornate `⁂` asterism is dropped in favor of a clean
 
 Two tiers of the same family, so the system reads as one voice across scales:
 
-### Tier 1 — `.empty-state` (full-surface)
+### Tier 1 — `.empty-state` (full-surface, editorial)
 
-Used on the entries-family list pages and `/search`. Structure:
+Used on **`/search` only** — a dedicated destination page where the editorial
+treatment reads as intentional, not as an in-context surprise. Structure:
 
 ```
         ▬               accent rule  (40×3px, --color-accent, opacity .8)
@@ -39,6 +40,22 @@ Used on the entries-family list pages and `/search`. Structure:
 Centered, `max-width: 30rem`, top whitespace via `margin`/`padding-top`.
 Carries an `.empty-state-kbd` inline element (migrated from `.search-status-kbd`)
 for keyboard hints.
+
+### Tier 1-quiet — `.empty-state-quiet` (entries-family list views)
+
+Used by the entries-family list pages (unread / all / read / starred /
+summarized / category / feed). An empty list is an *in-context* condition — you
+navigated into a view that happens to have no items — not an announcement, so
+the loud accent rule + large heading of Tier 1 is wrong here. Quieter structure,
+**no accent rule**:
+
+```
+   <heading>            serif, --font-lg, weight 500, --color-text-secondary
+   <subtext>            italic, muted, --font-sm, line-height 1.6
+```
+
+Centered, `max-width: 30rem`. Keeps the same heading + detail copy as the plan
+below, just rendered restrained.
 
 ### Tier 2 — `.empty-state-compact` (narrow surfaces)
 
@@ -77,13 +94,14 @@ This is the natural collapse of Tier 1 into tight space.
 
 - **`static/css/app.css`** — replace `.search-status` / `.search-status::before`
   / `.search-status-kbd` with the generic `.empty-state` / `.empty-state::before`
-  / `.empty-state-kbd`; add `.empty-state-compact`. Fold `.reading-pane-empty`'s
-  text styling onto the compact class (keep its flex vertical-centering wrapper).
+  / `.empty-state-kbd`; add `.empty-state-compact` and `.empty-state-quiet*`. Fold
+  `.reading-pane-empty`'s text styling onto the compact class (keep its flex
+  vertical-centering wrapper).
 - **`src/handlers/pages.rs`** — split `EntriesLayoutContext.empty_message:
   &'static str` into `empty_title: &'static str` + `empty_detail: &'static str`.
   Update all 8 construction sites with the copy above.
 - **Templates**
-  - `_entries_layout.html` — list empty state renders Tier 1
+  - `_entries_layout.html` — list empty state renders Tier 1-quiet
     (`empty_title` + `empty_detail`); the reading-pane placeholder renders Tier 2.
   - `search.html` — both states render Tier 1; `.search-status*` → `.empty-state*`.
   - `feeds.html`, `categories.html`, `admin.html` — `<td colspan>` empty rows

--- a/src/handlers/pages.rs
+++ b/src/handlers/pages.rs
@@ -104,7 +104,10 @@ pub struct FilterTab {
 pub struct EntriesLayoutContext {
     pub active: &'static str,
     pub description: Option<String>,
-    pub empty_message: &'static str,
+    /// Empty-state heading (Tier-1 `.empty-state-title`).
+    pub empty_title: &'static str,
+    /// Empty-state subtext (Tier-1 `.empty-state-text`).
+    pub empty_detail: &'static str,
     pub path: String,
     /// Render the All/Read/Starred/Summarized tab bar above the list. True
     /// for the 4 entries-tabs (`active = "all" | "read" | "starred" |
@@ -596,7 +599,9 @@ pub async fn unread_page(
             entries_layout: EntriesLayoutContext {
                 active: "unread",
                 description: None,
-                empty_message: "No unread entries — nice work.",
+                empty_title: "All caught up",
+                empty_detail:
+                    "You've read every unread entry — new items land here as your feeds refresh.",
                 path: "/".to_string(),
                 show_tab_bar: false,
                 mark_as_read_scope: Some("user/-/state/com.google/reading-list".to_string()),
@@ -1094,7 +1099,8 @@ pub async fn entries_page(
             entries_layout: EntriesLayoutContext {
                 active: "all",
                 description: None,
-                empty_message: "No entries.",
+                empty_title: "Nothing to read yet",
+                empty_detail: "Subscribe to a few feeds and their entries will gather here.",
                 path: "/entries".to_string(),
                 show_tab_bar: true,
                 mark_as_read_scope: Some("user/-/state/com.google/reading-list".to_string()),
@@ -1249,7 +1255,8 @@ pub async fn read_entries_page(
             entries_layout: EntriesLayoutContext {
                 active: "read",
                 description: None,
-                empty_message: "No read entries.",
+                empty_title: "No read entries yet",
+                empty_detail: "Entries stay here once you've opened and read them.",
                 path: "/entries/read".to_string(),
                 show_tab_bar: true,
                 mark_as_read_scope: None,
@@ -1330,7 +1337,8 @@ pub async fn starred_entries_page(
             entries_layout: EntriesLayoutContext {
                 active: "starred",
                 description: None,
-                empty_message: "No starred entries.",
+                empty_title: "No starred entries",
+                empty_detail: "Star an entry and it'll wait for you here.",
                 path: "/entries/starred".to_string(),
                 show_tab_bar: true,
                 mark_as_read_scope: None,
@@ -1411,7 +1419,8 @@ pub async fn summarized_entries_page(
             entries_layout: EntriesLayoutContext {
                 active: "summarized",
                 description: None,
-                empty_message: "No summarized entries.",
+                empty_title: "No summaries yet",
+                empty_detail: "Entries you summarize are collected on this page.",
                 path: "/entries/summarized".to_string(),
                 show_tab_bar: true,
                 mark_as_read_scope: None,
@@ -1550,7 +1559,8 @@ pub async fn category_entries_page(
         entries_layout: EntriesLayoutContext {
             active: "",
             description: None,
-            empty_message: "No entries in this category.",
+            empty_title: "Nothing in this category",
+            empty_detail: "The feeds in this category haven't brought in any entries yet.",
             path,
             show_tab_bar: false,
             mark_as_read_scope,
@@ -2003,7 +2013,8 @@ pub async fn feed_entries_page(
         entries_layout: EntriesLayoutContext {
             active: "",
             description: None,
-            empty_message: "No entries in this feed.",
+            empty_title: "Nothing in this feed",
+            empty_detail: "This feed hasn't published anything yet, or it's still syncing.",
             path,
             show_tab_bar: false,
             mark_as_read_scope,

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -1349,6 +1349,32 @@ dialog::backdrop {
     padding: var(--space-8) var(--space-4);
 }
 
+/* Quiet list empty-state. For the entries-family list views, where an empty
+   list is an in-context condition — not an announcement. No accent rule; a
+   smaller secondary-color heading over a small muted detail line, so it reads
+   as "nothing here right now" rather than a page banner. The full Tier-1
+   `.empty-state` (accent rule + large serif) is reserved for /search. */
+.empty-state-quiet {
+    text-align: center;
+    max-width: 30rem;
+    margin: var(--space-10) auto var(--space-8);
+}
+.empty-state-quiet-title {
+    font-family: var(--font-display);
+    font-size: var(--font-lg);
+    font-weight: 500;
+    color: var(--color-text-secondary);
+    margin: 0 0 var(--space-2);
+}
+.empty-state-quiet-text {
+    font-family: var(--font-body);
+    font-style: italic;
+    font-size: var(--font-sm);
+    color: var(--color-text-muted);
+    line-height: 1.6;
+    margin: 0;
+}
+
 /* ===== /search page ===== */
 /* Search form follows the standard form-group / button conventions used on
    /categories, /feeds, /user-settings. No custom borderless input; no custom

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -480,10 +480,6 @@ code {
     align-items: center;
     justify-content: center;
     height: 100%;
-    color: var(--color-text-muted);
-    font-family: var(--font-body);
-    font-size: var(--font-lg);
-    font-style: italic;
 }
 
 /* Reading-pane toolbar. Holds the prev/next nav on every viewport
@@ -1286,34 +1282,46 @@ dialog::backdrop {
     color: var(--color-text-muted);
 }
 
-/* Editorial empty-state used by /search (and any future SSR list page that
-   wants the same manuscript-aside tone). Italic Source Serif, generous
-   leading whitespace, soft drop-shadowed asterism mark above. */
-.search-status {
-    font-family: var(--font-body);
-    font-style: italic;
-    font-size: var(--font-lg);
-    color: var(--color-text-muted);
+/* Unified empty-state, editorial-modern ("D"). A thin gold accent rule above a
+   serif heading with an italic muted subtext — no icon, no card, no button.
+   Tier 1 (`.empty-state`) is the full-surface form used by the entries-family
+   list pages and /search. */
+.empty-state {
     text-align: center;
+    max-width: 30rem;
     margin: var(--space-12) auto var(--space-8);
-    max-width: 28rem;
-    line-height: 1.6;
     position: relative;
     padding-top: var(--space-8);
 }
-.search-status::before {
-    content: "⁂";
+.empty-state::before {
+    content: "";
     position: absolute;
     top: 0;
     left: 50%;
     transform: translateX(-50%);
-    font-style: normal;
-    font-size: var(--font-xl);
-    color: var(--color-accent);
-    letter-spacing: 0.2em;
-    opacity: 0.6;
+    width: 40px;
+    height: 3px;
+    border-radius: 2px;
+    background: var(--color-accent);
+    opacity: 0.8;
 }
-.search-status-kbd {
+.empty-state-title {
+    font-family: var(--font-display);
+    font-size: var(--font-2xl);
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    color: var(--color-text);
+    margin: 0 0 var(--space-3);
+}
+.empty-state-text {
+    font-family: var(--font-body);
+    font-style: italic;
+    font-size: var(--font-lg);
+    color: var(--color-text-muted);
+    line-height: 1.6;
+    margin: 0;
+}
+.empty-state-kbd {
     display: inline-block;
     font-family: var(--font-mono);
     font-style: normal;
@@ -1325,6 +1333,20 @@ dialog::backdrop {
     border: 1px solid var(--color-border);
     border-radius: var(--radius-sm);
     box-shadow: 0 1px 0 var(--color-border);
+}
+
+/* Tier 2 — compact single-line form for narrow surfaces (reading pane, table
+   cells, stats sub-sections) where a full editorial block would break the
+   layout. The natural collapse of Tier 1 into tight space. */
+.empty-state-compact {
+    text-align: center;
+    font-family: var(--font-body);
+    font-style: italic;
+    font-size: var(--font-base);
+    color: var(--color-text-muted);
+    line-height: 1.6;
+    margin: 0;
+    padding: var(--space-8) var(--space-4);
 }
 
 /* ===== /search page ===== */

--- a/templates/_entries_layout.html
+++ b/templates/_entries_layout.html
@@ -48,7 +48,10 @@
                     </div>
                     <div class="list-pane-body" data-entries-list>
                         {% if entries.is_empty() %}
-                            <p class="muted" style="padding: var(--space-4);">{{ entries_layout.empty_message }}</p>
+                            <div class="empty-state">
+                                <h2 class="empty-state-title">{{ entries_layout.empty_title }}</h2>
+                                <p class="empty-state-text">{{ entries_layout.empty_detail }}</p>
+                            </div>
                         {% else %}
                             {% for r in entries %}{% include "_entry_row.html" %}{% endfor %}
                             {% if let Some(after) = next_cursor %}
@@ -77,7 +80,7 @@
                 {% if let Some(pane) = reading_pane.as_ref() %}
                     {% include "_reading_pane.html" %}
                 {% else %}
-                    <div id="reading-pane" class="reading-pane reading-pane-empty"><p>Select an entry to read.</p></div>
+                    <div id="reading-pane" class="reading-pane reading-pane-empty"><p class="empty-state-compact">Select an entry from the list to start reading.</p></div>
                 {% endif %}
             </div>
         </main>

--- a/templates/_entries_layout.html
+++ b/templates/_entries_layout.html
@@ -48,9 +48,9 @@
                     </div>
                     <div class="list-pane-body" data-entries-list>
                         {% if entries.is_empty() %}
-                            <div class="empty-state">
-                                <h2 class="empty-state-title">{{ entries_layout.empty_title }}</h2>
-                                <p class="empty-state-text">{{ entries_layout.empty_detail }}</p>
+                            <div class="empty-state-quiet">
+                                <p class="empty-state-quiet-title">{{ entries_layout.empty_title }}</p>
+                                <p class="empty-state-quiet-text">{{ entries_layout.empty_detail }}</p>
                             </div>
                         {% else %}
                             {% for r in entries %}{% include "_entry_row.html" %}{% endfor %}

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -47,7 +47,7 @@
                         </tr>
                         {% endfor %}
                         {% if users.is_empty() %}
-                        <tr><td colspan="6" class="muted">No users found.</td></tr>
+                        <tr><td colspan="6" class="empty-state-compact">No users found.</td></tr>
                         {% endif %}
                     </tbody>
                 </table>

--- a/templates/categories.html
+++ b/templates/categories.html
@@ -45,7 +45,7 @@
                         </tr>
                         {% endfor %}
                         {% if categories.is_empty() %}
-                        <tr><td colspan="3" class="muted">No categories yet.</td></tr>
+                        <tr><td colspan="3" class="empty-state-compact">No categories yet — create one using the form above.</td></tr>
                         {% endif %}
                     </tbody>
                 </table>

--- a/templates/feeds.html
+++ b/templates/feeds.html
@@ -108,7 +108,7 @@
                             {% endif %}
                         {% endfor %}
                         {% if feeds.is_empty() %}
-                            <tr><td colspan="4" class="muted">No feeds yet.</td></tr>
+                            <tr><td colspan="4" class="empty-state-compact">No feeds yet — add one using the form above.</td></tr>
                         {% endif %}
                     </tbody>
                 </table>

--- a/templates/search.html
+++ b/templates/search.html
@@ -31,9 +31,15 @@
                 </script>
 
                 {% if q.is_empty() %}
-                    <p class="search-status">Enter a search term and press <kbd class="search-status-kbd">Enter</kbd> to search.</p>
+                    <div class="empty-state">
+                        <h2 class="empty-state-title">Search your library</h2>
+                        <p class="empty-state-text">Type a keyword and press <kbd class="empty-state-kbd">Enter</kbd> to find entries by title or content.</p>
+                    </div>
                 {% else if results.is_empty() %}
-                    <p class="search-status" data-testid="search-empty">Nothing matched &ldquo;{{ q }}&rdquo;.</p>
+                    <div class="empty-state" data-testid="search-empty">
+                        <h2 class="empty-state-title">No matches</h2>
+                        <p class="empty-state-text">Nothing matched &ldquo;{{ q }}&rdquo;. Try another keyword or check the spelling.</p>
+                    </div>
                 {% else %}
                     <ul class="search-results" data-testid="search-results">
                         {% for r in results %}

--- a/templates/statistics.html
+++ b/templates/statistics.html
@@ -69,7 +69,7 @@
                     <div class="stats-section">
                         <h2>Entries by Category</h2>
                         {% if categories.is_empty() %}
-                            <p class="muted">No entries in this period</p>
+                            <p class="empty-state-compact">No entries in this period.</p>
                         {% else %}
                             {% for c in categories %}
                                 <div class="stats-bar-row">
@@ -87,7 +87,7 @@
                     <div class="stats-section">
                         <h2>Top Feeds</h2>
                         {% if top_feeds.is_empty() %}
-                            <p class="muted">No entries in this period</p>
+                            <p class="empty-state-compact">No entries in this period.</p>
                         {% else %}
                             {% for f in top_feeds %}
                                 <div class="stats-bar-row">

--- a/tests/pages_test.rs
+++ b/tests/pages_test.rs
@@ -134,6 +134,11 @@ async fn test_unread_page_renders_ssr_layout() {
     assert!(body.contains("data-entries-list"));
     assert!(body.contains(r#"id="reading-pane""#));
     assert!(body.contains("Select an entry"));
+    // Empty unread list renders the Tier-1 editorial empty-state (heading +
+    // detail), not the old plain muted line.
+    assert!(body.contains("class=\"empty-state\""));
+    assert!(body.contains("class=\"empty-state-title\""));
+    assert!(body.contains("All caught up"));
 }
 
 #[tokio::test]
@@ -797,8 +802,10 @@ async fn test_search_page() {
     assert!(body.contains("<h1>Search</h1>"));
     assert!(body.contains("<form method=\"get\" action=\"/search\""));
     assert!(body.contains("data-testid=\"search-input\""));
-    assert!(body.contains("Enter a search term"));
-    assert!(body.contains("class=\"search-status\""));
+    assert!(body.contains("Search your library"));
+    assert!(body.contains("class=\"empty-state\""));
+    // Old editorial empty-state class fully retired in favor of `.empty-state`.
+    assert!(!body.contains("search-status"));
     assert!(!body.contains("<rdrs-entries-page>"));
     assert!(!body.contains("/static/js/pages/entries.js"));
 }
@@ -879,6 +886,9 @@ async fn test_search_page_no_results() {
     let body = response.text();
     assert!(body.contains("Nothing matched"));
     assert!(body.contains("zzznotfoundzzz"));
+    // Tier-1 empty-state with the no-results heading, behind the stable testid.
+    assert!(body.contains("No matches"));
+    assert!(body.contains("data-testid=\"search-empty\""));
 }
 
 // ============================================================================
@@ -993,7 +1003,7 @@ async fn test_category_entries_page() {
         "SSR page must not load the legacy entries.js bundle"
     );
     assert!(
-        html.contains("Select an entry to read."),
+        html.contains("Select an entry from the list to start reading."),
         "reading-pane placeholder must render"
     );
     if html.contains("id=\"load-more\"") {
@@ -1298,7 +1308,7 @@ async fn test_feed_entries_page() {
         "SSR page must not load the legacy entries.js bundle"
     );
     assert!(
-        html.contains("Select an entry to read."),
+        html.contains("Select an entry from the list to start reading."),
         "reading-pane placeholder must render when no entry is selected"
     );
     if html.contains("id=\"load-more\"") {
@@ -1894,8 +1904,9 @@ async fn test_categories_page_renders_empty_state() {
 
     // No CSR shell on the SSR page.
     assert!(!body.contains("<rdrs-categories-page>"));
-    // Empty state renders directly from the template.
-    assert!(body.contains("No categories yet."));
+    // Empty state renders directly from the template (Tier-2 compact).
+    assert!(body.contains("No categories yet"));
+    assert!(body.contains("class=\"empty-state-compact\""));
 }
 
 #[tokio::test]

--- a/tests/pages_test.rs
+++ b/tests/pages_test.rs
@@ -134,10 +134,10 @@ async fn test_unread_page_renders_ssr_layout() {
     assert!(body.contains("data-entries-list"));
     assert!(body.contains(r#"id="reading-pane""#));
     assert!(body.contains("Select an entry"));
-    // Empty unread list renders the Tier-1 editorial empty-state (heading +
-    // detail), not the old plain muted line.
-    assert!(body.contains("class=\"empty-state\""));
-    assert!(body.contains("class=\"empty-state-title\""));
+    // Empty list views render the quiet in-context empty-state (heading +
+    // detail), not the old plain muted line nor the loud Tier-1 banner.
+    assert!(body.contains("class=\"empty-state-quiet\""));
+    assert!(body.contains("class=\"empty-state-quiet-title\""));
     assert!(body.contains("All caught up"));
 }
 


### PR DESCRIPTION
## Summary

Empty states across the app were visually inconsistent — a fancy `⁂` asterism on
`/search`, a semi-fancy italic line in the reading pane, and plain muted text
everywhere else. This unifies them into one editorial-modern system, with the
treatment scaled to the surface so an empty state never reads louder than it
should.

### Three tiers

- **Tier 1 — `.empty-state`** (gold accent rule + serif heading + italic muted
  subtext): reserved for `/search`, a dedicated destination page where the
  editorial treatment is intentional. Replaces the old `.search-status` / `⁂`.
- **Tier 1-quiet — `.empty-state-quiet`** (no accent rule, smaller
  secondary-color heading + small muted detail): the entries-family list views
  (unread / all / read / starred / summarized / category / feed). An empty list
  is an in-context condition, not an announcement, so it stays restrained.
- **Tier 2 — `.empty-state-compact`** (single centered italic muted line): narrow
  surfaces — reading pane, table cells (`/feeds`, `/categories`, `/admin`), and
  `/statistics` sub-sections.

No icons, cards, or buttons; vanilla CSS only.

### Copy

`EntriesLayoutContext.empty_message` is split into `empty_title` + `empty_detail`,
and every empty state's copy is rewritten in a warmer, guidance-oriented voice
(e.g. unread → "All caught up", category → "Nothing in this category"). The
`search-empty` testid is preserved.

## Testing

- `cargo fmt`, `cargo clippy --all-targets -- -D warnings` — clean
- `cargo nextest run` — 743 passed, 0 skipped
- Visual check of all three tiers in light + dark with the real stylesheet

🤖 Generated with [Claude Code](https://claude.com/claude-code)