### PR TITLE
fix(reading): decode HTML entities in entry titles

### DIFF
--- a/src/handlers/entries.rs
+++ b/src/handlers/entries.rs
@@ -200,11 +200,16 @@ pub(crate) async fn build_reading_pane_view(
         title: ewf
             .entry
             .title
-            .clone()
+            .as_deref()
+            .map(crate::services::decode_html_entities)
             .unwrap_or_else(|| "(no title)".to_string()),
         link: ewf.entry.link.clone(),
         feed_title: ewf.feed_title.clone().unwrap_or_default(),
-        author: ewf.entry.author.clone(),
+        author: ewf
+            .entry
+            .author
+            .as_deref()
+            .map(crate::services::decode_html_entities),
         published_at_iso: published_at.map(|t| t.to_rfc3339()),
         published_relative: format_relative_time(published_at).0,
         content_html,

--- a/src/handlers/pages/mod.rs
+++ b/src/handlers/pages/mod.rs
@@ -163,7 +163,8 @@ pub(crate) fn row_view_from(
     let title = e
         .entry
         .title
-        .clone()
+        .as_deref()
+        .map(crate::services::decode_html_entities)
         .unwrap_or_else(|| "(no title)".to_string());
     let published_at = e.entry.published_at.unwrap_or(e.entry.created_at);
     EntryRowView {
@@ -2602,7 +2603,51 @@ pub async fn categories_page(
 
 #[cfg(test)]
 mod tests {
-    use super::{build_snippet, highlight_html};
+    use super::{build_snippet, highlight_html, row_view_from};
+    use crate::models::entry::{Entry, EntryWithFeed};
+    use chrono::Utc;
+
+    fn ewf_with_title(title: &str) -> EntryWithFeed {
+        let now = Utc::now();
+        EntryWithFeed {
+            entry: Entry {
+                id: 1,
+                feed_id: 1,
+                guid: "g".to_string(),
+                title: Some(title.to_string()),
+                link: None,
+                content: None,
+                summary: None,
+                author: None,
+                published_at: Some(now),
+                read_at: None,
+                starred_at: None,
+                created_at: now,
+                updated_at: now,
+            },
+            feed_title: Some("Feed".to_string()),
+            feed_url: "https://example.com/feed".to_string(),
+            site_url: None,
+            category_id: 1,
+            category_name: "Cat".to_string(),
+            feed_has_icon: false,
+            custom_referrer: None,
+        }
+    }
+
+    #[test]
+    fn row_view_decodes_hex_entity_in_title() {
+        let ewf = ewf_with_title("Collabora&#x27;s CODE 26.04 Release");
+        let row = row_view_from(&ewf, None);
+        assert_eq!(row.title, "Collabora's CODE 26.04 Release");
+    }
+
+    #[test]
+    fn row_view_decodes_decimal_and_named_entities() {
+        let ewf = ewf_with_title("Tom &amp; Jerry&#39;s &quot;day&quot;");
+        let row = row_view_from(&ewf, None);
+        assert_eq!(row.title, "Tom & Jerry's \"day\"");
+    }
 
     #[test]
     fn highlight_wraps_simple_match() {

--- a/src/services/html_entities.rs
+++ b/src/services/html_entities.rs
@@ -1,0 +1,170 @@
+//! Minimal HTML entity decoder for plain-text fields (entry titles, author
+//! names, OPML labels). Some feeds double-encode entities (e.g. emit
+//! `&amp;#x27;`); feed-rs / quick-xml only unescape one layer, leaving a
+//! literal `&#x27;` in the stored value. When Askama then auto-escapes the
+//! field for rendering, the `&` is escaped again and the reader sees the
+//! literal `&#x27;` instead of `'`. Decoding the residual entity before
+//! handing the string to the template fixes the display.
+//!
+//! Scope is deliberately narrow: named entities common in feed text, plus
+//! decimal (`&#NN;`) and hexadecimal (`&#xNN;` / `&#XNN;`) numeric character
+//! references. Unknown or malformed sequences are left verbatim — never a
+//! panic. This MUST NOT be applied to HTML fields (content / summary) that go
+//! through `sanitize_html`, only to plain-text fields.
+
+/// Decode the named/numeric HTML entities we care about in plain text.
+///
+/// Recognizes `&amp; &lt; &gt; &quot; &apos; &#39;`, decimal references
+/// `&#NN;`, and hex references `&#xNN;` / `&#XNN;`. Anything else (unknown
+/// name, missing terminating `;`, non-digit body, out-of-range code point)
+/// is preserved unchanged.
+pub fn decode_html_entities(s: &str) -> String {
+    // Fast path: no entity markers at all.
+    if !s.contains('&') {
+        return s.to_string();
+    }
+
+    let mut out = String::with_capacity(s.len());
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] != b'&' {
+            // Copy the current UTF-8 char wholesale (handles multibyte).
+            let ch_len = utf8_len(bytes[i]);
+            out.push_str(&s[i..i + ch_len]);
+            i += ch_len;
+            continue;
+        }
+
+        // Find the terminating ';' within a small window.
+        if let Some(semi) = s[i + 1..]
+            .char_indices()
+            .take_while(|&(off, _)| off < 32)
+            .find(|&(_, c)| c == ';')
+            .map(|(off, _)| i + 1 + off)
+        {
+            let body = &s[i + 1..semi];
+            if let Some(decoded) = decode_one(body) {
+                out.push(decoded);
+                i = semi + 1;
+                continue;
+            }
+        }
+
+        // Not a recognized entity — keep the '&' literal and move on.
+        out.push('&');
+        i += 1;
+    }
+    out
+}
+
+/// Decode the inside of a single `&…;` (the body excludes `&` and `;`).
+/// Returns `None` when the body is not a recognized entity.
+fn decode_one(body: &str) -> Option<char> {
+    match body {
+        "amp" => Some('&'),
+        "lt" => Some('<'),
+        "gt" => Some('>'),
+        "quot" => Some('"'),
+        "apos" => Some('\''),
+        _ => {
+            let num = body.strip_prefix('#')?;
+            let code = if let Some(hex) = num.strip_prefix(['x', 'X']) {
+                u32::from_str_radix(hex, 16).ok()?
+            } else {
+                num.parse::<u32>().ok()?
+            };
+            char::from_u32(code)
+        }
+    }
+}
+
+/// Byte length of the UTF-8 char starting at the given lead byte.
+fn utf8_len(lead: u8) -> usize {
+    match lead {
+        b if b < 0x80 => 1,
+        b if b >> 5 == 0b110 => 2,
+        b if b >> 4 == 0b1110 => 3,
+        _ => 4,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hex_reference_lowercase() {
+        assert_eq!(
+            decode_html_entities("Collabora&#x27;s CODE"),
+            "Collabora's CODE"
+        );
+    }
+
+    #[test]
+    fn hex_reference_uppercase_marker() {
+        assert_eq!(decode_html_entities("a&#X27;b"), "a'b");
+    }
+
+    #[test]
+    fn decimal_reference() {
+        assert_eq!(decode_html_entities("it&#39;s"), "it's");
+    }
+
+    #[test]
+    fn named_amp() {
+        assert_eq!(decode_html_entities("Tom &amp; Jerry"), "Tom & Jerry");
+    }
+
+    #[test]
+    fn named_quot_and_apos() {
+        assert_eq!(
+            decode_html_entities("&quot;hi&quot; &apos;yo&apos;"),
+            "\"hi\" 'yo'"
+        );
+    }
+
+    #[test]
+    fn named_lt_gt() {
+        assert_eq!(decode_html_entities("&lt;tag&gt;"), "<tag>");
+    }
+
+    #[test]
+    fn mixed() {
+        assert_eq!(
+            decode_html_entities("A &amp; B &#x27;C&#x27; &lt;d&gt; &#39;e&#39;"),
+            "A & B 'C' <d> 'e'"
+        );
+    }
+
+    #[test]
+    fn no_entities() {
+        assert_eq!(
+            decode_html_entities("plain text, no entities"),
+            "plain text, no entities"
+        );
+    }
+
+    #[test]
+    fn invalid_sequences_preserved() {
+        // Unknown name, missing semicolon, non-numeric body, bad code point.
+        assert_eq!(decode_html_entities("R&D"), "R&D");
+        assert_eq!(decode_html_entities("a&unknown;b"), "a&unknown;b");
+        assert_eq!(decode_html_entities("100&#nope;"), "100&#nope;");
+        assert_eq!(decode_html_entities("a & b"), "a & b");
+        // Out-of-range Unicode scalar -> char::from_u32 returns None.
+        assert_eq!(decode_html_entities("&#xFFFFFFFF;"), "&#xFFFFFFFF;");
+        // Surrogate code point is not a valid char.
+        assert_eq!(decode_html_entities("&#xD800;"), "&#xD800;");
+    }
+
+    #[test]
+    fn multibyte_passthrough() {
+        assert_eq!(decode_html_entities("日本語 &amp; 中文"), "日本語 & 中文");
+    }
+
+    #[test]
+    fn trailing_ampersand() {
+        assert_eq!(decode_html_entities("ends with &"), "ends with &");
+    }
+}

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,6 +1,7 @@
 pub mod background;
 pub mod feed_discovery;
 pub mod feed_sync;
+pub mod html_entities;
 pub mod http;
 pub mod icon_fetcher;
 pub mod image_proxy;
@@ -18,6 +19,7 @@ pub mod summary_worker;
 pub use background::start_background_sync;
 pub use feed_discovery::{discover_feed, DiscoveredFeed};
 pub use feed_sync::{refresh_feed, SyncResult};
+pub use html_entities::decode_html_entities;
 pub use image_proxy::{
     create_proxy_url, create_proxy_url_with_referrer, sign_url, sign_url_with_referrer,
     verify_signature, verify_signature_with_referrer,

--- a/src/services/opml.rs
+++ b/src/services/opml.rs
@@ -6,16 +6,7 @@ use std::io::Cursor;
 
 use crate::error::{AppError, AppResult};
 use crate::models::{category::Category, feed::Feed};
-
-/// Decode HTML entities in a string (e.g., &amp; -> &)
-fn decode_html_entities(s: &str) -> String {
-    s.replace("&amp;", "&")
-        .replace("&lt;", "<")
-        .replace("&gt;", ">")
-        .replace("&quot;", "\"")
-        .replace("&#39;", "'")
-        .replace("&apos;", "'")
-}
+use crate::services::html_entities::decode_html_entities;
 
 #[derive(Debug, Clone)]
 pub struct OpmlFeed {


### PR DESCRIPTION
## Problem

Entry titles rendered literal HTML entities — readers saw `Collabora&#x27;s CODE 26.04 Release...` instead of `Collabora's CODE...`.

## Root cause

Some feeds double-encode entities (e.g. emit `&amp;#x27;`). `feed-rs` / `quick-xml` only unescape **one** layer, so the title stored in the DB keeps a literal `&#x27;`. At render time Askama auto-escapes the field (`{{ pane.title }}`, no `|safe`), escaping the `&` a second time, so the browser shows the literal `&#x27;`.

## Fix

- New plain-text decoder `services/html_entities::decode_html_entities`. Supports:
  - named entities `&amp; &lt; &gt; &quot; &apos;`,
  - decimal references `&#NN;`,
  - hex references `&#xNN;` / `&#XNN;` (both marker cases).
  - Unknown / malformed sequences (bad name, missing `;`, non-numeric body, out-of-range / surrogate code point) are preserved verbatim — never panics. No new crate; small hand-written function.
- Applied at **render time** to plain-text fields only:
  - `row_view_from` → entry-row title,
  - `build_reading_pane_view` → reading-pane title + author.
  - HTML fields (`content` / `summary`) are untouched — they still pass through `sanitize_html`.
- The pre-existing `opml.rs` decoder (which lacked numeric/hex support) now delegates to this shared util, removing the duplicate and fixing OPML labels too.

## Render-time vs parse-time

Render-time was chosen deliberately. Parse-time decode (in `feed_sync` before upsert) would only fix rows fetched **after** the change; the already-stored buggy rows — including the one the user reported — would stay broken until the next refetch. Render-time decode fixes existing data immediately, and the per-title cost on short strings is negligible.

## Tests

- Unit tests for the decoder: `&#x27;`, `&#X27;`, `&#39;`, `&amp;`, `&quot;`/`&apos;`, `&lt;`/`&gt;`, mixed, no-entities, invalid/malformed sequences, multibyte passthrough, trailing `&`.
- Applied-point tests on `row_view_from`: a title containing `&#x27;` renders as `'`; decimal + named mix decodes correctly.
- `cargo nextest run` for the decoder, applied points, and the full OPML suite: all green (16 + 17 tests pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)