### PR TITLE
fix(reading-pane): drop stale fragment responses so the last click wins

### DIFF
--- a/e2e/features/reading.feature
+++ b/e2e/features/reading.feature
@@ -172,3 +172,12 @@ Feature: Reading entries
     And the reading-pane "Previous" button is enabled
     When I navigate to the "Next" entry in the reading pane
     Then the reading pane shows the title "Test Entry 4"
+
+  Scenario: A stale slow fragment response never overwrites a newer click
+    When I open the inbox
+    And the fragment response for the entry titled "Test Entry 1" is delayed
+    And I click the entry titled "Test Entry 1" without waiting for the pane
+    And I click the entry titled "Test Entry 2"
+    And the delayed fragment response has settled
+    Then the reading pane shows the title "Test Entry 2"
+    And the URL has the ?entry= parameter for "Test Entry 2"

--- a/e2e/steps/entries.steps.js
+++ b/e2e/steps/entries.steps.js
@@ -111,6 +111,60 @@ async function paneEntryId(page) {
   return m ? m[1] : null;
 }
 
+// Hold one entry's fragment response for 600ms before serving it, recording
+// when the route finished (served — or aborted by the stale-response guard).
+// Drives the race scenario: a slow stale response must never overwrite the
+// entry the user clicked afterwards.
+const delayedFragments = new WeakMap();
+
+When(
+  "the fragment response for the entry titled {string} is delayed",
+  async ({ page, seed, currentUser }, title) => {
+    const userId = seed.getUserId(currentUser.username);
+    const entryId = seed.findEntryIdByTitle(userId, title);
+    const state = {};
+    state.done = new Promise((resolve) => {
+      state.resolve = resolve;
+    });
+    delayedFragments.set(page, state);
+    await page.route(`**/entries/${entryId}/fragment*`, async (route) => {
+      await new Promise((r) => setTimeout(r, 600));
+      try {
+        await route.continue();
+      } catch {
+        // The stale-response guard aborted this request while it was held
+        // here — exactly the post-fix behaviour; nothing left to serve.
+      }
+      state.resolve();
+    });
+  }
+);
+
+When(
+  "I click the entry titled {string} without waiting for the pane",
+  async ({ page }, title) => {
+    // Same locator as "I click the entry titled {string}" but WITHOUT the
+    // pane-not-empty wait — this click's response is being held by the
+    // delayed route, so the pane must still be empty when the next step
+    // clicks the second entry.
+    await page
+      .getByTestId("entry-item")
+      .filter({ hasText: title })
+      .first()
+      .getByTestId("entry-title-link")
+      .click();
+  }
+);
+
+When("the delayed fragment response has settled", async ({ page }) => {
+  const state = delayedFragments.get(page);
+  if (!state) throw new Error("no delayed fragment route was armed");
+  await state.done;
+  // Give a (stale) swap one tick to apply before the Then assertions —
+  // pre-fix, the bug manifests as the pane flipping back AFTER this point.
+  await page.waitForTimeout(100);
+});
+
 When(
   "I navigate to the {string} entry in the reading pane",
   async ({ page }, direction) => {

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -110,12 +110,33 @@ function cancelPaneImages(pane) {
     }
 }
 
+// Monotonic token + abort handle for reading-pane *navigation* fetches
+// (GET /entries/{id}/fragment — entry clicks, Show Original, popstate
+// restores, prev/next fallbacks). Clicking entry A then quickly entry B
+// used to leave both responses in flight: whichever arrived LAST won the
+// pane, so a slow stale A response could overwrite the just-opened B (and
+// replaceState the URL back to ?entry=A). Each new navigation bumps the
+// token and aborts the previous fetch; a response whose token is stale by
+// the time it lands is discarded instead of applied. Action swaps (POST
+// Save / Fetch-Full-Content) re-target the same entry and stay outside
+// the guard. Same stale-fetch discipline as applyNeighborButtons().
+let paneNavSeq = 0;
+let paneNavAbort = null;
+
 async function performSwap(url, init, defaultTarget, options) {
     const method = (init.method || 'GET').toUpperCase();
     // popstate-driven restores pass `skipHistory: true` because the browser
     // has already moved the address bar via back/forward — we must not push
     // or replace on top of the slot the user just navigated into.
     const skipHistory = options?.skipHistory === true;
+    const isPaneNav = method === 'GET' && defaultTarget === '#reading-pane';
+    let navSeq = null;
+    if (isPaneNav) {
+        navSeq = ++paneNavSeq;
+        paneNavAbort?.abort();
+        paneNavAbort = new AbortController();
+        init.signal = paneNavAbort.signal;
+    }
     // Before fetching the next entry, cancel the current pane's image loads so
     // they stop starving the connection pool — but only when navigating to a
     // *different* entry (action swaps like Save / Fetch-Full-Content re-target
@@ -130,6 +151,10 @@ async function performSwap(url, init, defaultTarget, options) {
     try {
         response = await fetch(url, init);
     } catch {
+        // A newer pane navigation aborted this fetch — drop it silently.
+        // Falling through to `location.href` would hard-navigate the page
+        // to a fragment URL the user has already moved past.
+        if (isPaneNav && navSeq !== paneNavSeq) return;
         if (method !== 'GET' && window.flash) {
             window.flash.error('Action failed — please try again.');
             return;
@@ -137,6 +162,9 @@ async function performSwap(url, init, defaultTarget, options) {
         window.location.href = url;
         return;
     }
+    // Superseded while the headers were in flight (abort loses this race
+    // when the reply was already buffered): discard before acting on it.
+    if (isPaneNav && navSeq !== paneNavSeq) return;
     if (!response.ok) {
         if (method !== 'GET' && window.flash) {
             window.flash.error('Action failed — please try again.');
@@ -145,7 +173,17 @@ async function performSwap(url, init, defaultTarget, options) {
         window.location.href = url;
         return;
     }
-    const text = await response.text();
+    let text;
+    try {
+        text = await response.text();
+    } catch {
+        // Aborted mid-body by a newer navigation (fetch itself had already
+        // resolved) — same silent drop as above.
+        if (isPaneNav && navSeq !== paneNavSeq) return;
+        window.location.href = url;
+        return;
+    }
+    if (isPaneNav && navSeq !== paneNavSeq) return;
     const parsed = new DOMParser().parseFromString(text, 'text/html');
 
     // Decide pushState vs replaceState BEFORE the DOM mutates: opening an


### PR DESCRIPTION
## Problem

Alternating clicks between two entries (click A, then quickly click B) occasionally left the reading pane showing **A** instead of the last-clicked **B** — and reverting the `?entry=` URL to A — requiring a second click on B to recover.

Root cause: `performSwap()` issued each `GET /entries/{id}/fragment` with no stale-response protection. With two fragment fetches in flight, whichever response arrived **last** won the pane — so a slow stale A response could overwrite the just-opened B. This is an original design gap, not a recent regression; `applyNeighborButtons()` already guards neighbour fetches the same way.

## Fix

Guard reading-pane **navigations** (`GET` + `#reading-pane`: entry clicks, Show Original, popstate restores, prev/next fallbacks, j/k) with a monotonic sequence token plus an `AbortController`:

- Each new navigation bumps the token and aborts the previous in-flight fetch.
- A response that lands after being superseded (the token no longer matches) is discarded instead of applied — the token check is the correctness guarantee; the abort is just a connection-pool optimisation, since a fully-buffered fetch resolves even after `abort()`.
- The pre-fallback supersession checks prevent an aborted fetch from hard-navigating the whole page to a fragment URL the user already moved past.

POST action swaps (Save / Fetch-Full-Content) re-target the same entry and stay outside the guard.

## Tests

- New BDD scenario `A stale slow fragment response never overwrites a newer click` (red before the fix, green after): delays entry A's fragment, clicks A then B, asserts the pane and `?entry=` settle on B.
- Full regression green: Rust `779 passed`, e2e `84 passed`.
- Scripted race verification: natural rapid alternation `0/30 mismatches`; deterministic delayed-A repro reports `NO RACE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)