### PR TITLE
fix(feed): use HTTP Last-Modified as a freshness signal

### DIFF
--- a/src/services/feed_sync.rs
+++ b/src/services/feed_sync.rs
@@ -18,6 +18,23 @@ pub struct SyncResult {
     pub updated_entries: i64,
 }
 
+/// Pick the freshest available "last updated" signal for a feed.
+///
+/// Combines the feed-level timestamp (RSS `<lastBuildDate>` / Atom `<updated>`),
+/// the newest entry date, and the HTTP `Last-Modified` header, returning the most
+/// recent one. The HTTP header guards against feeds whose in-feed dates are stale
+/// or bogus (e.g. a frozen `<lastBuildDate>` on a feed with no entries).
+fn effective_feed_updated_at(
+    feed_timestamp: Option<chrono::DateTime<Utc>>,
+    latest_entry_date: Option<chrono::DateTime<Utc>>,
+    http_last_modified: Option<chrono::DateTime<Utc>>,
+) -> Option<chrono::DateTime<Utc>> {
+    [feed_timestamp, latest_entry_date, http_last_modified]
+        .into_iter()
+        .flatten()
+        .max()
+}
+
 pub async fn refresh_feed(
     db: DbPool,
     feed_id: i64,
@@ -258,6 +275,12 @@ pub async fn refresh_feed(
         .or(parsed_feed.published)
         .map(|dt| dt.with_timezone(&Utc));
 
+    // Parse the HTTP Last-Modified header as an additional freshness signal.
+    // Some feeds report a stale/bogus in-feed date (e.g. a frozen <lastBuildDate>
+    // on a feed with no entries) while the server still serves a recent
+    // Last-Modified; without this the feed's "last updated" would be misjudged.
+    let http_last_modified = new_last_modified.as_deref().and_then(parse_timestamp);
+
     let (new_entries, updated_entries) = db
         .background(move |conn| {
             let mut new_entries = 0i64;
@@ -315,11 +338,10 @@ pub async fn refresh_feed(
                 }
             }
 
-            // Use the most recent of feed-level timestamp and latest entry date
-            let effective_updated_at = match (feed_timestamp, latest_entry_date) {
-                (Some(a), Some(b)) => Some(a.max(b)),
-                (a, b) => a.or(b),
-            };
+            // Use the most recent of feed-level timestamp, latest entry date, and
+            // the HTTP Last-Modified header.
+            let effective_updated_at =
+                effective_feed_updated_at(feed_timestamp, latest_entry_date, http_last_modified);
 
             feed::update_fetch_result(
                 conn,
@@ -490,5 +512,64 @@ mod tests {
 
         // Chinese format
         assert!(parse_timestamp("週四, 22 一月 2026 15:09:47 +0800").is_some());
+    }
+
+    #[test]
+    fn test_parse_timestamp_http_last_modified() {
+        // HTTP-date (RFC 7231 IMF-fixdate) uses the "GMT" zone name
+        let result = parse_timestamp("Mon, 01 Jun 2026 17:46:41 GMT");
+        assert!(
+            result.is_some(),
+            "Should parse HTTP-date Last-Modified format"
+        );
+        let dt = result.unwrap();
+        assert_eq!(dt.year(), 2026);
+        assert_eq!(dt.month(), 6);
+        assert_eq!(dt.day(), 1);
+        assert_eq!(dt.hour(), 17);
+    }
+
+    fn dt(y: i32, mo: u32, d: u32) -> chrono::DateTime<Utc> {
+        use chrono::TimeZone;
+        Utc.with_ymd_and_hms(y, mo, d, 0, 0, 0).unwrap()
+    }
+
+    #[test]
+    fn test_effective_feed_updated_at_uses_http_last_modified_when_feed_date_is_stale() {
+        // Regression: blocktempo serves lastBuildDate=2019 with no entries, but the
+        // HTTP Last-Modified header is recent. The freshest signal must win.
+        let feed_ts = Some(dt(2019, 1, 22));
+        let latest_entry = None;
+        let http_lm = Some(dt(2026, 6, 1));
+        assert_eq!(
+            effective_feed_updated_at(feed_ts, latest_entry, http_lm),
+            Some(dt(2026, 6, 1))
+        );
+    }
+
+    #[test]
+    fn test_effective_feed_updated_at_picks_maximum() {
+        assert_eq!(
+            effective_feed_updated_at(
+                Some(dt(2026, 3, 1)),
+                Some(dt(2026, 5, 1)),
+                Some(dt(2026, 4, 1))
+            ),
+            Some(dt(2026, 5, 1))
+        );
+    }
+
+    #[test]
+    fn test_effective_feed_updated_at_all_none() {
+        assert_eq!(effective_feed_updated_at(None, None, None), None);
+    }
+
+    #[test]
+    fn test_effective_feed_updated_at_ignores_missing_signals() {
+        // Only entry dates present -> use them; no HTTP/feed-level date available.
+        assert_eq!(
+            effective_feed_updated_at(None, Some(dt(2026, 2, 2)), None),
+            Some(dt(2026, 2, 2))
+        );
     }
 }


### PR DESCRIPTION
## Problem

A feed's "last updated" time (`feed_updated_at`) was derived solely from in-feed dates: the feed-level timestamp (RSS `<lastBuildDate>` / Atom `<updated>`) and the newest entry date.

When a feed serves a stale or bogus in-feed date, this misjudges the feed's freshness. Concrete case: `https://www.blocktempo.com/feed/` is served from a Cloudflare edge cache as a broken object — it contains **no `<item>` entries** and its `<lastBuildDate>` is frozen at `Tue, 22 Jan 2019`. `feed-rs` maps `<lastBuildDate>` to `feed.updated`, so rdrs stored `feed_updated_at = 2019-01-22` and the UI flagged the feed as **stale (red)** — even though the HTTP response's `Last-Modified` header was recent (`Mon, 01 Jun 2026`).

## Root cause

The HTTP `Last-Modified` header was already captured in `refresh_feed` (used for conditional GET), but it never participated in the `feed_updated_at` computation. The least reliable signal (`<lastBuildDate>`) won.

## Fix

Parse the `Last-Modified` header and fold it into the effective timestamp via a new `effective_feed_updated_at()` helper that takes the **max** of all available signals:

```rust
fn effective_feed_updated_at(
    feed_timestamp: Option<DateTime<Utc>>,
    latest_entry_date: Option<DateTime<Utc>>,
    http_last_modified: Option<DateTime<Utc>>,
) -> Option<DateTime<Utc>> {
    [feed_timestamp, latest_entry_date, http_last_modified]
        .into_iter().flatten().max()
}
```

This is **monotonic**: it can only make a feed's timestamp newer, never older, so healthy feeds are unaffected. blocktempo now resolves to `2026-06-01` → fresh.

### Known trade-off

If a CDN keeps bumping `Last-Modified` on a genuinely dead feed, that feed would show as fresh. In practice blocktempo's `Last-Modified` is a stable real regeneration time, so the risk is low.

## Tests

- New regression test covering the blocktempo scenario (stale feed date + no entries + recent `Last-Modified`).
- `effective_feed_updated_at` unit tests (max selection, all-none, missing signals).
- `parse_timestamp` test for the HTTP-date / `GMT` zone format.
- Full suite: **753 passed, 0 failed**; `cargo clippy` clean; `cargo fmt` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)