### PR TITLE
chore(e2e): drop misleading @skip comments and a duplicate press step

### DIFF
--- a/e2e/features/search.feature
+++ b/e2e/features/search.feature
@@ -17,7 +17,7 @@ Feature: Search
     And the result count is 2
 
   Scenario: Pressing the slash key focuses the search input
-    When I press "/"
+    When I press the "/" key
     Then the search input is focused
 
   Scenario: Searching for a term with no matches shows an empty state

--- a/e2e/steps/search.steps.js
+++ b/e2e/steps/search.steps.js
@@ -27,11 +27,6 @@ When("I search for {string}", async ({ page }, term) => {
   await page.keyboard.press("Enter");
 });
 
-When("I press {string}", async ({ page }, key) => {
-  await page.click("body");
-  await page.keyboard.press(key);
-});
-
 Then("I see search results:", async ({ page }, table) => {
   await expect(page.getByTestId("search-results")).toBeVisible();
   for (const [title] of table.raw()) {

--- a/e2e/steps/triage.steps.js
+++ b/e2e/steps/triage.steps.js
@@ -49,7 +49,7 @@ Then("the sidebar starred count is at least {int}", async ({ page }, n) => {
   // The sidebar Starred link (<a href="/entries/starred">) has no numeric badge —
   // only the Unread link carries a count. This step can only assert the link is
   // visible; a count assertion requires a future UI addition.
-  // @skip kept on the owning scenario until a badge is added.
+  // Strengthen to a numeric assertion once the Starred link gains a badge.
   const locator = page.locator('a[href="/entries/starred"]').first();
   await expect(locator).toBeVisible();
   void n; // numeric check deferred until sidebar starred-count badge is added
@@ -59,7 +59,7 @@ Then("the sidebar unread count decreases by {int}", async ({ page }, _delta) => 
   // The total-unread badge has id="unread-count" (rendered by rdrs-sidebar.js).
   // Delta comparison requires capturing the before-count, which needs a fixture
   // hook. For now assert the element is present and shows a non-negative number.
-  // @skip kept on the owning scenario until before/after capture is wired.
+  // Strengthen to a delta assertion once before/after capture is wired.
   const locator = page.locator("#unread-count").first();
   const text = await locator.innerText();
   const count = parseInt(text, 10);


### PR DESCRIPTION
## What

Two small e2e tidy-ups from the carry-forward minors list — no behaviour change:

- **Misleading comments**: `triage.steps.js` had two `// @skip kept on the owning scenario until …` comments. The BDD suite has **zero** `@skip` scenarios; those steps run with intentionally-soft assertions (the Starred sidebar link has no numeric badge; the unread delta needs before/after capture). Reworded to say what would let the assertion be strengthened, instead of implying a skip exists.
- **Duplicate step**: `I press {string}` (defined in `search.steps.js`, used exactly once for the slash key) is removed in favour of the dominant `I press the {string} key` (~33 uses). `search.feature` updated to `When I press the "/" key`.

## Testing

- `npx playwright test` — **77/77 scenarios pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)