### PR TITLE
ci: bump codecov-action to v7.0.0 to fix GPG key verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
         run: cargo llvm-cov nextest --lcov --output-path lcov.info
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: henry40408/rdrs


### PR DESCRIPTION
## Problem

Since ~2026-06-04 the `coverage` job fails on every non-dependabot PR at the **Upload coverage reports to Codecov** step:

```
gpg: Can't check signature: No public key
==> Could not verify signature. Please contact Codecov if problem continues
    Exiting...
```

Root cause (per the [v7.0.0 release notes](https://github.com/codecov/codecov-action/releases/tag/v7.0.0)): Codecov deleted its `codecovsecurity` keybase account due to migration issues, so the pinned `codecov-action` v6.0.1 can no longer fetch the public key used to verify the downloaded Codecov CLI. With `fail_ci_if_error` enabled for non-dependabot actors, this turns the whole job red.

## Fix

Bump `codecov-action` v6.0.1 → **v7.0.0** (pinned by commit SHA `fb8b358`). v7.0.0 switches to the `codecovsecops` account with the original GPG key, restoring signature verification. Still a `composite` action; all inputs we use (`token`, `slug`, `files`, `fail_ci_if_error`) are unchanged, and the `v6.0.1...v7.0.0` changelog contains no user-facing breaking changes. (`v6.0.2` is the identical commit back-ported to the v6 line; this repo moves straight to the latest major.)

This keeps coverage gating intact (no `fail_ci_if_error: false` opt-out).

## Testing

The coverage job on this PR exercises the bumped action end-to-end — green coverage here confirms the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)