### PR TITLE
fix(mobile): move flash banners below the hamburger instead of indenting

### DIFF
--- a/e2e/features/responsive.feature
+++ b/e2e/features/responsive.feature
@@ -53,6 +53,13 @@ Feature: Responsive layout
     When I open the categories page
     Then the categories table is shown as cards
 
+  @mobile
+  Scenario: Flash banner clears the hamburger on mobile
+    Given I am viewing on a mobile screen
+    When I open the inbox
+    And a flash banner is shown
+    Then the flash banner sits below the hamburger
+
   @tablet
   Scenario: Sidebar is a drawer on tablet
     Given I am viewing on a tablet screen

--- a/e2e/steps/responsive.steps.js
+++ b/e2e/steps/responsive.steps.js
@@ -88,3 +88,22 @@ Then("the reading pane is visible on mobile", async ({ page }) => {
 When("I tap the reading-pane back button", async ({ page }) => {
   await page.getByTestId("reading-pane-back").click();
 });
+
+When("a flash banner is shown", async ({ page }) => {
+  // Drive the page-level <rdrs-flash> API directly — same entry point the
+  // app's own JS uses (window.flash is installed by rdrs-flash.js).
+  await page.evaluate(() =>
+    window.flash.show("success", "Marked older than 1 week entries as read.")
+  );
+  await expect(page.locator(".banner")).toBeVisible();
+});
+
+Then("the flash banner sits below the hamburger", async ({ page }) => {
+  const toggle = await page.locator(".sidebar-toggle").boundingBox();
+  const banner = await page.locator(".banner").first().boundingBox();
+  // Below the button (no overlap)…
+  expect(banner.y).toBeGreaterThanOrEqual(toggle.y + toggle.height);
+  // …and full-width: the banner's left edge reaches past the floating
+  // button's left edge instead of being indented to clear it.
+  expect(banner.x).toBeLessThan(toggle.x);
+});

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -1707,22 +1707,26 @@ summary {
         column-gap: var(--space-2);
     }
 
-    /* On narrow viewports the fixed hamburger overlays the top-left of
-       <main>. Keep the banner background edge-to-edge but push its
-       content right so the icon + message clear the button. (4rem
-       comfortably clears `.sidebar-toggle` at `left: space-4` plus its
-       width.) */
-    .main-content > .banner-stack .banner {
-        padding-inline-start: var(--space-16);
+    /* On narrow viewports the fixed hamburger floats over the top-left
+       of <main>. Start the banner stack below it — with the same
+       --space-4 gap under the button as above/left of it — so banners
+       stay full-width instead of indenting their content to dodge the
+       button (which read as the button punching a hole in the banner).
+       Clearance = button top offset + button height + gap:
+       --space-4 + (--font-xl + 2 × --space-2 + 2px border) + --space-4
+       = 16 + 38 + 16 = 70px. `line-height: 1` on .sidebar-toggle makes
+       --font-xl the content height. */
+    .main-content > .banner-stack:not(:empty) {
+        padding-top: calc(2 * var(--space-4) + var(--font-xl) + 2 * var(--space-2) + 2px);
     }
 
-    /* When the flash is visible, trim the top padding that normally
-       reserves space for the floating hamburger by roughly the
-       single-banner height (≈ 1 line of `--font-sm` + 16px padding ≈
-       36px). The remainder still clears the hamburger when it sticks
-       out below a short banner stack, and — most importantly — keeps
-       the heading at roughly the same Y position whether the banner
-       is shown or dismissed (no visible jump on dismiss). */
+    /* While a banner is visible, the banner-stack's own padding-top
+       (above) already clears the floating hamburger, so the header
+       below no longer needs its --space-16 clearance — trim it to
+       normal section spacing. The heading sits lower while a banner
+       is shown and moves up on dismiss; that's inherent to banners
+       now occupying real vertical space below the button instead of
+       rendering underneath it. */
     body:has(.main-content > .banner-stack:not(:empty)) .list-pane-header,
     body:has(.main-content > .banner-stack:not(:empty)) .page-content {
         padding-top: var(--space-6);


### PR DESCRIPTION
## Problem

On narrow viewports (≤1024px) the fixed hamburger (`position: fixed; top/left: --space-4`) floats over the top-left of `<main>`, overlapping the flash banner stack. The old fix indented every banner's content by `4rem` (`padding-inline-start: --space-16`) to dodge the button — which read as the white button **punching a hole** in the banner, with a dead gap on its left. Worse, stacked banners the button never overlapped were indented too.

## Fix

Pure CSS, entirely within the existing `@media (max-width: 1024px)` block in `static/css/app.css`:

- Drop the per-banner indent hack.
- Give the non-empty banner stack a `padding-top` that starts it **below** the hamburger, with the same `--space-4` gap under the button as above/left of it, so banners stay full-width:
  `calc(2 × --space-4 + --font-xl + 2 × --space-2 + 2px)` = 16 + 38 + 16 = **70px** (button top offset + button height + gap; `line-height: 1` makes `--font-xl` the content height).
- `:not(:empty)` guards the padding so dismissing the last banner collapses the space (no leftover hole).
- The header clearance-trim rule's comment is updated; its selector and value are unchanged.

Design confirmed against the user's approved mockup (hamburger floating alone on the first row, banners full-width starting below it).

## Tests

- New BDD scenario `Flash banner clears the hamburger on mobile` (red before, green after): asserts the banner sits below the toggle (no overlap) and reaches past the floating button's left edge (full-width).
- Full regression green: e2e `85 passed`, Rust `779 passed`.
- Visual smoke at 390px: measured `{gapAbove:16, gapBelow:16, bannerLeft:0}`; single- and double-banner screenshots show full-width, left-aligned banners with no indent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)