### PR TITLE
test(e2e): cover feed edit/delete and OPML import/export in BDD

### DIFF
--- a/e2e/features/organizing.feature
+++ b/e2e/features/organizing.feature
@@ -45,3 +45,29 @@ Feature: Organizing feeds and categories
     And I am on the feeds page
     When I refresh the feed "Test Feed"
     Then I see a success flash "Refreshed:"
+
+  Scenario: Editing a feed updates its title in the feeds table
+    Given I have a feed "Old Feed" in category "My Category"
+    And I am on the feeds page
+    When I edit the feed "Old Feed" and set its title to "New Feed Name"
+    Then I see a success flash "Feed updated."
+    When I am on the feeds page
+    Then the feeds table contains "New Feed Name"
+
+  Scenario: Deleting a feed removes it from the feeds table
+    Given I have a feed "Doomed Feed" in category "My Category"
+    And I am on the feeds page
+    When I confirm the next dialog
+    And I delete the feed "Doomed Feed"
+    Then I see a success flash "Feed deleted."
+    And the feeds table does not contain "Doomed Feed"
+
+  Scenario: Importing an OPML file adds its feeds to the feeds table
+    Given I am on the import OPML page
+    When I import the OPML fixture "sample.opml"
+    Then I see a success flash "OPML imported."
+    And the feeds table contains "Imported Feed"
+
+  Scenario: Exporting OPML includes my subscribed feeds
+    Given I have a feed "Exported Feed" in category "My Category"
+    Then the exported OPML contains "Exported Feed"

--- a/e2e/fixtures/sample.opml
+++ b/e2e/fixtures/sample.opml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<opml version="2.0">
+  <head>
+    <title>rdrs subscriptions</title>
+  </head>
+  <body>
+    <outline text="Imported Category" title="Imported Category">
+      <outline type="rss" text="Imported Feed" title="Imported Feed" xmlUrl="https://example.com/imported-feed.xml" htmlUrl="https://example.com/"/>
+    </outline>
+  </body>
+</opml>

--- a/e2e/steps/organize.steps.js
+++ b/e2e/steps/organize.steps.js
@@ -1,7 +1,14 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { createBdd } from "playwright-bdd";
 import { test, expect } from "../support/fixtures.js";
 
 const { Given, When, Then } = createBdd(test);
+
+const FIXTURES_DIR = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../fixtures"
+);
 
 Given("I have a category named {string}", async ({ seed, currentUser }, name) => {
   const userId = seed.getUserId(currentUser.username);
@@ -89,6 +96,53 @@ When("I refresh the feed {string}", async ({ page }, title) => {
     .filter({ hasText: title })
     .locator("form[action$='/refresh'] button")
     .click();
+});
+
+When(
+  "I edit the feed {string} and set its title to {string}",
+  async ({ page }, oldTitle, newTitle) => {
+    await page
+      .getByTestId("feeds-table")
+      .locator("tr")
+      .filter({ hasText: oldTitle })
+      .getByRole("link", { name: "edit" })
+      .click();
+    await page.getByTestId("feed-edit-title-input").fill(newTitle);
+    await page.getByTestId("feed-edit-save-btn").click();
+  }
+);
+
+When("I delete the feed {string}", async ({ page }, title) => {
+  // Same row-scoped danger-button pattern as "I delete category"; the caller
+  // must register "I confirm the next dialog" first (delete form uses confirm()).
+  await page
+    .getByTestId("feeds-table")
+    .locator("tr")
+    .filter({ hasText: title })
+    .locator("button.action-link-danger")
+    .click();
+});
+
+Given("I am on the import OPML page", async ({ page, serverUrl }) => {
+  await page.goto(`${serverUrl}/feeds/import`);
+  await expect(page.getByTestId("opml-file-input")).toBeVisible();
+});
+
+When("I import the OPML fixture {string}", async ({ page }, filename) => {
+  await page
+    .getByTestId("opml-file-input")
+    .setInputFiles(path.join(FIXTURES_DIR, filename));
+  await page.getByTestId("opml-import-btn").click();
+});
+
+Then("the exported OPML contains {string}", async ({ page, serverUrl }, text) => {
+  // The Export OPML link is a GET download; page.request shares the browser
+  // context's auth cookie, so this exports the signed-in user's subscriptions.
+  const res = await page.request.get(
+    `${serverUrl}/reader/api/0/subscription/export`
+  );
+  expect(res.ok()).toBeTruthy();
+  expect(await res.text()).toContain(text);
 });
 
 Then("I see a success flash {string}", async ({ page }, message) => {

--- a/templates/feed_edit.html
+++ b/templates/feed_edit.html
@@ -11,11 +11,11 @@
                 <form method="post" action="/feeds/{{ feed.id }}/edit">
                     <div class="form-group">
                         <label for="url">Feed URL</label>
-                        <input type="text" id="url" name="url" value="{{ feed.url }}" required>
+                        <input type="text" id="url" name="url" value="{{ feed.url }}" required data-testid="feed-edit-url-input">
                     </div>
                     <div class="form-group">
                         <label for="title">Title</label>
-                        <input type="text" id="title" name="title" value="{{ feed.title }}">
+                        <input type="text" id="title" name="title" value="{{ feed.title }}" data-testid="feed-edit-title-input">
                     </div>
                     <div class="form-group">
                         <label for="description">Description</label>
@@ -27,7 +27,7 @@
                     </div>
                     <div class="form-group">
                         <label for="category_id">Category</label>
-                        <select id="category_id" name="category_id" required>
+                        <select id="category_id" name="category_id" required data-testid="feed-edit-category-select">
                             {% for c in categories %}
                                 <option value="{{ c.id }}"{% if c.id == feed.category_id %} selected{% endif %}>{{ c.name }}</option>
                             {% endfor %}
@@ -55,7 +55,7 @@
                         </div>
                     </details>
                     <div class="modal-actions">
-                        <button type="submit">Save</button>
+                        <button type="submit" data-testid="feed-edit-save-btn">Save</button>
                         <a href="/feeds" class="btn btn-secondary">Cancel</a>
                     </div>
                 </form>

--- a/templates/feeds_import.html
+++ b/templates/feeds_import.html
@@ -11,14 +11,14 @@
                 <form method="post" action="/feeds/import" enctype="multipart/form-data">
                     <div class="form-group">
                         <label for="file">Upload .opml file</label>
-                        <input type="file" id="file" name="file" accept=".opml,.xml">
+                        <input type="file" id="file" name="file" accept=".opml,.xml" data-testid="opml-file-input">
                     </div>
                     <div class="form-group">
                         <label for="content">Or paste OPML content</label>
                         <textarea id="content" name="content" rows="10" class="textarea-full"></textarea>
                     </div>
                     <div class="modal-actions">
-                        <button type="submit">Import</button>
+                        <button type="submit" data-testid="opml-import-btn">Import</button>
                         <a href="/feeds" class="btn btn-secondary">Cancel</a>
                     </div>
                 </form>


### PR DESCRIPTION
## What

Closes the remaining `organizing.feature` coverage gaps. Category CRUD scenarios already landed earlier; the four user-facing flows still unguarded by BDD were **edit feed**, **delete feed**, **OPML import**, and **OPML export**. All four product surfaces already exist (SSR pages + form-action / GReader endpoints) — this is purely additive end-to-end coverage.

New scenarios in `e2e/features/organizing.feature`:

- **Editing a feed updates its title** — clicks the row's `edit` link, changes the title, saves, then re-checks the feeds table (the edit form redirects back to `/feeds/{id}/edit`, so the assertion re-navigates to `/feeds`).
- **Deleting a feed removes it from the table** — reuses the existing confirm-dialog + row `.action-link-danger` pattern (same as delete-category).
- **Importing an OPML file adds its feeds** — uploads a new `e2e/fixtures/sample.opml` via the file input; the fixture is round-trip-shaped so it matches the exporter's output.
- **Exporting OPML includes my subscribed feeds** — asserts the authenticated `GET /reader/api/0/subscription/export` body through `page.request` (shares the browser auth cookie).

## Product-side change

Adds `data-testid` hooks only — no behaviour change:
- `feed_edit.html`: `feed-edit-url-input`, `feed-edit-title-input`, `feed-edit-category-select`, `feed-edit-save-btn`
- `feeds_import.html`: `opml-file-input`, `opml-import-btn`

This follows the existing testid convention already used across `organize.steps.js`.

## Testing

- `npx playwright test -g "Organizing feeds and categories"` — **10/10 scenarios pass** (6 existing + 4 new)
- `cargo nextest run` — **753 passed, 0 skipped** (testid additions don't break any HTML-asserting Rust tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)