### PR TITLE
fix(frontend): preserve swap-target node identity to stop dropped entry clicks

### DIFF
--- a/e2e/features/reading.feature
+++ b/e2e/features/reading.feature
@@ -16,6 +16,21 @@ Feature: Reading entries
     Then the reading pane shows the title "Test Entry 1"
     And the reading pane shows the content "Content for test entry 1"
 
+  # Regression: opening an entry used to REPLACE the row's DOM node
+  # (insertBefore the new node, removeChild the old). If that replacement
+  # landed between a user's mousedown and mouseup on the same row — a slow
+  # fragment fetch resolving mid-click — the browser fired no `click` and the
+  # open was silently dropped ("click does nothing; hover shows; click again
+  # works"). The swap now morphs single-element targets in place, preserving
+  # the row's node identity. A JS property set on the node survives the open
+  # only when that identity is kept.
+  Scenario: Opening an entry preserves the row's DOM node (no dropped clicks)
+    When I open the inbox
+    And I mark the entry row for "Test Entry 1" with an identity probe
+    And I click the entry titled "Test Entry 1"
+    Then the reading pane shows the title "Test Entry 1"
+    And the entry row for "Test Entry 1" kept its identity probe
+
   Scenario: Reading pane shows feed title and published time
     When I open the inbox
     And I click the entry titled "Test Entry 1"

--- a/e2e/steps/entries.steps.js
+++ b/e2e/steps/entries.steps.js
@@ -86,6 +86,20 @@ When("I click the entry titled {string}", async ({ page }, title) => {
   await page.locator("#reading-pane:not(.reading-pane-empty)").waitFor({ state: "attached" });
 });
 
+When("I mark the entry row for {string} with an identity probe", async ({ page }, title) => {
+  // Stamp a JS property (not an attribute — the in-place morph syncs
+  // attributes, so a data-* probe would be stripped) on the row's DOM node.
+  // The property only survives the open swap if the node's identity is
+  // preserved (morph), not when the node is replaced.
+  await page
+    .getByTestId("entry-item")
+    .filter({ hasText: title })
+    .first()
+    .evaluate((el) => {
+      el.__identityProbe = "kept";
+    });
+});
+
 When("I click {string}", async ({ page }, label) => {
   await page.getByRole("button", { name: label }).click();
 });
@@ -288,6 +302,11 @@ Then("I am on the entries page for category {string}", async ({ page, seed, curr
   const userId = seed.getUserId(currentUser.username);
   const categoryId = seed.findCategoryIdByName(userId, name);
   await page.waitForURL(`${serverUrl}/categories/${categoryId}/entries`);
+});
+
+Then("the entry row for {string} kept its identity probe", async ({ page }, title) => {
+  const row = page.getByTestId("entry-item").filter({ hasText: title }).first();
+  await expect.poll(() => row.evaluate((el) => el.__identityProbe ?? null)).toBe("kept");
 });
 
 Then("the entry row for {string} shows as read", async ({ page }, title) => {

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -110,6 +110,45 @@ function cancelPaneImages(pane) {
     }
 }
 
+// Replace a swap target while PRESERVING its DOM node identity when the
+// payload is a single element of the same tag. The fallback path detaches the
+// target (`insertBefore` the replacement, then `removeChild` the original) —
+// but if that detachment lands between a user's `mousedown` and `mouseup` on
+// the same node (a slow fragment fetch resolving mid-click), the browser fires
+// NO `click` and the interaction is silently dropped: the entry row is the
+// click-to-open target, so the row just "doesn't open" (hover still shows,
+// because the replacement node is under the cursor) until a second click on
+// the now-stable node. Morphing in place keeps the node alive so the click
+// survives. Multi-node payloads (Load More appends N rows + a form) can't
+// collapse onto one node, so the caller keeps detach/insert for those.
+//
+// Returns true when it morphed in place, false when the caller should fall
+// back to detach/insert.
+function swapInPlace(dst, nodes) {
+    const elements = nodes.filter((n) => n.nodeType === Node.ELEMENT_NODE);
+    const onlyWhitespaceAround = nodes.every(
+        (n) =>
+            n.nodeType === Node.ELEMENT_NODE ||
+            (n.nodeType === Node.TEXT_NODE && !n.textContent.trim()),
+    );
+    if (elements.length !== 1 || !onlyWhitespaceAround) return false;
+    const incoming = elements[0];
+    if (incoming.tagName !== dst.tagName) return false;
+    // Sync attributes to mirror "replace with incoming": drop attributes the
+    // incoming node lacks, then set/overwrite the rest (e.g. the row's
+    // `entry-read` class flips here).
+    for (const attr of Array.from(dst.attributes)) {
+        if (!incoming.hasAttribute(attr.name)) dst.removeAttribute(attr.name);
+    }
+    for (const attr of Array.from(incoming.attributes)) {
+        if (dst.getAttribute(attr.name) !== attr.value) {
+            dst.setAttribute(attr.name, attr.value);
+        }
+    }
+    dst.replaceChildren(...incoming.childNodes);
+    return true;
+}
+
 async function performSwap(url, init, defaultTarget, options) {
     const method = (init.method || 'GET').toUpperCase();
     // popstate-driven restores pass `skipHistory: true` because the browser
@@ -172,18 +211,19 @@ async function performSwap(url, init, defaultTarget, options) {
             if (sel === '#reading-pane') swappedReadingPane = true;
             const dst = document.querySelector(sel);
             if (!dst) continue;
-            const parent = dst.parentNode;
-            // Insert every child of the template content (including
-            // multi-element payloads — e.g. Load-More returns N rows + a
-            // new load-more form) before the swap target, then remove
-            // the target. Single-element templates collapse to the same
-            // outcome as the previous outerHTML-replace behaviour, so
-            // existing call sites stay correct.
+            // Single-element payloads (reading pane, entry row, sidebar
+            // count) morph in place to keep the node's identity — see
+            // swapInPlace. Multi-element payloads (Load-More returns N rows +
+            // a new load-more form) insert every child of the template
+            // content before the swap target, then remove the target.
             const nodes = Array.from(tpl.content.childNodes);
-            for (const node of nodes) {
-                parent.insertBefore(node, dst);
+            if (!swapInPlace(dst, nodes)) {
+                const parent = dst.parentNode;
+                for (const node of nodes) {
+                    parent.insertBefore(node, dst);
+                }
+                parent.removeChild(dst);
             }
-            parent.removeChild(dst);
         }
         if (swappedReadingPane && incomingEntryId && incomingEntryId !== paneEntryIdBefore) {
             window.flash?.clear?.();
@@ -198,7 +238,11 @@ async function performSwap(url, init, defaultTarget, options) {
     if (!dst) return;
     const incoming = parsed.body.firstElementChild;
     if (!incoming) return;
-    dst.outerHTML = incoming.outerHTML;
+    // Morph in place when possible (preserves node identity → no dropped
+    // clicks on rapid re-clicks), else fall back to a full node replace.
+    if (!swapInPlace(dst, [incoming])) {
+        dst.outerHTML = incoming.outerHTML;
+    }
     if (defaultTarget === '#reading-pane' && incomingEntryId && incomingEntryId !== paneEntryIdBefore) {
         window.flash?.clear?.();
     }


### PR DESCRIPTION
## Problem

Clicking an entry row sometimes does nothing — the hover state shows, but the entry doesn't open until a second click. It happens intermittently when clicking back and forth between entries, and is worse when fragment fetches are slow (same family as the recently-fixed reading-pane latency).

## Root cause

Opening an entry is an async multi-target swap that **replaced the clicked row's DOM node** (`insertBefore` the replacement, `removeChild` the original). A browser only synthesizes a `click` when `mousedown` and `mouseup` land on the **same live node**. On rapid re-clicks, a slow fragment fetch can resolve and replace the row **between** a subsequent `mousedown` and `mouseup` on that row — the mousedown target is detached before mouseup, so the browser fires **no `click`** and the open is silently dropped. Hover still shows (the replacement node is under the cursor); a second click on the now-stable node works.

Verified with an isolated repro driving `mouse.down()` → node replacement → `mouse.up()`: the click count was `0` with node replacement and `1` when the node identity was preserved.

## Fix

Add `swapInPlace()` to the swap helper: when a swap target's payload is a **single element of the same tag** (reading pane, entry row, sidebar count), morph it **in place** (sync attributes, replace children) instead of detaching the node. The node identity survives the swap, so the click is never dropped. Multi-node payloads (Load More appends N rows + a form) keep the existing detach/insert path.

## Tests

- New deterministic regression scenario in `reading.feature`: a JS property stamped on the row node survives the open **only** when node identity is preserved. Confirmed it **fails** against a build with the morph disabled and **passes** with the fix.
- Full suites green: `reading` 24/24, `triage` + `keyboard_shortcuts` + `organizing` 27/27.

No Rust changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)