### PR TITLE
fix(empty-state): add inline padding to quiet empty state

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -1358,6 +1358,7 @@ dialog::backdrop {
     text-align: center;
     max-width: 30rem;
     margin: var(--space-10) auto var(--space-8);
+    padding-inline: var(--space-6);
 }
 .empty-state-quiet-title {
     font-family: var(--font-display);


### PR DESCRIPTION
## Summary

`.empty-state-quiet` only had vertical margins plus a `max-width` with `auto` side margins. On viewports narrower than its `max-width`, the block filled the available width and the centered text sat flush against the container edges, feeling cramped.

This adds `padding-inline: var(--space-6)` (1.5rem each side) so the text keeps breathing room on narrow surfaces, while wide layouts remain governed by `max-width` and are visually unchanged.

## Changes

- `static/css/app.css`: add `padding-inline: var(--space-6)` to `.empty-state-quiet`.

## Notes

Purely visual. The existing `tests/pages_test.rs` assertions only check class names, so no test changes are needed; no docs reference this rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)