### PR TITLE
refactor(e2e): move inline step SQL into SeedHelper methods

### DIFF
--- a/e2e/steps/admin.steps.js
+++ b/e2e/steps/admin.steps.js
@@ -1,19 +1,13 @@
 import { createBdd } from "playwright-bdd";
 import { test, expect } from "../support/fixtures.js";
-import Database from "better-sqlite3";
 
 const { Given, When, Then } = createBdd(test);
 
-// Promote the currentUser to admin via direct SQL, then sign in.
+// Promote the currentUser to admin via the seed helper, then sign in.
 Given("I am signed in as an admin", async ({ page, api, currentUser, seed, serverUrl }) => {
   await api.register(currentUser.username, currentUser.password);
   const userId = seed.getUserId(currentUser.username);
-  const db = new Database(seed.dbPath);
-  try {
-    db.prepare(`UPDATE user SET role = 'admin' WHERE id = ?`).run(userId);
-  } finally {
-    db.close();
-  }
+  seed.makeAdmin(userId);
   await page.goto(`${serverUrl}/login`);
   await page.getByTestId("username-input").fill(currentUser.username);
   await page.getByTestId("password-input").fill(currentUser.password);

--- a/e2e/steps/entries.steps.js
+++ b/e2e/steps/entries.steps.js
@@ -1,27 +1,7 @@
 import { createBdd } from "playwright-bdd";
-import Database from "better-sqlite3";
 import { test, expect } from "../support/fixtures.js";
 
 const { Given, When, Then } = createBdd(test);
-
-function entryIdByTitle(seed, currentUser, title) {
-  const db = new Database(seed.dbPath);
-  try {
-    const userId = seed.getUserId(currentUser.username);
-    const row = db
-      .prepare(
-        `SELECT e.id FROM entry e
-         JOIN feed f ON e.feed_id = f.id
-         JOIN category c ON f.category_id = c.id
-         WHERE c.user_id = ? AND e.title = ?`
-      )
-      .get(userId, title);
-    if (!row) throw new Error(`Entry '${title}' not found`);
-    return row.id;
-  } finally {
-    db.close();
-  }
-}
 
 Given(
   "I have a feed {string} with {int} test entries in category {string}",
@@ -38,54 +18,28 @@ Given(
 );
 
 Given("the entry titled {string} is marked read", async ({ seed, currentUser }, title) => {
-  const id = entryIdByTitle(seed, currentUser, title);
-  seed.markRead(id);
+  const userId = seed.getUserId(currentUser.username);
+  seed.markRead(seed.findEntryIdByTitle(userId, title));
 });
 
 Given("the entry titled {string} is starred", async ({ seed, currentUser }, title) => {
-  const id = entryIdByTitle(seed, currentUser, title);
-  seed.markStarred(id);
+  const userId = seed.getUserId(currentUser.username);
+  seed.markStarred(seed.findEntryIdByTitle(userId, title));
 });
 
 Given("the entry titled {string} has a summary", async ({ seed, currentUser }, title) => {
-  const id = entryIdByTitle(seed, currentUser, title);
   const userId = seed.getUserId(currentUser.username);
-  seed.insertSummary(id, userId);
+  seed.insertSummary(seed.findEntryIdByTitle(userId, title), userId);
 });
 
 Given("all entries in category {string} are marked read", async ({ seed, currentUser }, name) => {
   const userId = seed.getUserId(currentUser.username);
-  const db = new Database(seed.dbPath);
-  try {
-    db.prepare(
-      `UPDATE entry SET read_at = datetime('now')
-       WHERE feed_id IN (
-         SELECT f.id FROM feed f
-         JOIN category c ON f.category_id = c.id
-         WHERE c.user_id = ? AND c.name = ?
-       )`
-    ).run(userId, name);
-  } finally {
-    db.close();
-  }
+  seed.markCategoryRead(userId, name);
 });
 
 Given("the feed has {int} entries", async ({ seed, currentUser }, count) => {
   const userId = seed.getUserId(currentUser.username);
-  const db = new Database(seed.dbPath);
-  let feedId;
-  try {
-    const row = db
-      .prepare(
-        `SELECT f.id FROM feed f JOIN category c ON f.category_id = c.id WHERE c.user_id = ? LIMIT 1`
-      )
-      .get(userId);
-    if (!row) throw new Error("No feed found for user");
-    feedId = row.id;
-  } finally {
-    db.close();
-  }
-  seed.seedTestEntries(feedId, count);
+  seed.seedTestEntries(seed.firstFeedId(userId), count);
 });
 
 When("I open the all entries page", async ({ page, serverUrl }) => {
@@ -106,35 +60,13 @@ When("I open the summarized entries page", async ({ page, serverUrl }) => {
 
 When("I open the entries page for feed {string}", async ({ page, seed, currentUser, serverUrl }, feedTitle) => {
   const userId = seed.getUserId(currentUser.username);
-  const db = new Database(seed.dbPath);
-  let feedId;
-  try {
-    const row = db
-      .prepare(
-        `SELECT f.id FROM feed f JOIN category c ON f.category_id = c.id WHERE c.user_id = ? AND f.title = ?`
-      )
-      .get(userId, feedTitle);
-    if (!row) throw new Error(`Feed '${feedTitle}' not found`);
-    feedId = row.id;
-  } finally {
-    db.close();
-  }
+  const feedId = seed.findFeedIdByTitle(userId, feedTitle);
   await page.goto(`${serverUrl}/feeds/${feedId}/entries`);
 });
 
 When("I open the entries page for category {string}", async ({ page, seed, currentUser, serverUrl }, name) => {
   const userId = seed.getUserId(currentUser.username);
-  const db = new Database(seed.dbPath);
-  let categoryId;
-  try {
-    const row = db
-      .prepare(`SELECT id FROM category WHERE user_id = ? AND name = ?`)
-      .get(userId, name);
-    if (!row) throw new Error(`Category '${name}' not found`);
-    categoryId = row.id;
-  } finally {
-    db.close();
-  }
+  const categoryId = seed.findCategoryIdByName(userId, name);
   await page.goto(`${serverUrl}/categories/${categoryId}/entries`);
 });
 
@@ -297,7 +229,8 @@ When("I reload the page", async ({ page }) => {
 When(
   "I open the inbox deep-linked to entry titled {string}",
   async ({ page, serverUrl, seed, currentUser }, title) => {
-    const id = entryIdByTitle(seed, currentUser, title);
+    const userId = seed.getUserId(currentUser.username);
+    const id = seed.findEntryIdByTitle(userId, title);
     await page.goto(`${serverUrl}/?entry=${id}`);
   }
 );
@@ -305,7 +238,8 @@ When(
 Then(
   "the URL has the ?entry= parameter for {string}",
   async ({ page, seed, currentUser }, title) => {
-    const id = entryIdByTitle(seed, currentUser, title);
+    const userId = seed.getUserId(currentUser.username);
+    const id = seed.findEntryIdByTitle(userId, title);
     // performSwap rewrites the URL after a #reading-pane swap (pushState on
     // first-open from an empty pane, replaceState on subsequent switches);
     // wait until the address-bar `entry` query matches the clicked entry's id.
@@ -327,33 +261,13 @@ Then("I am on the unread inbox", async ({ page, serverUrl }) => {
 
 Then("I am on the entries page for feed {string}", async ({ page, seed, currentUser, serverUrl }, feedTitle) => {
   const userId = seed.getUserId(currentUser.username);
-  const db = new Database(seed.dbPath);
-  let feedId;
-  try {
-    const row = db
-      .prepare(`SELECT f.id FROM feed f JOIN category c ON f.category_id = c.id WHERE c.user_id = ? AND f.title = ?`)
-      .get(userId, feedTitle);
-    if (!row) throw new Error(`Feed '${feedTitle}' not found`);
-    feedId = row.id;
-  } finally {
-    db.close();
-  }
+  const feedId = seed.findFeedIdByTitle(userId, feedTitle);
   await page.waitForURL(`${serverUrl}/feeds/${feedId}/entries`);
 });
 
 Then("I am on the Read filter for feed {string}", async ({ page, seed, currentUser, serverUrl }, feedTitle) => {
   const userId = seed.getUserId(currentUser.username);
-  const db = new Database(seed.dbPath);
-  let feedId;
-  try {
-    const row = db
-      .prepare(`SELECT f.id FROM feed f JOIN category c ON f.category_id = c.id WHERE c.user_id = ? AND f.title = ?`)
-      .get(userId, feedTitle);
-    if (!row) throw new Error(`Feed '${feedTitle}' not found`);
-    feedId = row.id;
-  } finally {
-    db.close();
-  }
+  const feedId = seed.findFeedIdByTitle(userId, feedTitle);
   await page.waitForURL(`${serverUrl}/feeds/${feedId}/entries?status=read`);
 });
 
@@ -372,17 +286,7 @@ Then("pressing the {string} key opens a new tab at {string}", async ({ page }, k
 
 Then("I am on the entries page for category {string}", async ({ page, seed, currentUser, serverUrl }, name) => {
   const userId = seed.getUserId(currentUser.username);
-  const db = new Database(seed.dbPath);
-  let categoryId;
-  try {
-    const row = db
-      .prepare(`SELECT id FROM category WHERE user_id = ? AND name = ?`)
-      .get(userId, name);
-    if (!row) throw new Error(`Category '${name}' not found`);
-    categoryId = row.id;
-  } finally {
-    db.close();
-  }
+  const categoryId = seed.findCategoryIdByName(userId, name);
   await page.waitForURL(`${serverUrl}/categories/${categoryId}/entries`);
 });
 

--- a/e2e/support/seed.js
+++ b/e2e/support/seed.js
@@ -142,6 +142,96 @@ export class SeedHelper {
     }
   }
 
+  makeAdmin(userId) {
+    const db = new Database(this.dbPath);
+    try {
+      db.prepare(`UPDATE user SET role = 'admin' WHERE id = ?`).run(userId);
+    } finally {
+      db.close();
+    }
+  }
+
+  findEntryIdByTitle(userId, title) {
+    const db = new Database(this.dbPath);
+    try {
+      const row = db
+        .prepare(
+          `SELECT e.id FROM entry e
+           JOIN feed f ON e.feed_id = f.id
+           JOIN category c ON f.category_id = c.id
+           WHERE c.user_id = ? AND e.title = ?`
+        )
+        .get(userId, title);
+      if (!row) throw new Error(`Entry '${title}' not found`);
+      return row.id;
+    } finally {
+      db.close();
+    }
+  }
+
+  findFeedIdByTitle(userId, feedTitle) {
+    const db = new Database(this.dbPath);
+    try {
+      const row = db
+        .prepare(
+          `SELECT f.id FROM feed f
+           JOIN category c ON f.category_id = c.id
+           WHERE c.user_id = ? AND f.title = ?`
+        )
+        .get(userId, feedTitle);
+      if (!row) throw new Error(`Feed '${feedTitle}' not found`);
+      return row.id;
+    } finally {
+      db.close();
+    }
+  }
+
+  firstFeedId(userId) {
+    const db = new Database(this.dbPath);
+    try {
+      const row = db
+        .prepare(
+          `SELECT f.id FROM feed f
+           JOIN category c ON f.category_id = c.id
+           WHERE c.user_id = ? LIMIT 1`
+        )
+        .get(userId);
+      if (!row) throw new Error("No feed found for user");
+      return row.id;
+    } finally {
+      db.close();
+    }
+  }
+
+  findCategoryIdByName(userId, name) {
+    const db = new Database(this.dbPath);
+    try {
+      const row = db
+        .prepare(`SELECT id FROM category WHERE user_id = ? AND name = ?`)
+        .get(userId, name);
+      if (!row) throw new Error(`Category '${name}' not found`);
+      return row.id;
+    } finally {
+      db.close();
+    }
+  }
+
+  markCategoryRead(userId, categoryName) {
+    const db = new Database(this.dbPath);
+    try {
+      db.prepare(
+        `UPDATE entry SET read_at = datetime('now')
+         WHERE feed_id IN (
+           SELECT f.id FROM feed f
+           JOIN category c ON f.category_id = c.id
+           WHERE c.user_id = ? AND c.name = ?
+         )`
+      ).run(userId, categoryName);
+    } finally {
+      db.close();
+    }
+  }
+
   seedTestEntries(feedId, count) {
     const entries = [];
     for (let i = 1; i <= count; i++) {


### PR DESCRIPTION
## What

Carry-forward cleanup #2. The BDD step files (`admin.steps.js`, `entries.steps.js`) opened raw `better-sqlite3` connections and ran ad-hoc SQL for test setup and id lookups. This centralizes that SQL in `SeedHelper` — the pattern PR #211 established with `configureKagi` — so the SQL has one home and the step files stay declarative.

New `SeedHelper` methods:
- `makeAdmin(userId)` — promote a user to admin
- `findEntryIdByTitle(userId, title)` / `findFeedIdByTitle(userId, title)` / `findCategoryIdByName(userId, name)` — user-scoped id lookups (throw if missing)
- `firstFeedId(userId)` — first feed for a user
- `markCategoryRead(userId, name)` — mark every entry in a category read

`admin.steps.js` and `entries.steps.js` no longer import `better-sqlite3` or touch the DB directly; the local `entryIdByTitle` helper is removed.

## Testing

- `npx playwright test` — **77/77 scenarios pass**. Pure refactor, no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)