### PR TITLE
perf(proxy): reuse a single pooled HTTP client for image proxying

### DIFF
--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -5,6 +5,7 @@ use axum::{
 };
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use serde::Deserialize;
+use std::sync::LazyLock;
 use url::Url;
 
 use crate::{
@@ -16,6 +17,24 @@ use crate::{
 };
 
 const MAX_IMAGE_SIZE: u64 = 10 * 1024 * 1024; // 10MB
+
+/// Process-wide HTTP client for image proxying, built once and reused.
+///
+/// `reqwest::Client` owns a connection pool; cloning/reusing it lets upstream
+/// origin connections be kept alive and reused across proxied images. The
+/// previous code built a fresh client *per request*, which discarded the pool
+/// every time and forced a new TCP+TLS handshake to the origin for every image.
+/// That is masked under HTTP/1.1 — the browser caps at ~6 concurrent requests to
+/// us — but under HTTP/2 the browser dispatches every image of an entry at once,
+/// so we receive N concurrent proxy requests, each building a client and opening
+/// a brand-new origin connection. Sharing one client removes that per-request
+/// build + handshake overhead.
+static IMAGE_PROXY_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
+    reqwest::Client::builder()
+        .timeout(DEFAULT_TIMEOUT)
+        .build()
+        .expect("failed to build image proxy HTTP client")
+});
 
 /// Fallback caching directive used only when the origin image specifies none.
 const DEFAULT_CACHE_CONTROL: &str = "public, max-age=86400";
@@ -111,16 +130,13 @@ pub async fn proxy_image(
     let url = Url::parse(&url_str).map_err(|_| AppError::InvalidImageUrl)?;
     url_validation::validate_url(&url).map_err(|_| AppError::InvalidImageUrl)?;
 
-    // Fetch the image
-    let client = reqwest::Client::builder()
-        .timeout(DEFAULT_TIMEOUT)
-        .build()
-        .map_err(|e| AppError::ImageFetchError(e.to_string()))?;
-
+    // Fetch the image through the shared, connection-pooled client.
     let url_str = url.to_string();
     let user_agent = state.config.user_agent.clone();
     let response = send_with_retry_on_error(&RetryConfig::default(), || {
-        let mut req = client.get(&url_str).header("User-Agent", &user_agent);
+        let mut req = IMAGE_PROXY_CLIENT
+            .get(&url_str)
+            .header("User-Agent", &user_agent);
         if let Some(ref referrer) = referrer {
             req = req.header("Referer", referrer.as_str());
         }


### PR DESCRIPTION
## Problem

The image proxy built a fresh `reqwest::Client` on **every request**:

```rust
let client = reqwest::Client::builder().timeout(DEFAULT_TIMEOUT).build()?;
```

A `reqwest::Client` owns a connection pool. Rebuilding it per request discards that pool every time, forcing a fresh TCP+TLS handshake to the origin for **every proxied image**.

HTTP/1.1 masks this: the browser caps at ~6 concurrent requests to us, so rdrs only ever sees ~6 concurrent proxy fetches. **Under HTTP/2** (the typical production setup behind nginx), the browser dispatches *every* image of an entry at once, so rdrs receives N concurrent proxy requests — each building a client and opening a brand-new origin connection. The per-request cost is amplified N-fold exactly where it hurts.

## Fix

Build the client once per process via `LazyLock` and reuse it, so upstream connections are pooled/kept alive across proxied images. Behaviour is otherwise unchanged: timeout, per-request `User-Agent`/`Referer` headers, and signature/SSRF validation all stay the same.

## Measurement

Local back-to-back HTTP/2 measurement (nginx in front of rdrs, fixed `IMAGE_PROXY_SECRET`, identical URL set, observed within-run so CDN drift is controlled), 30 concurrent proxied images:

| warm steady-state wall-clock (30 concurrent) | before | after |
|---|---|---|
| per-request client | ~1.5–2.0s | — |
| shared pooled client | — | **~0.47s (~3–4×)** |

The within-run pattern is itself the proof: the shared client plateaus at ~0.46s once the pool warms, while the per-request client never drops (it rebuilds the client + does a fresh origin TLS handshake on every request).

## Tests

`cargo nextest run` — **779 passed, 0 failed**. No behavioural change; existing proxy/handler tests cover the path.

## Note

This is complementary to caching proxied images at the reverse proxy (`nginx proxy_cache`), which eliminates the origin round-trip on revisits entirely. This PR reduces the cost of the fetches that *do* reach the origin (first view / cache miss).
