### PR TITLE
perf(mem): use mimalloc allocator with page reclaim to bound RSS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -817,6 +817,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cty"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35"
+
+[[package]]
 name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1959,6 +1965,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+ "cty",
+]
+
+[[package]]
 name = "libsqlite3-sys"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2129,6 +2145,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -3037,6 +3062,8 @@ dependencies = [
  "http-body-util",
  "ico",
  "image",
+ "libmimalloc-sys",
+ "mimalloc",
  "moka",
  "openssl",
  "password-hash 0.6.1",
@@ -3063,7 +3090,6 @@ dependencies = [
  "url",
  "uuid",
  "webauthn-rs",
- "webauthn-rs-proto",
  "wiremock",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,13 @@ sha2 = "0.11"
 webauthn-rs = { version = "0.5", features = [
   "danger-allow-state-serialisation",
 ] }
-webauthn-rs-proto = "0.5"
 uuid = { version = "1", features = ["v4", "serde"] }
 openssl = { version = "0.10", features = ["vendored"] }
 moka = { version = "0.12", features = ["sync"] }
 time = "0.3"
 hex = "0.4.3"
+mimalloc = "0.1"
+libmimalloc-sys = { version = "0.1", features = ["extended"] }
 
 [build-dependencies]
 resvg = "0.47"

--- a/src/handlers/feeds.rs
+++ b/src/handlers/feeds.rs
@@ -428,6 +428,10 @@ pub async fn import_opml_form(
             Ok::<_, AppError>(())
         })
         .await;
+    // The import dropped its transient OPML parse tree and per-feed buffers;
+    // return those freed pages to the OS now instead of waiting for the
+    // allocator's lazy purge.
+    crate::reclaim_memory();
     match result {
         Ok(Ok(())) => {
             state.sidebar_cache.bust(user_id);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,20 @@ pub use version::GIT_VERSION;
 
 use services::{SidebarCache, SummaryCache, SummaryJob};
 
+/// Force the allocator to return freed pages to the OS.
+///
+/// Bulk operations (OPML import, a full background sync cycle) allocate large
+/// transient buffers that mimalloc would otherwise hold for up to its purge
+/// delay. Calling this right after the bulk work collapses the resident spike
+/// to the steady-state footprint immediately, which matters on
+/// memory-constrained hosts.
+pub fn reclaim_memory() {
+    // SAFETY: `mi_collect` is a thread-safe collection call with no
+    // side-effects beyond reclaiming memory; `true` forces it to also return
+    // memory to the OS.
+    unsafe { libmimalloc_sys::mi_collect(true) }
+}
+
 #[derive(Clone)]
 pub struct AppState {
     pub db: DbPool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,12 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+// Use mimalloc to keep resident memory low: long-running multi-threaded sync
+// accumulates allocator fragmentation that the system glibc allocator tends to
+// retain as RSS. mimalloc returns freed pages to the OS far more aggressively.
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 use rdrs::{auth, create_router, db, services, AppState, Config, DbPool};
 use rusqlite::Connection;
 use tokio_util::sync::CancellationToken;

--- a/src/services/feed_sync.rs
+++ b/src/services/feed_sync.rs
@@ -448,6 +448,11 @@ pub async fn refresh_bucket(
         }
     }
 
+    // A full bucket sync fetches and parses many feeds concurrently, leaving
+    // transient per-feed buffers behind. Reclaim them now so steady-state RSS
+    // does not creep up over long uptime.
+    crate::reclaim_memory();
+
     results
 }
 


### PR DESCRIPTION
## What

Swap the global allocator to **mimalloc**, which returns freed pages to the OS far more aggressively than the system glibc allocator. Add a `reclaim_memory()` helper (`mi_collect(true)`) and call it after the two bulk-allocation paths so transient buffers do not linger as resident memory:

- after **OPML import** (`import_opml_form`) — one-shot parse tree + per-feed buffers
- after **each background sync bucket** (`refresh_bucket`) — concurrent per-feed fetch/parse buffers, reclaimed so steady-state RSS does not creep up over long uptime

Also drops the redundant direct `webauthn-rs-proto` dependency: its types are already re-exported via `webauthn-rs`'s prelude (no direct `webauthn_rs_proto` reference in `src/`) and it is still pulled in transitively by `webauthn-rs-core`.

## Why

`rdrs` is a long-running multi-threaded server; allocator fragmentation accumulates over uptime and glibc tends to retain freed pages as RSS. This mirrors the same change already shipped in the sibling `noadd` project (~35% steady-state RSS reduction there). The gain here comes from bounding long-uptime fragmentation rather than collapsing a single large build spike, so the effect is steadier and less dramatic than in `noadd`.

## Testing

- `cargo build` / `cargo clippy --all-targets` — clean
- `cargo nextest run` — **753 passed, 0 skipped**
- passkey/auth subset re-run after dropping `webauthn-rs-proto` — all green

## Notes

- `openssl` (vendored) is intentionally **kept** — it is a build-control dependency forcing the transitive openssl in the webauthn chain to build vendored; it is not unused.
- An in-session before/after RSS soak was not run: the benefit manifests over long uptime, not in a short idle measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)