### PR TITLE
feat(unread): support "o" to mark loaded entries as read

### DIFF
--- a/e2e/features/keyboard_shortcuts.feature
+++ b/e2e/features/keyboard_shortcuts.feature
@@ -29,6 +29,12 @@ Feature: Keyboard shortcut overhaul (toggle read, mark all, rebinds)
     And I press the "o" key
     Then I see 0 entries in the entry list
 
+  Scenario: o marks every loaded entry above as read (on unread page)
+    When I open the inbox
+    And I confirm the next dialog
+    And I press the "o" key
+    Then I see 0 entries in the entry list
+
   Scenario: Enter opens the selected entry into the reading pane
     When I open the inbox
     And I press the "j" key

--- a/src/handlers/pages/mod.rs
+++ b/src/handlers/pages/mod.rs
@@ -547,7 +547,7 @@ pub async fn unread_page(
                 active_category_id: None,
                 filter_tabs: None,
                 status_filter: None,
-                show_mark_above: false,
+                show_mark_above: true,
                 onboarding: no_feeds,
             },
         },

--- a/tests/greader_test.rs
+++ b/tests/greader_test.rs
@@ -532,6 +532,86 @@ async fn test_edit_tag_mark_read() {
 }
 
 #[tokio::test]
+async fn test_edit_tag_mark_read_multiple() {
+    let app = create_test_app(default_test_config());
+    let user_id = setup_authenticated_user(&app).await;
+
+    let (_cat_id, feed_id) =
+        create_test_feed(&app.db, user_id, "Tech", "https://example.com/feed.xml").await;
+    let entry_ids = create_test_entries(&app.db, feed_id, 3).await;
+
+    // Mark every loaded entry as read in a single batch request — the server
+    // path behind the "o" / Mark-loaded-as-read shortcut.
+    let mut form: Vec<(String, String)> = entry_ids
+        .iter()
+        .map(|id| {
+            (
+                "i".to_string(),
+                format!("tag:google.com,2005:reader/item/{:016x}", *id),
+            )
+        })
+        .collect();
+    form.push(("a".to_string(), "user/-/state/com.google/read".to_string()));
+
+    let response = app.server.post("/reader/api/0/edit-tag").form(&form).await;
+    response.assert_status_ok();
+    assert_eq!(response.text(), "OK");
+
+    // All three are now read -> reading-list unread count is 0.
+    let response = app.server.get("/reader/api/0/unread-count").await;
+    let body: serde_json::Value = response.json();
+    let counts = body["unreadcounts"].as_array().unwrap();
+    let reading_list_count = counts
+        .iter()
+        .find(|c| c["id"].as_str().unwrap().contains("reading-list"))
+        .map(|c| c["count"].as_i64().unwrap())
+        .unwrap_or(0);
+    assert_eq!(reading_list_count, 0);
+}
+
+#[tokio::test]
+async fn test_edit_tag_mark_read_rejects_unknown_entry() {
+    let app = create_test_app(default_test_config());
+    let user_id = setup_authenticated_user(&app).await;
+
+    let (_cat_id, feed_id) =
+        create_test_feed(&app.db, user_id, "Tech", "https://example.com/feed.xml").await;
+    let entry_ids = create_test_entries(&app.db, feed_id, 2).await;
+
+    // A batch that mixes two owned entries with one id that does not exist.
+    // The handler verifies every id up front and rejects the whole batch, so
+    // no entry is marked read.
+    let mut form: Vec<(String, String)> = entry_ids
+        .iter()
+        .map(|id| {
+            (
+                "i".to_string(),
+                format!("tag:google.com,2005:reader/item/{:016x}", *id),
+            )
+        })
+        .collect();
+    form.push((
+        "i".to_string(),
+        format!("tag:google.com,2005:reader/item/{:016x}", 999_999_i64),
+    ));
+    form.push(("a".to_string(), "user/-/state/com.google/read".to_string()));
+
+    let response = app.server.post("/reader/api/0/edit-tag").form(&form).await;
+    response.assert_status(StatusCode::NOT_FOUND);
+
+    // The two owned entries must remain unread (batch rolled back).
+    let response = app.server.get("/reader/api/0/unread-count").await;
+    let body: serde_json::Value = response.json();
+    let counts = body["unreadcounts"].as_array().unwrap();
+    let reading_list_count = counts
+        .iter()
+        .find(|c| c["id"].as_str().unwrap().contains("reading-list"))
+        .map(|c| c["count"].as_i64().unwrap())
+        .unwrap_or(0);
+    assert_eq!(reading_list_count, 2);
+}
+
+#[tokio::test]
 async fn test_edit_tag_star_and_unstar() {
     let app = create_test_app(default_test_config());
     let user_id = setup_authenticated_user(&app).await;

--- a/tests/pages_test.rs
+++ b/tests/pages_test.rs
@@ -2260,6 +2260,13 @@ async fn test_unread_page_renders_entry_rows() {
     // Reading pane placeholder + swap target
     assert!(html.contains(r#"id="reading-pane""#));
     assert!(html.contains("Select an entry"));
+
+    // Mark Above as Read button must render so the "o" shortcut can mark
+    // the currently-loaded unread rows as read.
+    assert!(
+        html.contains(r#"id="mark-above-read""#),
+        "unread page must render the Mark Above as Read button"
+    );
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

The unread inbox (`/`) now supports the `o` keyboard shortcut to mark every currently-loaded entry as read, matching the existing behavior on feed and category pages.

The `o` handler and the "Mark Above as Read" button already mark every rendered `[data-entry-row]` as read via the GReader edit-tag endpoint, but they only render where `show_mark_above` is `true`. Previously this was limited to feed/category pages. This PR enables it on the unread page.

## What changed

- `src/handlers/pages/mod.rs`: flip `show_mark_above` from `false` to `true` in `unread_page` (the `EntriesLayoutContext` for `/`). The template (`templates/_entries_layout.html`) and the JS handler (`static/js/app.js`) are page-agnostic and required no changes — the button click reads all loaded rows, posts `a=user/-/state/com.google/read`, then reloads.
- `tests/pages_test.rs`: extend `test_unread_page_renders_entry_rows` to assert the `#mark-above-read` button renders on `/`.
- `e2e/features/keyboard_shortcuts.feature`: add an unread-page scenario mirroring the existing feed-page `o` scenario. All steps were reused.

## Test results

- Backend: `cargo nextest run --test pages_test` — 57 passed, 0 skipped.
- E2E (playwright-bdd): both `o marks every loaded entry above as read` scenarios (feed page + new unread page) pass against a freshly rebuilt debug binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)