### PR TITLE
feat(onboarding): unblock fresh install from install to first read

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,10 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+
+  - package-ecosystem: "npm"
+    directory: "/e2e"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/README.md
+++ b/README.md
@@ -37,10 +37,16 @@ docker run -d \
   -p 3000:3000 \
   -v rdrs_data:/data \
   -e SIGNUP_ENABLED=true \
+  -e IMAGE_PROXY_SECRET="$(openssl rand -base64 32)" \
   ghcr.io/henry40408/rdrs:latest
 ```
 
 Visit `http://localhost:3000` and create your account.
+
+> **`IMAGE_PROXY_SECRET`** — if left unset, a random secret is generated on
+> each startup, which invalidates every previously-proxied image URL whenever
+> the container restarts. Set it to a persistent value (e.g.
+> `openssl rand -base64 32`) so proxied images survive restarts.
 
 ### Building from Source
 
@@ -55,6 +61,12 @@ cargo build --release
 # Run server
 ./target/release/rdrs
 ```
+
+Visit `http://localhost:3000` and create your account. The **first account is
+always allowed** even when `SIGNUP_ENABLED=false` (the default), so a source
+build works out of the box. `SIGNUP_ENABLED` (together with
+`MULTI_USER_ENABLED`) only governs *additional* registrations after the first
+account exists.
 
 ## Configuration
 
@@ -73,6 +85,13 @@ All configuration is done via environment variables:
 | `WEBAUTHN_RP_ORIGIN` | `http://localhost:{port}` | WebAuthn Relying Party origin URL |
 | `WEBAUTHN_RP_NAME` | `rdrs` | WebAuthn Relying Party display name |
 | `RUST_LOG` | - | Log level filter (e.g., `info`, `debug`, `rdrs=debug`) |
+
+> **Deploying behind a domain?** `WEBAUTHN_RP_ID` and `WEBAUTHN_RP_ORIGIN`
+> default to `localhost` and **must** be overridden to your public host (e.g.
+> `WEBAUTHN_RP_ID=rdrs.example.com`,
+> `WEBAUTHN_RP_ORIGIN=https://rdrs.example.com`), otherwise the browser rejects
+> passkeys. rdrs logs a startup warning while the RP origin still points at
+> `localhost`, and the active values are shown on the Settings page.
 
 ## Usage
 

--- a/docs/superpowers/specs/2026-06-08-onboarding-improvements-design.md
+++ b/docs/superpowers/specs/2026-06-08-onboarding-improvements-design.md
@@ -67,15 +67,31 @@ unchanged.
 **README:** the *Building from Source* section gains a note that the first account always
 works and `SIGNUP_ENABLED` only controls additional registrations.
 
-### #2 — Seed "Uncategorized" on user creation
+### #2 — Seed "Uncategorized" at registration
 
-`models::user::create_user` seeds a default category named `Uncategorized` for the new user
-in the same transaction-scoped path, so every new account (password or passkey) has a usable
-category and the Add Feed form's `<select>` is never empty. This matches the existing
-`Uncategorized` convention used by OPML import and the GReader subscription API.
+The **registration handler** (`handlers::auth::register`) seeds a default category named
+`Uncategorized` for the new user, in the same `db.user(...)` closure right after
+`create_user`, so a fresh account has a usable category and the Add Feed form's `<select>`
+is never empty. This matches the existing `Uncategorized` convention used by OPML import and
+the GReader subscription API.
+
+Seeding lives in the handler rather than `models::user::create_user` because `create_user`
+is a low-level building block reused by dozens of model/integration test fixtures (and by
+nothing else that creates real accounts). Passkeys are added to *already-authenticated*
+users via `passkey::finish_registration`, so the password `register` handler is the only
+genuine account-creation entry point. Keeping `create_user` pure avoids broad test churn.
 
 The `feeds.html` empty-`<option>` branch becomes unreachable for real users but is left in
 place as a defensive fallback.
+
+**Sidebar-cache interaction.** `read_chrome_data` previously skipped caching the sidebar
+only when an account had *no categories*. Seeding `Uncategorized` makes that always false,
+so a brand-new account would cache a `[Uncategorized]`-only sidebar and mask
+direct-DB-seeded feeds (which E2E relies on) behind the 60 s TTL. The cache gate is changed
+to skip when the account has *no feeds and no unread* (`has_feeds || total_unread > 0`),
+restoring the "don't cache an empty account" invariant. The `category_nav` E2E background
+removes the seeded `Uncategorized` so its wrap-around scenarios still exercise a clean
+three-category set.
 
 ### #3 — Surface and warn about WebAuthn RP config
 
@@ -121,7 +137,8 @@ only; other empty states keep their current title/detail.
 | User creation | `src/models/user.rs` | seed `Uncategorized`; tests |
 | Register handler | `src/handlers/auth.rs` | unchanged logic, benefits from #1 |
 | Landing page | `src/handlers/pages.rs` | feed-count → onboarding vs all-caught-up |
-| Feed model | `src/models/feed.rs` | `count_by_user` (if added) |
+| Feed model | `src/models/feed.rs` | `count_by_user` |
+| Sidebar cache | `src/handlers/user.rs` | gate caching on feeds/unread, not on having any category (see note) |
 | Settings page | `src/handlers/pages.rs`, `templates/settings.html` | RP id/origin/name rows |
 | Startup | `src/main.rs` | RP-origin warning |
 | Templates | `templates/_entries_layout.html` | onboarding empty-state block |

--- a/docs/superpowers/specs/2026-06-08-onboarding-improvements-design.md
+++ b/docs/superpowers/specs/2026-06-08-onboarding-improvements-design.md
@@ -131,20 +131,25 @@ only; other empty states keep their current title/detail.
 
 **BDD (`e2e/features/onboarding.feature`):**
 
-- A brand-new user (zero users) can register even with signup disabled, then sign in and
-  land on the unread inbox. *(#1)*
-- A freshly-registered user's Add Feed form shows an `Uncategorized` category and a feed can
-  be added immediately without first creating a category. *(#2)*
-- A signed-in user with no feeds sees the onboarding welcome (3 steps + "Add your first
-  feed" / "Import OPML" CTAs) instead of "All caught up". *(#5/#6)*
-- After adding a feed, the landing page no longer shows the onboarding block. *(#5/#6)*
-- The Settings page shows the active WebAuthn RP id / origin. *(#3, UI portion)*
+- A freshly-registered user's Add Feed form offers an `Uncategorized` category and a feed
+  can be added immediately without first creating a category. *(#2)*
+- A signed-in user with no feeds sees the getting-started guide ("Add your first feed" /
+  "Import OPML" CTAs) on the landing page. *(#5/#6)*
+- An account that has a feed shows "All caught up" and not the getting-started guide. *(#5)*
+- The Settings page shows the active WebAuthn RP origin. *(#3, UI portion)*
 
 **Unit / Rust tests:**
 
 - `config::can_register` truth table including the new first-account-always row. *(#1)*
 - `create_user` seeds exactly one `Uncategorized` category for the new user. *(#2)*
 - `feed::count_by_user` (if added). *(#5)*
+
+**Why #1 is not BDD-covered:** the shared, worker-scoped e2e server fixture is hard-wired to
+`SIGNUP_ENABLED=true` / `MULTI_USER_ENABLED=true` and is reused across parallel scenarios, so
+"signup disabled, zero users, first account still registers" cannot be expressed without a
+dedicated isolated server. The behaviour is config logic, so it is verified by the
+`config::can_register` unit test instead. (An isolated-server BDD scenario could be added later
+if desired.)
 
 **Not BDD-covered:** the startup RP-origin warning (#3 log) and the README/docker doc
 changes (#4) — covered by code review and (for the warning) a focused unit test on the

--- a/docs/superpowers/specs/2026-06-08-onboarding-improvements-design.md
+++ b/docs/superpowers/specs/2026-06-08-onboarding-improvements-design.md
@@ -1,0 +1,157 @@
+# Onboarding Improvements — Design
+
+**Issue:** #269 — Improve onboarding: from install to first successful read
+**Date:** 2026-06-08
+**Status:** Approved
+
+## Problem
+
+The fresh-install happy path (*found the project* → *reading feeds*) is broken by two
+hard blockers and degraded by several first-run/deployment gaps:
+
+1. 🔴 **Source-build users are locked out.** `SIGNUP_ENABLED` defaults to `false`, and
+   `can_register` requires it even for the very first account, so a source build can never
+   create its first user without manual DB surgery.
+2. 🔴 **Can't add the first feed.** The Add Feed `<select required>` only offers an empty
+   `No categories available` option for a new user; the browser silently blocks submission.
+3. 🟠 **Passkey silently fails off-localhost.** `WEBAUTHN_RP_ID`/`RP_ORIGIN` default to
+   `localhost`; deploying behind a domain without overriding them breaks passkeys with no
+   log or UI signal, and Settings never shows the active values.
+4. 🟠 **`IMAGE_PROXY_SECRET` rotates on restart when unset.** The `docker run` quick-start
+   (the most-copied snippet) omits it, so proxied image URLs break on every restart.
+5. 🟡 **Misleading landing empty state.** `/` (Unread) hardcodes "All caught up" and never
+   distinguishes "no feeds yet" from "all read".
+6. 🟡 **No getting-started affordance.** No checklist or CTA points a brand-new user at
+   adding a feed or importing OPML.
+
+## Scope decisions
+
+- **#5 and #6 are merged** into a single SSR onboarding empty state. They share the same
+  trigger (account has zero feeds) and the same screen location, so rendering both would
+  duplicate guidance. One block covers both.
+- **No dismiss control** for the onboarding block. It is shown only while the account has
+  zero feeds and disappears naturally once the first feed exists — no JS, no cookie, no
+  persisted state.
+- **#1's "actionable hint for zero-user lockout" is dropped as moot.** Once the first
+  account can always register, the zero-user lockout cannot occur, so no special hint is
+  needed. The generic "Registration is currently disabled" message remains for the
+  legitimately-disabled case (≥1 user, signup not enabled).
+
+## Design
+
+### #1 — First account can always register
+
+`Config::can_register` changes so the first account is always allowed, while the flag still
+gates every subsequent account:
+
+```rust
+pub fn can_register(&self, user_count: i64) -> bool {
+    user_count == 0 || (self.signup_enabled && self.multi_user_enabled)
+}
+```
+
+Behaviour table:
+
+| user_count | signup_enabled | multi_user_enabled | before | after |
+|------------|----------------|--------------------|--------|-------|
+| 0          | false          | false              | ❌     | ✅    |
+| 0          | true           | false              | ✅     | ✅    |
+| 1          | true           | false              | ❌     | ❌    |
+| ≥1         | true           | true               | ✅     | ✅    |
+| ≥1         | false          | *                  | ❌     | ❌    |
+
+The only behavioural change is the first row: the very first account now registers even
+when `SIGNUP_ENABLED=false`. The single-user-with-signup and multi-user paths are
+unchanged.
+
+**README:** the *Building from Source* section gains a note that the first account always
+works and `SIGNUP_ENABLED` only controls additional registrations.
+
+### #2 — Seed "Uncategorized" on user creation
+
+`models::user::create_user` seeds a default category named `Uncategorized` for the new user
+in the same transaction-scoped path, so every new account (password or passkey) has a usable
+category and the Add Feed form's `<select>` is never empty. This matches the existing
+`Uncategorized` convention used by OPML import and the GReader subscription API.
+
+The `feeds.html` empty-`<option>` branch becomes unreachable for real users but is left in
+place as a defensive fallback.
+
+### #3 — Surface and warn about WebAuthn RP config
+
+- **Startup warning:** in `main.rs`, after building `Config`, log a `tracing::warn!` when
+  the effective RP origin still points at `localhost` **or** disagrees with a configured
+  `PUBLIC_BASE_URL`. The message names the active RP origin and explains passkeys will fail
+  off-localhost.
+- **Settings page:** add three read-only rows to the config table showing the active
+  `WEBAUTHN_RP_ID`, `WEBAUTHN_RP_ORIGIN`, and `WEBAUTHN_RP_NAME`. `SettingsTemplate` gains
+  the corresponding fields.
+- **README:** document `WEBAUTHN_RP_ID`/`RP_ORIGIN` as required when deploying behind a
+  domain (the Configuration table already lists them; add a deployment note).
+
+### #4 — `IMAGE_PROXY_SECRET` in the docker quick-start
+
+The `docker run` quick-start in README gains `-e IMAGE_PROXY_SECRET=...` with a generate
+note (`openssl rand -base64 32`) and a one-line call-out that, left unset, the secret
+regenerates on restart and invalidates previously-proxied image URLs. The startup warning
+already exists in `main.rs` and is unchanged.
+
+### #5 + #6 — Onboarding empty state on the landing page
+
+`unread_page` determines whether the account has any feeds (a new
+`feed::count_by_user(conn, user_id)` returning `i64`, or reuse of an existing list length).
+The result selects the empty-state content rendered by `_entries_layout.html`:
+
+- **Zero feeds** → onboarding copy: a welcome title, a 3-step list
+  (1) add a feed or import OPML, (2) wait for the first sync, (3) read — and two CTA links:
+  **Add your first feed →** (`/feeds`) and **Import OPML** (`/feeds/import`).
+- **Has feeds, all read** → the existing "All caught up" / "You've read every unread
+  entry…" copy, unchanged.
+
+Implementation: `EntriesLayoutContext` gains an optional onboarding flag/structure (e.g.
+`onboarding: Option<OnboardingView>`) so `_entries_layout.html` renders the CTA block
+instead of the plain title/detail when present. This is scoped to the landing (`/`) handler
+only; other empty states keep their current title/detail.
+
+## Components touched
+
+| Area | File | Change |
+|------|------|--------|
+| Config logic | `src/config.rs` | `can_register` rule; unit tests |
+| User creation | `src/models/user.rs` | seed `Uncategorized`; tests |
+| Register handler | `src/handlers/auth.rs` | unchanged logic, benefits from #1 |
+| Landing page | `src/handlers/pages.rs` | feed-count → onboarding vs all-caught-up |
+| Feed model | `src/models/feed.rs` | `count_by_user` (if added) |
+| Settings page | `src/handlers/pages.rs`, `templates/settings.html` | RP id/origin/name rows |
+| Startup | `src/main.rs` | RP-origin warning |
+| Templates | `templates/_entries_layout.html` | onboarding empty-state block |
+| Docs | `README.md` | source-build note, docker `IMAGE_PROXY_SECRET`, RP deploy note |
+
+## Testing
+
+**BDD (`e2e/features/onboarding.feature`):**
+
+- A brand-new user (zero users) can register even with signup disabled, then sign in and
+  land on the unread inbox. *(#1)*
+- A freshly-registered user's Add Feed form shows an `Uncategorized` category and a feed can
+  be added immediately without first creating a category. *(#2)*
+- A signed-in user with no feeds sees the onboarding welcome (3 steps + "Add your first
+  feed" / "Import OPML" CTAs) instead of "All caught up". *(#5/#6)*
+- After adding a feed, the landing page no longer shows the onboarding block. *(#5/#6)*
+- The Settings page shows the active WebAuthn RP id / origin. *(#3, UI portion)*
+
+**Unit / Rust tests:**
+
+- `config::can_register` truth table including the new first-account-always row. *(#1)*
+- `create_user` seeds exactly one `Uncategorized` category for the new user. *(#2)*
+- `feed::count_by_user` (if added). *(#5)*
+
+**Not BDD-covered:** the startup RP-origin warning (#3 log) and the README/docker doc
+changes (#4) — covered by code review and (for the warning) a focused unit test on the
+warning predicate if one is extracted.
+
+## Out of scope
+
+- No registration UI redesign, no signup-flow changes beyond `can_register`.
+- No dismiss/persistence mechanism for the onboarding block.
+- No changes to OPML import behaviour (it already auto-creates categories).

--- a/e2e/features/category_nav.feature
+++ b/e2e/features/category_nav.feature
@@ -3,6 +3,7 @@ Feature: Category navigation shortcuts
 
   Background:
     Given I am signed in
+    And the default "Uncategorized" category is removed
     And I have a feed "Alpha Feed" with 2 test entries in category "Cat A"
     And I have a feed "Bravo Feed" with 2 test entries in category "Cat B"
     And I have a feed "Charlie Feed" with 2 test entries in category "Cat C"

--- a/e2e/features/onboarding.feature
+++ b/e2e/features/onboarding.feature
@@ -23,7 +23,7 @@ Feature: Onboarding from a fresh account to the first read
   Scenario: The landing page reserves "All caught up" for an account that has feeds
     Given I am signed in
     And I have a feed "My First Feed" in category "Uncategorized"
-    When I am on the unread inbox
+    When I open the landing page
     Then the landing page does not show the getting-started guide
     And I see "All caught up" on the landing page
 

--- a/e2e/features/onboarding.feature
+++ b/e2e/features/onboarding.feature
@@ -1,0 +1,33 @@
+@parallel
+Feature: Onboarding from a fresh account to the first read
+
+  A brand-new account should reach "reading feeds" without manual setup. A
+  default "Uncategorized" category lets the first feed be added immediately, and
+  the empty landing page guides the user toward adding or importing feeds
+  instead of claiming they are already "all caught up".
+
+  Scenario: A new account has a default category so the first feed adds immediately
+    Given I am signed in
+    And I am on the feeds page
+    Then the category dropdown offers "Uncategorized"
+    When I add a feed from the mock RSS server under "Uncategorized"
+    Then I see a success flash "Feed added"
+    And the feeds table contains "Test Feed"
+
+  Scenario: The empty landing page guides a new user to add their first feed
+    Given I am signed in
+    Then the landing page shows the getting-started guide
+    And I see an "Add your first feed" call to action
+    And I see an "Import OPML" call to action
+
+  Scenario: The landing page reserves "All caught up" for an account that has feeds
+    Given I am signed in
+    And I have a feed "My First Feed" in category "Uncategorized"
+    When I am on the unread inbox
+    Then the landing page does not show the getting-started guide
+    And I see "All caught up" on the landing page
+
+  Scenario: Settings shows the active WebAuthn relying-party origin
+    Given I am signed in
+    When I am on the settings page
+    Then I see the active WebAuthn RP origin

--- a/e2e/steps/onboarding.steps.js
+++ b/e2e/steps/onboarding.steps.js
@@ -1,0 +1,40 @@
+import { createBdd } from "playwright-bdd";
+import { test, expect } from "../support/fixtures.js";
+
+const { When, Then } = createBdd(test);
+
+When("I open the landing page", async ({ page, serverUrl }) => {
+  await page.goto(`${serverUrl}/`);
+});
+
+When("I am on the settings page", async ({ page, serverUrl }) => {
+  await page.goto(`${serverUrl}/settings`);
+});
+
+Then("the category dropdown offers {string}", async ({ page }, label) => {
+  await expect(page.getByTestId("feed-category-select")).toContainText(label);
+});
+
+Then("the landing page shows the getting-started guide", async ({ page }) => {
+  await expect(page.getByTestId("onboarding-guide")).toBeVisible();
+});
+
+Then("the landing page does not show the getting-started guide", async ({ page }) => {
+  await expect(page.getByTestId("onboarding-guide")).toHaveCount(0);
+});
+
+Then("I see an {string} call to action", async ({ page }, label) => {
+  await expect(
+    page.getByTestId("onboarding-guide").getByRole("link", { name: label })
+  ).toBeVisible();
+});
+
+Then("I see {string} on the landing page", async ({ page }, text) => {
+  await expect(page.getByText(text)).toBeVisible();
+});
+
+Then("I see the active WebAuthn RP origin", async ({ page }) => {
+  const origin = page.getByTestId("webauthn-rp-origin");
+  await expect(origin).toBeVisible();
+  await expect(origin).toContainText("http");
+});

--- a/e2e/steps/organize.steps.js
+++ b/e2e/steps/organize.steps.js
@@ -15,6 +15,11 @@ Given("I have a category named {string}", async ({ seed, currentUser }, name) =>
   seed.createCategory(userId, name);
 });
 
+Given("the default {string} category is removed", async ({ seed, currentUser }, name) => {
+  const userId = seed.getUserId(currentUser.username);
+  seed.deleteCategory(userId, name);
+});
+
 Given(
   "I have a feed {string} in category {string}",
   async ({ seed, currentUser }, feedTitle, categoryName) => {

--- a/e2e/support/seed.js
+++ b/e2e/support/seed.js
@@ -60,6 +60,15 @@ export class SeedHelper {
     }
   }
 
+  deleteCategory(userId, name) {
+    const db = new Database(this.dbPath);
+    try {
+      db.prepare(`DELETE FROM category WHERE user_id = ? AND name = ?`).run(userId, name);
+    } finally {
+      db.close();
+    }
+  }
+
   createFeed(categoryId, url, title) {
     const db = new Database(this.dbPath);
     try {

--- a/src/config.rs
+++ b/src/config.rs
@@ -72,8 +72,38 @@ impl Config {
         (secret, true)
     }
 
+    /// Whether a new account may be registered given the current user count.
+    ///
+    /// The very first account is always allowed so a fresh install (including a
+    /// source build that never set `SIGNUP_ENABLED`) can always create its
+    /// initial admin. Every subsequent account requires both `SIGNUP_ENABLED`
+    /// and `MULTI_USER_ENABLED`.
     pub fn can_register(&self, user_count: i64) -> bool {
-        self.signup_enabled && (self.multi_user_enabled || user_count == 0)
+        user_count == 0 || (self.signup_enabled && self.multi_user_enabled)
+    }
+
+    /// A startup warning about WebAuthn relying-party config that would silently
+    /// break passkeys in a real deployment, or `None` when the config looks
+    /// deployable. Returns a message when the RP origin still points at
+    /// `localhost` (the default), or when it disagrees with `PUBLIC_BASE_URL`.
+    pub fn webauthn_rp_warning(&self) -> Option<String> {
+        if self.webauthn_rp_origin.contains("localhost") {
+            return Some(format!(
+                "WEBAUTHN_RP_ORIGIN is still '{}'. Passkeys will be rejected from any other \
+                 origin — set WEBAUTHN_RP_ID and WEBAUTHN_RP_ORIGIN to your deployment domain.",
+                self.webauthn_rp_origin
+            ));
+        }
+        if let Some(base) = &self.public_base_url {
+            if base.trim_end_matches('/') != self.webauthn_rp_origin.trim_end_matches('/') {
+                return Some(format!(
+                    "WEBAUTHN_RP_ORIGIN ('{}') does not match PUBLIC_BASE_URL ('{}'). Passkeys \
+                     may be rejected — align WEBAUTHN_RP_ORIGIN with the URL users access.",
+                    self.webauthn_rp_origin, base
+                ));
+            }
+        }
+        None
     }
 }
 
@@ -99,11 +129,12 @@ mod tests {
 
     #[test]
     fn test_can_register() {
+        // Single-user (signup on, multi-user off): only the first account.
         let config = test_config();
-
         assert!(config.can_register(0));
         assert!(!config.can_register(1));
 
+        // Multi-user: every account is allowed.
         let config_multi = Config {
             multi_user_enabled: true,
             ..config.clone()
@@ -111,10 +142,42 @@ mod tests {
         assert!(config_multi.can_register(0));
         assert!(config_multi.can_register(5));
 
+        // Signup disabled: the first account still works (fresh-install bootstrap),
+        // but no further accounts may register.
         let config_disabled = Config {
             signup_enabled: false,
             ..config
         };
-        assert!(!config_disabled.can_register(0));
+        assert!(config_disabled.can_register(0));
+        assert!(!config_disabled.can_register(1));
+    }
+
+    #[test]
+    fn test_webauthn_rp_warning() {
+        // Default localhost origin → warn.
+        let config = test_config();
+        assert!(config.webauthn_rp_warning().is_some());
+
+        // Real domain, no PUBLIC_BASE_URL → fine.
+        let deployed = Config {
+            webauthn_rp_id: "rdrs.example.com".to_string(),
+            webauthn_rp_origin: "https://rdrs.example.com".to_string(),
+            ..test_config()
+        };
+        assert!(deployed.webauthn_rp_warning().is_none());
+
+        // Real domain matching PUBLIC_BASE_URL (trailing slash ignored) → fine.
+        let matched = Config {
+            public_base_url: Some("https://rdrs.example.com/".to_string()),
+            ..deployed.clone()
+        };
+        assert!(matched.webauthn_rp_warning().is_none());
+
+        // Real domain disagreeing with PUBLIC_BASE_URL → warn.
+        let mismatched = Config {
+            public_base_url: Some("https://reader.example.com".to_string()),
+            ..deployed
+        };
+        assert!(mismatched.webauthn_rp_warning().is_some());
     }
 }

--- a/src/handlers/auth.rs
+++ b/src/handlers/auth.rs
@@ -6,6 +6,7 @@ use time::Duration;
 use crate::auth::{hash_password, verify_password};
 use crate::error::{AppError, AppResult};
 use crate::middleware::{AuthUser, SESSION_COOKIE_NAME};
+use crate::models::category;
 use crate::models::session;
 use crate::models::user::{self, Role};
 use crate::AppState;
@@ -56,6 +57,12 @@ pub async fn register(
             };
 
             let user = user::create_user(conn, &req.username, &password_hash, role)?;
+
+            // Seed a default category so the account can add its first feed
+            // without first creating a category. Matches the "Uncategorized"
+            // convention used by OPML import and the GReader subscription API.
+            category::create_category(conn, user.id, "Uncategorized")?;
+
             Ok::<_, AppError>(user)
         })
         .await??;

--- a/src/handlers/pages.rs
+++ b/src/handlers/pages.rs
@@ -145,6 +145,12 @@ pub struct EntriesLayoutContext {
     /// read (loaded + Load-More-appended rows; unloaded entries are
     /// untouched). Only the feed + category entries pages set this true.
     pub show_mark_above: bool,
+    /// When `true` and the list is empty, the shared layout renders the
+    /// getting-started onboarding block (welcome + 3 steps + "Add your first
+    /// feed" / "Import OPML" CTAs) instead of the plain empty-state text. Set
+    /// only by the landing page (`/`) when the account has no feeds; every
+    /// other route leaves it `false`.
+    pub onboarding: bool,
 }
 
 /// Map an `EntryWithFeed` (+ optional summary status) to an `EntryRowView`.
@@ -587,6 +593,17 @@ pub async fn unread_page(
     .await;
     let reading_pane = maybe_build_reading_pane(&state, user_id, query.entry).await;
 
+    // When the unread list is empty, distinguish a brand-new account with no
+    // feeds yet (→ getting-started onboarding) from an inbox where everything
+    // has been read (→ "All caught up"). Only query when the list is empty.
+    let no_feeds = entries.is_empty()
+        && state
+            .db
+            .read_user(move |conn| feed::count_by_user(conn, user_id).unwrap_or(0))
+            .await
+            .map(|count| count == 0)
+            .unwrap_or(false);
+
     (
         flash,
         UnreadTemplate {
@@ -611,6 +628,7 @@ pub async fn unread_page(
                 filter_tabs: None,
                 status_filter: None,
                 show_mark_above: false,
+                onboarding: no_feeds,
             },
         },
     )
@@ -1110,6 +1128,7 @@ pub async fn entries_page(
                 filter_tabs: None,
                 status_filter: None,
                 show_mark_above: false,
+                onboarding: false,
             },
         },
     )
@@ -1186,6 +1205,9 @@ pub async fn settings_page(
             signup_enabled: state.config.signup_enabled,
             multi_user_enabled: state.config.multi_user_enabled,
             image_proxy_secret_generated: state.config.image_proxy_secret_generated,
+            webauthn_rp_id: state.config.webauthn_rp_id.clone(),
+            webauthn_rp_origin: state.config.webauthn_rp_origin.clone(),
+            webauthn_rp_name: state.config.webauthn_rp_name.clone(),
         },
     )
 }
@@ -1266,6 +1288,7 @@ pub async fn read_entries_page(
                 filter_tabs: None,
                 status_filter: None,
                 show_mark_above: false,
+                onboarding: false,
             },
         },
     )
@@ -1348,6 +1371,7 @@ pub async fn starred_entries_page(
                 filter_tabs: None,
                 status_filter: None,
                 show_mark_above: false,
+                onboarding: false,
             },
         },
     )
@@ -1430,6 +1454,7 @@ pub async fn summarized_entries_page(
                 filter_tabs: None,
                 status_filter: None,
                 show_mark_above: false,
+                onboarding: false,
             },
         },
     )
@@ -1570,6 +1595,7 @@ pub async fn category_entries_page(
             filter_tabs,
             status_filter,
             show_mark_above: true,
+            onboarding: false,
         },
     };
 
@@ -2024,6 +2050,7 @@ pub async fn feed_entries_page(
             filter_tabs,
             status_filter,
             show_mark_above: true,
+            onboarding: false,
         },
     };
 
@@ -2147,6 +2174,9 @@ pub struct SettingsTemplate {
     pub signup_enabled: bool,
     pub multi_user_enabled: bool,
     pub image_proxy_secret_generated: bool,
+    pub webauthn_rp_id: String,
+    pub webauthn_rp_origin: String,
+    pub webauthn_rp_name: String,
 }
 
 impl IntoResponse for SettingsTemplate {

--- a/src/handlers/user.rs
+++ b/src/handlers/user.rs
@@ -189,13 +189,14 @@ pub async fn read_chrome_data(
         };
     }
 
-    let fresh = state
+    let (fresh, has_feeds) = state
         .db
         .read_user(move |conn| {
             let theme = user_settings::get_theme(conn, user_id).unwrap_or(None);
             let cats = category::list_by_user(conn, user_id).unwrap_or_default();
             let unread_by_cat = entry::count_unread_by_category(conn, user_id).unwrap_or_default();
             let total_unread = entry::count_unread_by_user(conn, user_id).unwrap_or(0);
+            let has_feeds = crate::models::feed::count_by_user(conn, user_id).unwrap_or(0) > 0;
             let categories: Vec<SidebarCategoryDto> = cats
                 .into_iter()
                 .map(|c| SidebarCategoryDto {
@@ -204,23 +205,27 @@ pub async fn read_chrome_data(
                     unread_count: *unread_by_cat.get(&c.id).unwrap_or(&0),
                 })
                 .collect();
-            crate::services::CachedChrome {
-                theme,
-                categories,
-                total_unread,
-            }
+            (
+                crate::services::CachedChrome {
+                    theme,
+                    categories,
+                    total_unread,
+                },
+                has_feeds,
+            )
         })
         .await
         .unwrap_or_default();
 
-    // Skip caching the "completely empty" state (no categories, no unread).
-    // Real new accounts pay a trivial extra query per page load until they
-    // add their first feed; cache populates normally after that. The
-    // benefit: the empty state is the most likely-to-go-stale entry —
-    // anything added via a path that bypasses our handler bust hooks (e.g.
-    // E2E tests that seed straight into SQLite) would otherwise be hidden
-    // behind a stale empty cache for up to the 60 s TTL.
-    if !fresh.categories.is_empty() || fresh.total_unread > 0 {
+    // Skip caching the "no content yet" state — an account with no feeds and no
+    // unread (e.g. a brand-new account whose only category is the auto-seeded
+    // empty "Uncategorized"). Such accounts pay a trivial extra query per page
+    // load until they add their first feed; the cache populates normally after
+    // that. The benefit: the empty state is the most likely-to-go-stale entry —
+    // anything added via a path that bypasses our handler bust hooks (e.g. E2E
+    // tests that seed straight into SQLite) would otherwise be hidden behind a
+    // stale cache for up to the 60 s TTL.
+    if has_feeds || fresh.total_unread > 0 {
         state.sidebar_cache.insert(user_id, fresh.clone());
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,10 @@ async fn main() {
         );
     }
 
+    if let Some(warning) = config.webauthn_rp_warning() {
+        tracing::warn!("{warning}");
+    }
+
     let write_conn = Connection::open(&config.database_url).expect("Failed to open database");
     db::init_db(&write_conn).expect("Failed to initialize database");
 

--- a/src/models/feed.rs
+++ b/src/models/feed.rs
@@ -178,6 +178,21 @@ pub fn list_by_user(conn: &Connection, user_id: i64) -> AppResult<Vec<Feed>> {
     Ok(feeds)
 }
 
+/// Count how many feeds a user has subscribed to (across all categories).
+pub fn count_by_user(conn: &Connection, user_id: i64) -> AppResult<i64> {
+    conn.query_row(
+        r#"
+        SELECT COUNT(*)
+        FROM feed f
+        INNER JOIN category c ON f.category_id = c.id
+        WHERE c.user_id = ?1
+        "#,
+        params![user_id],
+        |row| row.get(0),
+    )
+    .map_err(AppError::Database)
+}
+
 /// Find a feed by URL across all categories for a given user.
 pub fn find_by_url_for_user(conn: &Connection, url: &str, user_id: i64) -> AppResult<Option<Feed>> {
     conn.query_row(
@@ -629,5 +644,40 @@ mod tests {
 
         // Feed should be deleted too
         assert!(find_by_id(&conn, feed.id).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_count_by_user() {
+        let conn = setup_db();
+        let user_id = create_test_user(&conn, "testuser");
+        let other_id = create_test_user(&conn, "other");
+        let category_id = create_test_category(&conn, user_id, "Tech");
+
+        // No feeds yet.
+        assert_eq!(count_by_user(&conn, user_id).unwrap(), 0);
+
+        for url in [
+            "https://a.example.com/feed.xml",
+            "https://b.example.com/feed.xml",
+        ] {
+            create_feed(
+                &conn,
+                &CreateFeedParams {
+                    category_id,
+                    url,
+                    title: None,
+                    description: None,
+                    site_url: None,
+                    custom_user_agent: None,
+                    http2_disabled: None,
+                    custom_referrer: None,
+                },
+            )
+            .unwrap();
+        }
+
+        assert_eq!(count_by_user(&conn, user_id).unwrap(), 2);
+        // Another user's count is isolated.
+        assert_eq!(count_by_user(&conn, other_id).unwrap(), 0);
     }
 }

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -1376,6 +1376,27 @@ dialog::backdrop {
     margin: 0;
 }
 
+/* Onboarding empty state on the landing page (no feeds yet). */
+.onboarding-guide .empty-state-quiet-text {
+    font-style: normal;
+}
+.onboarding-steps {
+    display: inline-block;
+    text-align: left;
+    margin: var(--space-4) 0;
+    padding-left: var(--space-6);
+    color: var(--color-text-secondary);
+    font-size: var(--font-sm);
+    line-height: 1.8;
+}
+.onboarding-cta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-3);
+    justify-content: center;
+    margin-top: var(--space-4);
+}
+
 /* ===== /search page ===== */
 /* Search form follows the standard form-group / button conventions used on
    /categories, /feeds, /user-settings. No custom borderless input; no custom

--- a/templates/_entries_layout.html
+++ b/templates/_entries_layout.html
@@ -48,10 +48,26 @@
                     </div>
                     <div class="list-pane-body" data-entries-list>
                         {% if entries.is_empty() %}
-                            <div class="empty-state-quiet">
-                                <p class="empty-state-quiet-title">{{ entries_layout.empty_title }}</p>
-                                <p class="empty-state-quiet-text">{{ entries_layout.empty_detail }}</p>
-                            </div>
+                            {% if entries_layout.onboarding %}
+                                <div class="empty-state-quiet onboarding-guide" data-testid="onboarding-guide">
+                                    <p class="empty-state-quiet-title">Welcome to rdrs</p>
+                                    <p class="empty-state-quiet-text">Three steps to your first read:</p>
+                                    <ol class="onboarding-steps">
+                                        <li>Add a feed, or import an OPML file</li>
+                                        <li>Wait for the first sync to fetch entries</li>
+                                        <li>Read</li>
+                                    </ol>
+                                    <div class="onboarding-cta">
+                                        <a href="/feeds" class="btn" data-testid="onboarding-add-feed">Add your first feed →</a>
+                                        <a href="/feeds/import" class="btn btn-secondary" data-testid="onboarding-import-opml">Import OPML</a>
+                                    </div>
+                                </div>
+                            {% else %}
+                                <div class="empty-state-quiet">
+                                    <p class="empty-state-quiet-title">{{ entries_layout.empty_title }}</p>
+                                    <p class="empty-state-quiet-text">{{ entries_layout.empty_detail }}</p>
+                                </div>
+                            {% endif %}
                         {% else %}
                             {% for r in entries %}{% include "_entry_row.html" %}{% endfor %}
                             {% if let Some(after) = next_cursor %}

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -61,6 +61,24 @@
                                 <td data-label="Default"><em>(auto-generated)</em></td>
                                 <td data-label="Current">{% if image_proxy_secret_generated %}<span class="muted">Auto-generated</span>{% else %}<span class="success-text">Configured</span>{% endif %}</td>
                             </tr>
+                            <tr>
+                                <td><code>WEBAUTHN_RP_ID</code></td>
+                                <td data-label="Description">WebAuthn Relying Party ID for passkeys</td>
+                                <td data-label="Default"><code>localhost</code></td>
+                                <td data-label="Current"><code data-testid="webauthn-rp-id">{{ webauthn_rp_id }}</code></td>
+                            </tr>
+                            <tr>
+                                <td><code>WEBAUTHN_RP_ORIGIN</code></td>
+                                <td data-label="Description">WebAuthn Relying Party origin URL (must match the URL you deploy at)</td>
+                                <td data-label="Default"><code>http://localhost:{port}</code></td>
+                                <td data-label="Current"><code data-testid="webauthn-rp-origin">{{ webauthn_rp_origin }}</code></td>
+                            </tr>
+                            <tr>
+                                <td><code>WEBAUTHN_RP_NAME</code></td>
+                                <td data-label="Description">WebAuthn Relying Party display name</td>
+                                <td data-label="Default"><code>rdrs</code></td>
+                                <td data-label="Current"><code data-testid="webauthn-rp-name">{{ webauthn_rp_name }}</code></td>
+                            </tr>
                         </tbody>
                     </table>
                 </div>

--- a/tests/auth_test.rs
+++ b/tests/auth_test.rs
@@ -127,12 +127,24 @@ async fn test_register_duplicate_username() {
 }
 
 #[tokio::test]
-async fn test_register_disabled() {
+async fn test_register_disabled_still_allows_first_account() {
+    // With signup disabled, a fresh install must still be able to create its
+    // first (admin) account — otherwise a source build is unusable. Subsequent
+    // registrations stay blocked.
     let config = Config {
         signup_enabled: false,
         ..default_test_config()
     };
     let server = create_test_server(config);
+
+    server
+        .post("/api/register")
+        .json(&json!({
+            "username": "admin",
+            "password": "password123"
+        }))
+        .await
+        .assert_status(StatusCode::CREATED);
 
     let response = server
         .post("/api/register")

--- a/tests/handlers_test.rs
+++ b/tests/handlers_test.rs
@@ -237,8 +237,9 @@ async fn test_list_categories() {
     create_category(&server, "News").await;
     create_category(&server, "Sports").await;
 
+    // 3 created + the "Uncategorized" category seeded at registration.
     let count = count_folder_tags(&server).await;
-    assert_eq!(count, 3);
+    assert_eq!(count, 4);
 }
 
 #[tokio::test]
@@ -809,9 +810,9 @@ async fn test_import_opml_multiple_categories() {
     let body: serde_json::Value = response.json();
     assert_eq!(body["subscriptions"].as_array().unwrap().len(), 3);
 
-    // Verify 2 folder-type tags
+    // Verify 2 imported folder-type tags + the seeded "Uncategorized".
     let count = count_folder_tags(&server).await;
-    assert_eq!(count, 2);
+    assert_eq!(count, 3);
 }
 
 // ============================================================================
@@ -1385,9 +1386,10 @@ async fn test_category_isolation_between_users() {
         .await
         .assert_status_ok();
 
-    // User2's tag/list should have no folder tags (only 4 built-in state tags)
-    let count = count_folder_tags(&server).await;
-    assert_eq!(count, 0);
+    // User2 sees only its own seeded "Uncategorized", never User1's category.
+    let names = get_folder_tag_names(&server).await;
+    assert!(!names.contains(&"User1 Category".to_string()));
+    assert_eq!(names, vec!["Uncategorized".to_string()]);
 }
 
 // ============================================================================
@@ -3015,7 +3017,11 @@ async fn test_create_category_form_empty_name() {
         })
         .await
         .unwrap();
-    assert_eq!(count, 0, "no category should be created for an empty name");
+    // Only the seeded "Uncategorized" remains; the empty name created nothing.
+    assert_eq!(
+        count, 1,
+        "no category should be created for an empty name (only the seeded default)"
+    );
 }
 
 #[tokio::test]

--- a/tests/pages_test.rs
+++ b/tests/pages_test.rs
@@ -119,7 +119,30 @@ async fn login(server: &TestServer, username: &str) {
 #[tokio::test]
 async fn test_unread_page_renders_ssr_layout() {
     let app = create_test_app(default_test_config());
-    setup_users(&app.db).await;
+    let (admin_id, _) = setup_users(&app.db).await;
+
+    // Give admin a feed (no entries) so the empty unread list is the genuine
+    // "all caught up" case rather than the no-feeds onboarding case.
+    app.db
+        .user(move |conn| {
+            let cat = rdrs::models::category::create_category(conn, admin_id, "Tech").unwrap();
+            rdrs::models::feed::create_feed(
+                conn,
+                &rdrs::models::feed::CreateFeedParams {
+                    category_id: cat.id,
+                    url: "https://example.com/feed.xml",
+                    title: Some("Test Feed"),
+                    description: None,
+                    site_url: None,
+                    custom_user_agent: None,
+                    http2_disabled: None,
+                    custom_referrer: None,
+                },
+            )
+            .unwrap();
+        })
+        .await
+        .unwrap();
 
     login(&app.server, "admin").await;
 
@@ -139,6 +162,25 @@ async fn test_unread_page_renders_ssr_layout() {
     assert!(body.contains("class=\"empty-state-quiet\""));
     assert!(body.contains("class=\"empty-state-quiet-title\""));
     assert!(body.contains("All caught up"));
+}
+
+#[tokio::test]
+async fn test_unread_page_shows_onboarding_when_no_feeds() {
+    // A brand-new account with no feeds gets the getting-started guide, not the
+    // misleading "All caught up" empty state.
+    let app = create_test_app(default_test_config());
+    setup_users(&app.db).await;
+
+    login(&app.server, "admin").await;
+
+    let response = app.server.get("/").await;
+    response.assert_status_ok();
+    let body = response.text();
+
+    assert!(body.contains("data-testid=\"onboarding-guide\""));
+    assert!(body.contains("Add your first feed"));
+    assert!(body.contains("Import OPML"));
+    assert!(!body.contains("All caught up"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
Closes #269.

Fixes the fresh-install happy path (*found the project* → *reading feeds*), which was broken by two hard blockers, plus several first-run and deployment gaps.

## Changes

- **#1 — First account always registers.** `Config::can_register` now allows the very first account even when `SIGNUP_ENABLED=false` (the default), so a source build is usable out of the box. The flag (with `MULTI_USER_ENABLED`) still gates every subsequent account.
- **#2 — Seed `Uncategorized` at registration.** A new account gets a default category, so the first feed can be added without first creating a category (the Add Feed `<select required>` is never empty). Seeding lives in the `register` handler — passkeys attach to already-authenticated users, so the password register flow is the only real account-creation entry point, and `models::user::create_user` stays pure (no test-fixture churn).
- **#3 — Surface & warn about WebAuthn RP config.** Settings now shows the active `WEBAUTHN_RP_ID` / `WEBAUTHN_RP_ORIGIN` / `WEBAUTHN_RP_NAME`; a startup warning fires when the RP origin still points at `localhost` or disagrees with `PUBLIC_BASE_URL`; README documents these as required behind a domain.
- **#4 — `IMAGE_PROXY_SECRET` in the docker quick-start.** Added to the `docker run` snippet with an `openssl rand -base64 32` generate/persist note and the restart-invalidation caveat.
- **#5 / #6 — Landing-page onboarding.** When the account has no feeds, the landing page renders a getting-started empty state (welcome + 3 steps + "Add your first feed" / "Import OPML" CTAs) instead of the misleading "All caught up", which is now reserved for the genuinely-all-read case.

### Incidental fix

Gating the sidebar cache on *feeds/unread* rather than on *having any category*. Seeding `Uncategorized` otherwise caused a brand-new account to cache a `[Uncategorized]`-only sidebar, masking direct-DB-seeded feeds (E2E) behind the 60 s stale-empty cache.

### Also

- Track `e2e/` npm dependencies with dependabot (Playwright, playwright-bdd, etc.).

## Testing

- Rust: 756 tests pass — added coverage for the `can_register` truth table, the RP-origin warning predicate, `feed::count_by_user`, registration category seeding, and the no-feeds onboarding render. Adjusted GReader tag-list and category-nav expectations for the now-always-present default category.
- E2E: 81 scenarios pass, including a new `onboarding.feature` (default category, getting-started guide vs "All caught up", active WebAuthn RP origin on Settings).
- `cargo clippy --all-targets` and `cargo fmt --check` clean.

Note: #1's "signup disabled, first account still registers" is verified by a Rust unit test rather than BDD — the shared, worker-scoped E2E server is hard-wired to `SIGNUP_ENABLED=true`, so the precondition can't be expressed there.

Design spec: `docs/superpowers/specs/2026-06-08-onboarding-improvements-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)