### PR TITLE
fix(reading): keep mobile prev/next live after Fetch Full Content

### DIFF
--- a/e2e/features/reading.feature
+++ b/e2e/features/reading.feature
@@ -154,3 +154,21 @@ Feature: Reading entries
     And I click the entry titled "Test Entry 5"
     Then the reading-pane "Previous" button is enabled
     And the reading-pane "Next" button is disabled
+
+  # Regression: Fetch Full Content re-renders the pane for the *same* entry,
+  # resetting prev/next to their default disabled state. The neighbour
+  # re-resolve skipped re-enabling them because the entry id was unchanged,
+  # so the freshly-rendered buttons stayed disabled forever. Disabled buttons
+  # swallow taps, killing mobile navigation permanently (desktop j/k bypasses
+  # the buttons, which is why the breakage was mobile-only).
+  @mobile
+  Scenario: Reading-pane navigation survives Fetch Full Content on mobile
+    Given I am viewing on a mobile screen
+    When I open the all entries page
+    And I click the entry titled "Test Entry 3"
+    And I click the "Fetch Full Content" button
+    And I see a flash message
+    Then the reading-pane "Next" button is enabled
+    And the reading-pane "Previous" button is enabled
+    When I navigate to the "Next" entry in the reading pane
+    Then the reading pane shows the title "Test Entry 4"

--- a/e2e/steps/entries.steps.js
+++ b/e2e/steps/entries.steps.js
@@ -300,3 +300,11 @@ Then("the entry row for {string} shows as read", async ({ page }, title) => {
 Then("I see no flash message", async ({ page }) => {
   await expect(page.getByTestId("flash-message")).toHaveCount(0);
 });
+
+// Barrier for form-action swaps whose only visible signal is a toast (Save /
+// Fetch Full Content). The flash is shown right after the reading-pane swap
+// lands and the neighbour re-resolve fires, so waiting on it sequences any
+// follow-up navigation after the pane has fully settled.
+Then("I see a flash message", async ({ page }) => {
+  await expect(page.getByTestId("flash-message").first()).toBeVisible();
+});

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -349,7 +349,17 @@ async function resolveNeighbors(entryId) {
 let lastResolvedPaneId = null;
 function maybeResolveNeighbors() {
     const id = currentPaneEntryId();
-    if (id === lastResolvedPaneId) return;
+    if (id === lastResolvedPaneId) {
+        // Same entry, but the pane DOM may have just been re-rendered by an
+        // action swap that re-targets the same entry (Fetch Full Content /
+        // Save) — which resets prev/next to their default `disabled` state.
+        // neighborState is still valid here, so re-apply it; otherwise the
+        // freshly-rendered buttons stay permanently disabled and, because a
+        // disabled button swallows taps, mobile prev/next navigation dies for
+        // good (desktop j/k bypasses the buttons via navigateNeighbor()).
+        applyNeighborButtons();
+        return;
+    }
     lastResolvedPaneId = id;
     if (id == null) {
         neighborState = { entryId: null, prevId: null, nextId: null };


### PR DESCRIPTION
## Problem

On the mobile layout, tapping **Fetch Full Content** permanently broke the reading-pane **Previous / Next** buttons — they stopped working and never recovered.

## Root cause

Fetch Full Content (and Save) return `ReadingPaneWithFlash`, which re-renders `#reading-pane` for the *same* entry. The template renders prev/next as `disabled` by default; `app.js` enables them via `applyNeighborButtons()` once neighbours resolve.

After the action swap, `maybeResolveNeighbors()` bailed out early because the entry id was unchanged (`id === lastResolvedPaneId`), so it never re-enabled the freshly-rendered buttons. They stayed `disabled` forever, and a disabled button swallows taps — killing mobile navigation. Desktop `j`/`k` calls `navigateNeighbor()` directly and bypasses the buttons, which is why the breakage was mobile-only.

## Fix

When the pane settles on the same entry, re-apply the still-valid `neighborState` instead of bailing out, restoring the buttons after an action swap. This naturally covers Save too.

## Tests

- New `@mobile` BDD regression scenario in `reading.feature` (mobile viewport → open entry → Fetch Full Content → assert Next/Previous stay live and navigate).
- New reusable `I see a flash message` barrier step to sequence assertions after the action swap lands (removes a test race).

Verified: scenario fails 3/3 without the fix, passes 5/5 with it; full `reading` + `responsive` suites pass 34/34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)