### PR TITLE
refactor(http): share connection-pooled clients across all fetchers

### DIFF
--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -5,36 +5,17 @@ use axum::{
 };
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use serde::Deserialize;
-use std::sync::LazyLock;
 use url::Url;
 
 use crate::{
     error::{AppError, AppResult},
-    services::http::{send_with_retry_on_error, RetryConfig, DEFAULT_TIMEOUT},
+    services::http::{send_with_retry_on_error, RetryConfig, SHARED_CLIENT},
     services::{verify_signature, verify_signature_with_referrer},
     utils::url_validation,
     AppState,
 };
 
 const MAX_IMAGE_SIZE: u64 = 10 * 1024 * 1024; // 10MB
-
-/// Process-wide HTTP client for image proxying, built once and reused.
-///
-/// `reqwest::Client` owns a connection pool; cloning/reusing it lets upstream
-/// origin connections be kept alive and reused across proxied images. The
-/// previous code built a fresh client *per request*, which discarded the pool
-/// every time and forced a new TCP+TLS handshake to the origin for every image.
-/// That is masked under HTTP/1.1 — the browser caps at ~6 concurrent requests to
-/// us — but under HTTP/2 the browser dispatches every image of an entry at once,
-/// so we receive N concurrent proxy requests, each building a client and opening
-/// a brand-new origin connection. Sharing one client removes that per-request
-/// build + handshake overhead.
-static IMAGE_PROXY_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
-    reqwest::Client::builder()
-        .timeout(DEFAULT_TIMEOUT)
-        .build()
-        .expect("failed to build image proxy HTTP client")
-});
 
 /// Fallback caching directive used only when the origin image specifies none.
 const DEFAULT_CACHE_CONTROL: &str = "public, max-age=86400";
@@ -134,7 +115,7 @@ pub async fn proxy_image(
     let url_str = url.to_string();
     let user_agent = state.config.user_agent.clone();
     let response = send_with_retry_on_error(&RetryConfig::default(), || {
-        let mut req = IMAGE_PROXY_CLIENT
+        let mut req = SHARED_CLIENT
             .get(&url_str)
             .header("User-Agent", &user_agent);
         if let Some(ref referrer) = referrer {

--- a/src/services/feed_discovery.rs
+++ b/src/services/feed_discovery.rs
@@ -1,8 +1,9 @@
+use reqwest::header::USER_AGENT;
 use scraper::{Html, Selector};
 use url::Url;
 
 use crate::error::{AppError, AppResult};
-use crate::services::http::{send_with_retry_on_error, RetryConfig, DEFAULT_TIMEOUT};
+use crate::services::http::{send_with_retry_on_error, RetryConfig, SHARED_CLIENT};
 
 #[derive(Debug, Clone)]
 pub struct DiscoveredFeed {
@@ -20,19 +21,15 @@ pub async fn discover_feed(url: &str, user_agent: &str) -> AppResult<DiscoveredF
         return Err(AppError::InvalidUrl);
     }
 
-    // Fetch the URL
-    let client = reqwest::Client::builder()
-        .timeout(DEFAULT_TIMEOUT)
-        .user_agent(user_agent)
-        .build()
-        .map_err(|e| AppError::FetchError(e.to_string()))?;
-
+    // Fetch the URL via the shared, connection-pooled client (UA per request).
     let retry_config = RetryConfig::default();
     let url_owned = url.to_string();
 
-    let response = send_with_retry_on_error(&retry_config, || client.get(&url_owned))
-        .await
-        .map_err(|e| AppError::FetchError(e.to_string()))?;
+    let response = send_with_retry_on_error(&retry_config, || {
+        SHARED_CLIENT.get(&url_owned).header(USER_AGENT, user_agent)
+    })
+    .await
+    .map_err(|e| AppError::FetchError(e.to_string()))?;
 
     if !response.status().is_success() {
         return Err(AppError::FetchError(format!("HTTP {}", response.status())));
@@ -59,9 +56,11 @@ pub async fn discover_feed(url: &str, user_agent: &str) -> AppResult<DiscoveredF
     let feed_url = find_feed_link_in_html(&body, &parsed_url)?;
 
     // Fetch and parse the discovered feed
-    let feed_response = send_with_retry_on_error(&retry_config, || client.get(&feed_url))
-        .await
-        .map_err(|e| AppError::FetchError(e.to_string()))?;
+    let feed_response = send_with_retry_on_error(&retry_config, || {
+        SHARED_CLIENT.get(&feed_url).header(USER_AGENT, user_agent)
+    })
+    .await
+    .map_err(|e| AppError::FetchError(e.to_string()))?;
 
     if !feed_response.status().is_success() {
         return Err(AppError::FetchError(format!(

--- a/src/services/feed_sync.rs
+++ b/src/services/feed_sync.rs
@@ -1,5 +1,5 @@
 use chrono::Utc;
-use reqwest::header::{HeaderMap, HeaderValue, IF_MODIFIED_SINCE, IF_NONE_MATCH};
+use reqwest::header::{HeaderMap, HeaderValue, IF_MODIFIED_SINCE, IF_NONE_MATCH, USER_AGENT};
 use serde::Serialize;
 use tracing::{debug, error, info, warn};
 
@@ -7,7 +7,7 @@ use crate::db::DbPool;
 use crate::error::{AppError, AppResult};
 use crate::models::{entry, feed, image};
 use crate::services::http::{
-    send_with_retry_on_error, RetryConfig, DEFAULT_TIMEOUT, FEED_SYNC_TIMEOUT,
+    send_with_retry_on_error, RetryConfig, FEED_SYNC_TIMEOUT, SHARED_CLIENT, SHARED_CLIENT_H1,
 };
 use crate::services::icon_fetcher;
 use crate::utils::datetime::parse_timestamp;
@@ -51,21 +51,23 @@ pub async fn refresh_feed(
         .as_deref()
         .unwrap_or(default_user_agent);
 
-    // Build HTTP client with per-feed settings
-    let mut client_builder = reqwest::Client::builder()
-        .timeout(DEFAULT_TIMEOUT)
-        .user_agent(effective_user_agent);
-
-    // Disable HTTP/2 if configured for this feed
-    if feed_data.http2_disabled {
-        client_builder = client_builder.http1_only();
-    }
-
-    let client = client_builder
-        .build()
-        .map_err(|e| AppError::FetchError(e.to_string()))?;
+    // Per-feed opt-out of HTTP/2 needs the HTTP/1.1-only pooled client; all
+    // other feeds share the default pooled client. `http1_only()` is a
+    // client-level setting and cannot be applied per request, which is why this
+    // one knob still selects between two shared clients.
+    let client = if feed_data.http2_disabled {
+        &*SHARED_CLIENT_H1
+    } else {
+        &*SHARED_CLIENT
+    };
 
     let mut headers = HeaderMap::new();
+
+    // User-Agent (possibly a per-feed override) is sent per request now that the
+    // client is shared rather than rebuilt with `.user_agent(...)` each call.
+    if let Ok(value) = HeaderValue::from_str(effective_user_agent) {
+        headers.insert(USER_AGENT, value);
+    }
 
     if let Some(ref etag) = feed_data.etag {
         if let Ok(value) = HeaderValue::from_str(etag) {

--- a/src/services/http.rs
+++ b/src/services/http.rs
@@ -1,4 +1,5 @@
 use std::future::Future;
+use std::sync::LazyLock;
 use std::time::Duration;
 
 use reqwest::{Response, StatusCode};
@@ -21,6 +22,35 @@ pub const FEED_SYNC_TIMEOUT: Duration = Duration::from_secs(90);
 
 /// Timeout for enqueuing background jobs from HTTP handlers (5s)
 pub const JOB_QUEUE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Process-wide, connection-pooled HTTP client, built once and reused everywhere.
+///
+/// A `reqwest::Client` owns a connection pool; reusing one keeps upstream
+/// connections alive across requests instead of doing a fresh TCP+TLS handshake
+/// every time. Building a client per request (the old pattern across the image
+/// proxy and the feed/icon/readability fetchers) discarded that pool on every
+/// call. Per-request settings that used to live on the builder are applied on the
+/// `RequestBuilder` instead: the `User-Agent` as a header, and a shorter timeout
+/// via `RequestBuilder::timeout` (e.g. `ICON_TIMEOUT`). The client carries
+/// `DEFAULT_TIMEOUT` as the baseline so a caller that sets neither is still
+/// bounded.
+pub static SHARED_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
+    reqwest::Client::builder()
+        .timeout(DEFAULT_TIMEOUT)
+        .build()
+        .expect("failed to build shared HTTP client")
+});
+
+/// HTTP/1.1-only variant of [`SHARED_CLIENT`], for feeds that opt out of HTTP/2
+/// (`feed.http2_disabled`). `http1_only()` is a client-level setting and cannot
+/// be overridden per request, so those feeds need their own pooled client.
+pub static SHARED_CLIENT_H1: LazyLock<reqwest::Client> = LazyLock::new(|| {
+    reqwest::Client::builder()
+        .timeout(DEFAULT_TIMEOUT)
+        .http1_only()
+        .build()
+        .expect("failed to build HTTP/1.1-only shared client")
+});
 
 /// Configuration for retry behavior
 #[derive(Debug, Clone)]

--- a/src/services/icon_fetcher.rs
+++ b/src/services/icon_fetcher.rs
@@ -1,9 +1,9 @@
-use reqwest::header::CONTENT_TYPE;
+use reqwest::header::{CONTENT_TYPE, USER_AGENT};
 use tracing::debug;
 use url::Url;
 
-use crate::error::{AppError, AppResult};
-use crate::services::http::{send_with_retry_on_error, RetryConfig, ICON_TIMEOUT};
+use crate::error::AppResult;
+use crate::services::http::{send_with_retry_on_error, RetryConfig, ICON_TIMEOUT, SHARED_CLIENT};
 
 const MAX_ICON_SIZE: usize = 256 * 1024; // 256KB
 
@@ -46,16 +46,17 @@ pub async fn fetch_feed_icon(
 }
 
 async fn fetch_image(url: &str, user_agent: &str) -> AppResult<Option<FetchedImage>> {
-    let client = reqwest::Client::builder()
-        .timeout(ICON_TIMEOUT)
-        .user_agent(user_agent)
-        .build()
-        .map_err(|e| AppError::FetchError(e.to_string()))?;
-
     let retry_config = RetryConfig::icon();
     let url_owned = url.to_string();
 
-    let response = match send_with_retry_on_error(&retry_config, || client.get(&url_owned)).await {
+    let response = match send_with_retry_on_error(&retry_config, || {
+        SHARED_CLIENT
+            .get(&url_owned)
+            .timeout(ICON_TIMEOUT)
+            .header(USER_AGENT, user_agent)
+    })
+    .await
+    {
         Ok(r) => r,
         Err(e) => {
             debug!("Failed to fetch image from {}: {}", url, e);
@@ -124,16 +125,17 @@ async fn fetch_favicon(site_url: &str, user_agent: &str) -> AppResult<Option<Fet
     }
 
     // Try parsing HTML for link rel="icon"
-    let client = reqwest::Client::builder()
-        .timeout(ICON_TIMEOUT)
-        .user_agent(user_agent)
-        .build()
-        .map_err(|e| AppError::FetchError(e.to_string()))?;
-
     let retry_config = RetryConfig::icon();
     let site_url_owned = site_url.to_string();
 
-    let html = match send_with_retry_on_error(&retry_config, || client.get(&site_url_owned)).await {
+    let html = match send_with_retry_on_error(&retry_config, || {
+        SHARED_CLIENT
+            .get(&site_url_owned)
+            .timeout(ICON_TIMEOUT)
+            .header(USER_AGENT, user_agent)
+    })
+    .await
+    {
         Ok(r) if r.status().is_success() => match r.text().await {
             Ok(t) => t,
             Err(_) => return Ok(None),

--- a/src/services/readability.rs
+++ b/src/services/readability.rs
@@ -1,8 +1,9 @@
 use readability::extractor;
+use reqwest::header::USER_AGENT;
 use url::Url;
 
 use crate::error::{AppError, AppResult};
-use crate::services::http::{send_with_retry_on_error, RetryConfig, DEFAULT_TIMEOUT};
+use crate::services::http::{send_with_retry_on_error, RetryConfig, SHARED_CLIENT};
 use crate::utils::url_validation;
 
 pub struct ExtractedContent {
@@ -16,17 +17,13 @@ pub async fn fetch_and_extract(url: &str, user_agent: &str) -> AppResult<Extract
     let parsed_url = Url::parse(url).map_err(|_| AppError::InvalidUrl)?;
     url_validation::validate_url(&parsed_url).map_err(|_| AppError::InvalidUrl)?;
 
-    // Fetch HTML using existing reqwest (rustls-tls)
-    let client = reqwest::Client::builder()
-        .timeout(DEFAULT_TIMEOUT)
-        .user_agent(user_agent)
-        .build()
-        .map_err(|e| AppError::FetchError(e.to_string()))?;
-
+    // Fetch HTML via the shared, connection-pooled client (User-Agent per request).
     let url_owned = url.to_string();
-    let response = send_with_retry_on_error(&RetryConfig::default(), || client.get(&url_owned))
-        .await
-        .map_err(|e| AppError::FetchError(e.to_string()))?;
+    let response = send_with_retry_on_error(&RetryConfig::default(), || {
+        SHARED_CLIENT.get(&url_owned).header(USER_AGENT, user_agent)
+    })
+    .await
+    .map_err(|e| AppError::FetchError(e.to_string()))?;
 
     if !response.status().is_success() {
         return Err(AppError::FetchError(format!("HTTP {}", response.status())));


### PR DESCRIPTION
## Summary

Follow-up to #283, which made only the **image proxy** reuse a pooled `reqwest::Client`. Every other outbound HTTP path still built a fresh client per call:

| site | trigger |
|---|---|
| `feed_sync::refresh_feed` | background sync (per feed, every minute) |
| `readability::fetch_and_extract` | "Fetch full content" action |
| `icon_fetcher::fetch_image` / `fetch_favicon` | icon/favicon fetch |
| `feed_discovery::discover_feed` | adding a feed |

A `reqwest::Client` owns a connection pool; rebuilding it per call discards that pool and forces a fresh TCP+TLS handshake to the origin on every request.

## Change

Two shared, process-wide `LazyLock` clients in `services/http.rs`:

- `SHARED_CLIENT` — default pooled client (`DEFAULT_TIMEOUT` baseline).
- `SHARED_CLIENT_H1` — `http1_only()` variant for feeds with `http2_disabled`.

Per-call settings move onto the `RequestBuilder`:
- **User-Agent** → request header (supports per-feed custom UA).
- **shorter icon timeout** → `RequestBuilder::timeout(ICON_TIMEOUT)`.

`http1_only()` is the only client-level knob that can't be set per request, which is why feed sync selects between the two shared clients. The image proxy's own `LazyLock` from #283 is folded into `SHARED_CLIENT` so there is now a single canonical pooled client.

## Behaviour

Unchanged: timeouts (default 30s, icon 10s, feed 30s), per-feed custom User-Agent, per-feed `http1_only`, conditional GET (`If-None-Match` / `If-Modified-Since`), and retry configs. Only difference is connection reuse instead of a fresh client + TLS per call.

## Tests

`cargo nextest run` — **779 passed, 0 failed**. `cargo clippy` clean. No public API change.