### PR TITLE
feat: per-user read-entry retention with tombstones

### DIFF
--- a/docs/superpowers/plans/2026-06-12-per-user-retention-tombstone.md
+++ b/docs/superpowers/plans/2026-06-12-per-user-retention-tombstone.md
@@ -1,0 +1,1136 @@
+# Per-User Read-Entry Retention + Tombstones Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an opt-in, per-user retention policy that deletes old *read* entries, backed by an `entry_tombstone` table that prevents deleted entries from being re-imported as unread on the next feed refresh, plus a gated-VACUUM maintenance step so the database file actually shrinks.
+
+**Architecture:** A new `entry_tombstone(feed_id, guid, created_at)` table records deletions. The feed-sync insert path gains an atomic `WHERE NOT EXISTS (entry_tombstone)` guard. A new background worker (`entry_retention`) periodically prunes read+aged+non-starred entries per each user's `user_settings.retention_read_days` threshold (batches of 500, tombstone+delete per batch in one transaction), then runs maintenance (`PRAGMA optimize`, a `VACUUM` gated at ≥20% freelist, `wal_checkpoint(TRUNCATE)`). Opt-in lives in the existing user-settings UI; `0` = disabled (default).
+
+**Tech Stack:** Rust, rusqlite (raw SQL, `prepare_cached`), SQLite (WAL), tokio background worker + `CancellationToken`, Askama SSR template, playwright-bdd.
+
+**Spec:** `docs/superpowers/specs/2026-06-12-per-user-retention-tombstone-design.md`
+
+---
+
+## Environment notes (this box)
+
+- **Before every cargo command**, re-source the OpenSSL env: `source /tmp/rdrs-env.sh && <cargo cmd>`.
+- Run tests with **`cargo nextest run`** (not `cargo test`).
+- Run **`cargo fmt`** before each commit.
+- Run a **`pwd`** check first; all cargo/git commands run from `/home/nixos/Develop/claude/rdrs`.
+- Commits are **GPG-signed** (default). Stage files **explicitly by name** (never `git add -A`/`.`).
+
+## File Structure
+
+- `src/db/schema.rs` — add `entry_tombstone` table + `user_settings.retention_read_days` column; bump schema version 7→8. (Migration)
+- `src/models/user_settings.rs` — `retention_read_days` field, getter, `update_retention_read_days()`. (Per-user opt-in storage)
+- `src/models/entry/mod.rs` — `UpsertOutcome` enum + tombstone guard in `upsert_entry_id`; adapt `upsert_entry` wrapper; `insert_tombstone()` test helper; `prune_read_retention_batch()`. (Tombstone guard + pruning core)
+- `src/services/feed_sync.rs` — map `UpsertOutcome` (new/updated/skipped counters). (Refresh adaptation)
+- `src/services/entry_retention.rs` — **new**: `start_retention_worker()` + `run_maintenance()`. (Background worker)
+- `src/services/mod.rs` — register/export the new module.
+- `src/main.rs` — start the worker; add to graceful-shutdown join set.
+- `src/handlers/pages/mod.rs` — load `retention_read_days` into `UserSettingsTemplate`.
+- `src/handlers/user.rs` — accept `retention_read_days` in `UpdatePreferencesForm`.
+- `templates/user_settings.html` — number input in the preferences form.
+- `e2e/` — a BDD scenario for the new settings field.
+
+---
+
+### Task 1: Migration — `entry_tombstone` table + `retention_read_days` column
+
+**Files:**
+- Modify: `src/db/schema.rs` (main `execute_batch` block; migration block ~`src/db/schema.rs:236-247`; tests ~`:256-298`)
+
+- [ ] **Step 1: Update the version tests to expect 8 and assert the new table**
+
+In `src/db/schema.rs`, in `test_init_db` add an assertion, and change both `assert_eq!(version, 7)` to `8`:
+
+```rust
+        assert!(tables.contains(&"entry_summary".to_string()));
+        assert!(tables.contains(&"entry_tombstone".to_string()));
+```
+
+```rust
+        assert_eq!(version, 8);
+```
+
+(There are two `assert_eq!(version, 7)` occurrences — in `test_init_db_idempotent` and `test_init_db_sets_user_version`. Change both to `8`.)
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `source /tmp/rdrs-env.sh && cargo nextest run -p rdrs db::schema`
+Expected: FAIL — `entry_tombstone` not in table list; version is 7 not 8.
+
+- [ ] **Step 3: Add the table to the main batch and the column to `user_settings`**
+
+In the big `conn.execute_batch(r#" ... "#)` block: add the `retention_read_days` column to the `user_settings` CREATE TABLE (after `entries_per_page`):
+
+```sql
+        CREATE TABLE IF NOT EXISTS user_settings (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            user_id INTEGER NOT NULL UNIQUE REFERENCES user(id) ON DELETE CASCADE,
+            entries_per_page INTEGER NOT NULL DEFAULT 30,
+            retention_read_days INTEGER NOT NULL DEFAULT 0,
+            save_services TEXT,
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+```
+
+And add the tombstone table near the `entry` indexes (anywhere inside the batch):
+
+```sql
+        -- Tombstones for entries deleted by retention. Keyed by (feed_id, guid),
+        -- mirroring entry's UNIQUE(feed_id, guid). The refresh insert path checks
+        -- this so a deleted entry the feed still serves is not re-imported as
+        -- unread. created_at follows the schema-wide convention; kept forever
+        -- (lightweight, no GC). Cascades when the feed is deleted.
+        CREATE TABLE IF NOT EXISTS entry_tombstone (
+            feed_id    INTEGER NOT NULL REFERENCES feed(id) ON DELETE CASCADE,
+            guid       TEXT NOT NULL,
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            PRIMARY KEY (feed_id, guid)
+        ) WITHOUT ROWID;
+```
+
+- [ ] **Step 4: Add the v8 migration block and bump `LATEST_VERSION`**
+
+Replace the `if version < 7 { ... }` ... `const LATEST_VERSION: i64 = 7;` tail with an added block and bumped constant:
+
+```rust
+    if version < 8 {
+        // Add the per-user retention threshold to existing databases. The
+        // entry_tombstone table is created via CREATE TABLE IF NOT EXISTS in the
+        // main batch above (picked up on restart). `let _ =` swallows the
+        // duplicate-column error on fresh DBs where the main batch already added
+        // the column (mirrors the v1/v2 legacy ALTERs).
+        let _ = conn.execute(
+            "ALTER TABLE user_settings ADD COLUMN retention_read_days INTEGER NOT NULL DEFAULT 0",
+            [],
+        );
+    }
+
+    const LATEST_VERSION: i64 = 8;
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `source /tmp/rdrs-env.sh && cargo nextest run -p rdrs db::schema`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/nixos/Develop/claude/rdrs && cargo fmt
+git add src/db/schema.rs
+git commit -m "feat(db): add entry_tombstone table and retention_read_days column (schema v8)"
+```
+
+---
+
+### Task 2: `user_settings` model — retention threshold storage
+
+**Files:**
+- Modify: `src/models/user_settings.rs` (struct ~`:12-21`, `row_to_user_settings` ~`:43-56`, SELECT in `find_by_user_id` ~`:60`, add fns near `update_theme` ~`:140`, tests)
+
+- [ ] **Step 1: Write failing tests for the getter and updater**
+
+Add to the `tests` module in `src/models/user_settings.rs`:
+
+```rust
+    #[test]
+    fn test_retention_read_days_default_zero() {
+        let conn = setup_db();
+        let user = user::create_user(&conn, "ret", "hash", Role::User).unwrap();
+        assert_eq!(get_retention_read_days(&conn, user.id).unwrap(), 0);
+    }
+
+    #[test]
+    fn test_update_retention_read_days() {
+        let conn = setup_db();
+        let user = user::create_user(&conn, "ret", "hash", Role::User).unwrap();
+
+        update_retention_read_days(&conn, user.id, 30).unwrap();
+        assert_eq!(get_retention_read_days(&conn, user.id).unwrap(), 30);
+
+        // Preserves other settings.
+        upsert(&conn, user.id, 50).unwrap();
+        update_retention_read_days(&conn, user.id, 14).unwrap();
+        let s = find_by_user_id(&conn, user.id).unwrap().unwrap();
+        assert_eq!(s.retention_read_days, 14);
+        assert_eq!(s.entries_per_page, 50);
+
+        // Negatives are rejected.
+        assert!(matches!(
+            update_retention_read_days(&conn, user.id, -1),
+            Err(AppError::Validation(_))
+        ));
+    }
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `source /tmp/rdrs-env.sh && cargo nextest run -p rdrs user_settings`
+Expected: FAIL — `get_retention_read_days`/`update_retention_read_days` not found; field `retention_read_days` missing.
+
+- [ ] **Step 3: Add the field, mapping, SELECT column, and functions**
+
+In `struct UserSettings`, add after `entries_per_page`:
+
+```rust
+    pub retention_read_days: i64,
+```
+
+In `row_to_user_settings`, the column order changes (new column is index 2 in the SELECT below, shifting the rest). Update the SELECT in `find_by_user_id` and the row mapping together:
+
+```rust
+pub fn find_by_user_id(conn: &Connection, user_id: i64) -> AppResult<Option<UserSettings>> {
+    conn.query_row(
+        "SELECT id, user_id, entries_per_page, retention_read_days, save_services, theme, created_at, updated_at FROM user_settings WHERE user_id = ?1",
+        params![user_id],
+        row_to_user_settings,
+    )
+    .optional()
+    .map_err(AppError::Database)
+}
+```
+
+```rust
+fn row_to_user_settings(row: &rusqlite::Row) -> rusqlite::Result<UserSettings> {
+    let created_at: String = row.get(6)?;
+    let updated_at: String = row.get(7)?;
+
+    Ok(UserSettings {
+        id: row.get(0)?,
+        user_id: row.get(1)?,
+        entries_per_page: row.get(2)?,
+        retention_read_days: row.get(3)?,
+        save_services: row.get(4)?,
+        theme: row.get(5)?,
+        created_at: parse_datetime(&created_at),
+        updated_at: parse_datetime(&updated_at),
+    })
+}
+```
+
+Add the two functions after `update_theme` (~`:155`):
+
+```rust
+/// Get the per-user read-entry retention threshold in days (0 = disabled).
+pub fn get_retention_read_days(conn: &Connection, user_id: i64) -> AppResult<i64> {
+    match find_by_user_id(conn, user_id)? {
+        Some(settings) => Ok(settings.retention_read_days),
+        None => Ok(0),
+    }
+}
+
+/// Set the per-user read-entry retention threshold in days. `0` disables
+/// retention for the user; negative values are rejected.
+pub fn update_retention_read_days(conn: &Connection, user_id: i64, days: i64) -> AppResult<()> {
+    if days < 0 {
+        return Err(AppError::Validation(
+            "retention_read_days must be >= 0".to_string(),
+        ));
+    }
+    // Ensure a row exists, then update (mirrors update_theme).
+    conn.execute(
+        "INSERT INTO user_settings (user_id, entries_per_page) VALUES (?1, ?2)
+         ON CONFLICT(user_id) DO NOTHING",
+        params![user_id, DEFAULT_ENTRIES_PER_PAGE],
+    )?;
+    conn.execute(
+        "UPDATE user_settings SET retention_read_days = ?1, updated_at = datetime('now') WHERE user_id = ?2",
+        params![days, user_id],
+    )?;
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `source /tmp/rdrs-env.sh && cargo nextest run -p rdrs user_settings`
+Expected: PASS (existing `user_settings` tests still pass — the struct gained a field but all constructors go through SQL).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/nixos/Develop/claude/rdrs && cargo fmt
+git add src/models/user_settings.rs
+git commit -m "feat(settings): per-user retention_read_days getter/updater"
+```
+
+---
+
+### Task 3: Tombstone guard in the entry insert path
+
+**Files:**
+- Modify: `src/models/entry/mod.rs` (`upsert_entry_id` ~`:484-539`, `upsert_entry` ~`:547-571`, add `insert_tombstone`, update test `test_upsert_entry_id_returns_id_and_is_new` ~`:1751`)
+
+- [ ] **Step 1: Write failing tests for the guard and the new outcome type**
+
+Add to the `tests` module in `src/models/entry/mod.rs` (the helpers `setup_db`, feed/category/user creation already exist in that module's tests — follow the existing pattern used by nearby tests like `test_upsert_entry_id_returns_id_and_is_new`):
+
+```rust
+    #[test]
+    fn test_upsert_skips_tombstoned_guid() {
+        let conn = setup_db();
+        let feed_id = setup_feed(&conn); // existing test helper in this module
+
+        // Tombstone a guid, then a refresh that serves it must be skipped.
+        insert_tombstone(&conn, feed_id, "ghost").unwrap();
+        let outcome = upsert_entry_id(
+            &conn, feed_id, "ghost", Some("Ghost"), None, None, None, None, None,
+        )
+        .unwrap();
+        assert!(matches!(outcome, UpsertOutcome::SkippedTombstoned));
+
+        // The entry must not exist.
+        assert!(find_by_guid_and_feed(&conn, "ghost", feed_id).unwrap().is_none());
+    }
+
+    #[test]
+    fn test_upsert_inserts_then_updates() {
+        let conn = setup_db();
+        let feed_id = setup_feed(&conn);
+
+        let first = upsert_entry_id(
+            &conn, feed_id, "g1", Some("First"), None, None, None, None, None,
+        )
+        .unwrap();
+        let id = match first {
+            UpsertOutcome::Inserted(id) => id,
+            other => panic!("expected Inserted, got {other:?}"),
+        };
+
+        let second = upsert_entry_id(
+            &conn, feed_id, "g1", Some("Updated"), None, None, None, None, None,
+        )
+        .unwrap();
+        assert!(matches!(second, UpsertOutcome::Updated(uid) if uid == id));
+    }
+```
+
+Also update the existing `test_upsert_entry_id_returns_id_and_is_new` (it destructures `(id1, is_new)`): replace its body's `upsert_entry_id` assertions to match the enum, e.g.:
+
+```rust
+        let first = upsert_entry_id(&conn, feed_id, "guid-1", Some("Title"), None, None, None, None, None).unwrap();
+        let id1 = match first { UpsertOutcome::Inserted(id) => id, o => panic!("expected Inserted, got {o:?}") };
+
+        let second = upsert_entry_id(&conn, feed_id, "guid-1", Some("Title 2"), None, None, None, None, None).unwrap();
+        assert!(matches!(second, UpsertOutcome::Updated(id) if id == id1));
+```
+
+If `setup_feed` does not already exist as a helper in this test module, add it near the top of the `tests` module:
+
+```rust
+    fn setup_feed(conn: &Connection) -> i64 {
+        let user_id = crate::models::user::create_user(conn, "u", "h", crate::models::user::Role::User).unwrap().id;
+        let category_id = crate::models::category::create_category(conn, user_id, "C").unwrap().id;
+        crate::models::feed::create_feed(conn, &crate::models::feed::CreateFeedParams {
+            category_id, url: "https://example.com/f.xml", title: Some("F"),
+            description: None, site_url: None, custom_user_agent: None,
+            http2_disabled: None, custom_referrer: None,
+        }).unwrap().id
+    }
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `source /tmp/rdrs-env.sh && cargo nextest run -p rdrs entry::`
+Expected: FAIL — `UpsertOutcome`/`insert_tombstone` not defined; `upsert_entry_id` still returns a tuple.
+
+- [ ] **Step 3: Define `UpsertOutcome`, add the guard, add `insert_tombstone`**
+
+Above `upsert_entry_id`, add the enum:
+
+```rust
+/// Result of an entry upsert. The insert path is guarded against tombstones,
+/// so a third "skipped" state exists alongside insert/update.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UpsertOutcome {
+    Inserted(i64),
+    Updated(i64),
+    SkippedTombstoned,
+}
+```
+
+Change `upsert_entry_id`'s return type and its two `Ok(...)` returns and the INSERT:
+
+```rust
+) -> AppResult<UpsertOutcome> {
+```
+
+```rust
+        .execute(params![title, link, content, summary, author, id])?;
+
+        return Ok(UpsertOutcome::Updated(id));
+    }
+
+    // Insert, but never resurrect a tombstoned guid. The WHERE NOT EXISTS makes
+    // the tombstone check atomic with the insert, so a retention delete that
+    // commits between a separate check and this statement cannot bring the
+    // entry back as unread.
+    let inserted = conn
+        .prepare_cached(
+            r#"
+            INSERT INTO entry (feed_id, guid, title, link, content, summary, author, published_at)
+            SELECT ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8
+            WHERE NOT EXISTS (
+                SELECT 1 FROM entry_tombstone WHERE feed_id = ?1 AND guid = ?2
+            )
+            "#,
+        )?
+        .execute(params![
+            feed_id, guid, title, link, content, summary, author, published_at_str
+        ])?;
+
+    if inserted == 0 {
+        return Ok(UpsertOutcome::SkippedTombstoned);
+    }
+    Ok(UpsertOutcome::Inserted(conn.last_insert_rowid()))
+}
+```
+
+Adapt the `upsert_entry` wrapper so its `(Entry, bool)` signature is unchanged (its ~30 callers stay compiling):
+
+```rust
+    let (id, is_new) = match upsert_entry_id(
+        conn, feed_id, guid, title, link, content, summary, author, published_at,
+    )? {
+        UpsertOutcome::Inserted(id) => (id, true),
+        UpsertOutcome::Updated(id) => (id, false),
+        UpsertOutcome::SkippedTombstoned => {
+            return Err(AppError::Internal(
+                "upsert_entry called for a tombstoned guid".to_string(),
+            ))
+        }
+    };
+    let entry = find_by_id(conn, id)?.ok_or(AppError::EntryNotFound)?;
+    Ok((entry, is_new))
+```
+
+Add `insert_tombstone` near `upsert_entry_id` (used by retention and tests):
+
+```rust
+/// Record a tombstone for `(feed_id, guid)`. Idempotent.
+pub fn insert_tombstone(conn: &Connection, feed_id: i64, guid: &str) -> AppResult<()> {
+    conn.execute(
+        "INSERT INTO entry_tombstone (feed_id, guid) VALUES (?1, ?2)
+         ON CONFLICT(feed_id, guid) DO NOTHING",
+        params![feed_id, guid],
+    )?;
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `source /tmp/rdrs-env.sh && cargo nextest run -p rdrs entry::`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/nixos/Develop/claude/rdrs && cargo fmt
+git add src/models/entry/mod.rs
+git commit -m "feat(entry): tombstone-guarded insert via UpsertOutcome"
+```
+
+---
+
+### Task 4: Adapt feed-sync to `UpsertOutcome`
+
+**Files:**
+- Modify: `src/services/feed_sync.rs` (entry loop ~`:286-374`)
+
+- [ ] **Step 1: Update the closure to match the enum and count skips**
+
+Replace the tuple destructure and counters. Change the closure's return tuple to include a skipped count and the `match`:
+
+```rust
+    let (new_entries, updated_entries, skipped_entries) = db
+        .background(move |conn| {
+            let mut new_entries = 0i64;
+            let mut updated_entries = 0i64;
+            let mut skipped_entries = 0i64;
+            let mut latest_entry_date: Option<chrono::DateTime<Utc>> = None;
+
+            let tx = conn.unchecked_transaction()?;
+
+            for item in parsed_feed.entries {
+                // ... unchanged extraction of guid/title/link/content/summary/author/published_at ...
+
+                match entry::upsert_entry_id(
+                    &tx,
+                    feed_id,
+                    &guid,
+                    title.as_deref(),
+                    link.as_deref(),
+                    content.as_deref(),
+                    summary.as_deref(),
+                    author.as_deref(),
+                    published_at,
+                )? {
+                    entry::UpsertOutcome::Inserted(_) => new_entries += 1,
+                    entry::UpsertOutcome::Updated(_) => updated_entries += 1,
+                    entry::UpsertOutcome::SkippedTombstoned => skipped_entries += 1,
+                }
+            }
+
+            // ... unchanged effective_updated_at + feed::update_fetch_result + tx.commit() ...
+
+            Ok::<_, AppError>((new_entries, updated_entries, skipped_entries))
+        })
+        .await??;
+
+    info!(
+        "Feed {} refreshed: {} new, {} updated, {} skipped (tombstoned)",
+        feed_id, new_entries, updated_entries, skipped_entries
+    );
+```
+
+(Leave the `published_at` "track latest_entry_date" block and the metadata update exactly as they are — only the upsert call/counters and the log line change. `SyncResult` keeps its existing `new_entries`/`updated_entries` fields; `skipped_entries` is log-only.)
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run: `source /tmp/rdrs-env.sh && cargo build -p rdrs`
+Expected: PASS (no type errors).
+
+- [ ] **Step 3: Run feed-sync tests**
+
+Run: `source /tmp/rdrs-env.sh && cargo nextest run -p rdrs feed_sync`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/nixos/Develop/claude/rdrs && cargo fmt
+git add src/services/feed_sync.rs
+git commit -m "feat(feed-sync): handle tombstoned-skip outcome, log skip count"
+```
+
+---
+
+### Task 5: Pruning core — `prune_read_retention_batch`
+
+**Files:**
+- Modify: `src/models/entry/mod.rs` (add function + tests)
+
+- [ ] **Step 1: Write failing tests**
+
+Add to the entry `tests` module:
+
+```rust
+    #[test]
+    fn test_prune_respects_threshold_star_and_optin() {
+        let conn = setup_db();
+        let feed_id = setup_feed(&conn); // feed belongs to the user created in setup_feed
+
+        // Helper: insert a read entry aged `days_old`.
+        let mk = |guid: &str, days: i64, starred: bool| {
+            upsert_entry_id(&conn, feed_id, guid, Some(guid), None, None, None, None, None).unwrap();
+            conn.execute(
+                "UPDATE entry SET read_at = datetime('now', ?2) WHERE guid = ?1 AND feed_id = ?3",
+                rusqlite::params![guid, format!("-{days} days"), feed_id],
+            ).unwrap();
+            if starred {
+                conn.execute(
+                    "UPDATE entry SET starred_at = datetime('now') WHERE guid = ?1 AND feed_id = ?2",
+                    rusqlite::params![guid, feed_id],
+                ).unwrap();
+            }
+        };
+        mk("old", 40, false);     // read, 40d, not starred -> victim once enabled
+        mk("oldstar", 40, true);  // starred -> never deleted
+        mk("fresh", 1, false);    // too recent -> kept
+        // "unread" entry: insert without read_at
+        upsert_entry_id(&conn, feed_id, "unread", Some("u"), None, None, None, None, None).unwrap();
+
+        // Opt-in disabled (default 0): nothing pruned.
+        assert_eq!(prune_read_retention_batch(&conn, 500).unwrap(), 0);
+
+        // Enable retention at 30 days for the feed's owner.
+        let user_id: i64 = conn.query_row(
+            "SELECT c.user_id FROM feed f JOIN category c ON c.id = f.category_id WHERE f.id = ?1",
+            rusqlite::params![feed_id], |r| r.get(0),
+        ).unwrap();
+        crate::models::user_settings::update_retention_read_days(&conn, user_id, 30).unwrap();
+
+        // Only "old" is pruned; a tombstone is written for it.
+        assert_eq!(prune_read_retention_batch(&conn, 500).unwrap(), 1);
+        assert!(find_by_guid_and_feed(&conn, "old", feed_id).unwrap().is_none());
+        assert!(find_by_guid_and_feed(&conn, "oldstar", feed_id).unwrap().is_some());
+        assert!(find_by_guid_and_feed(&conn, "fresh", feed_id).unwrap().is_some());
+        assert!(find_by_guid_and_feed(&conn, "unread", feed_id).unwrap().is_some());
+
+        // Tombstone present -> a refresh serving "old" again is skipped.
+        let outcome = upsert_entry_id(&conn, feed_id, "old", Some("Old"), None, None, None, None, None).unwrap();
+        assert!(matches!(outcome, UpsertOutcome::SkippedTombstoned));
+
+        // Idempotent: nothing left to prune.
+        assert_eq!(prune_read_retention_batch(&conn, 500).unwrap(), 0);
+    }
+
+    #[test]
+    fn test_prune_batch_size_limits_rows() {
+        let conn = setup_db();
+        let feed_id = setup_feed(&conn);
+        let user_id: i64 = conn.query_row(
+            "SELECT c.user_id FROM feed f JOIN category c ON c.id = f.category_id WHERE f.id = ?1",
+            rusqlite::params![feed_id], |r| r.get(0),
+        ).unwrap();
+        crate::models::user_settings::update_retention_read_days(&conn, user_id, 1).unwrap();
+        for i in 0..5 {
+            let g = format!("g{i}");
+            upsert_entry_id(&conn, feed_id, &g, Some(&g), None, None, None, None, None).unwrap();
+            conn.execute(
+                "UPDATE entry SET read_at = datetime('now', '-10 days') WHERE guid = ?1 AND feed_id = ?2",
+                rusqlite::params![g, feed_id],
+            ).unwrap();
+        }
+        assert_eq!(prune_read_retention_batch(&conn, 2).unwrap(), 2);
+        assert_eq!(prune_read_retention_batch(&conn, 2).unwrap(), 2);
+        assert_eq!(prune_read_retention_batch(&conn, 2).unwrap(), 1);
+        assert_eq!(prune_read_retention_batch(&conn, 2).unwrap(), 0);
+    }
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `source /tmp/rdrs-env.sh && cargo nextest run -p rdrs entry::`
+Expected: FAIL — `prune_read_retention_batch` not defined.
+
+- [ ] **Step 3: Implement the function**
+
+Add to `src/models/entry/mod.rs` (near `insert_tombstone`):
+
+```rust
+/// Delete up to `batch_size` read, aged, non-starred entries belonging to users
+/// who have opted into retention (`user_settings.retention_read_days > 0`),
+/// recording a tombstone for each. Returns the number of entries deleted.
+///
+/// One batch runs in a single transaction so the tombstone+delete pair is
+/// atomic against a concurrent feed refresh. Victims are gathered first (Rust
+/// side) so the delete targets exact ids rather than re-running a `LIMIT`
+/// without `ORDER BY`. Each user's own threshold is applied via the join.
+pub fn prune_read_retention_batch(conn: &Connection, batch_size: usize) -> AppResult<u64> {
+    let tx = conn.unchecked_transaction()?;
+
+    let victims: Vec<(i64, i64, String)> = {
+        let mut stmt = tx.prepare_cached(
+            r#"
+            SELECT e.id, e.feed_id, e.guid
+            FROM entry e
+            JOIN feed f           ON f.id = e.feed_id
+            JOIN category c       ON c.id = f.category_id
+            JOIN user_settings us ON us.user_id = c.user_id
+            WHERE us.retention_read_days > 0
+              AND e.read_at    IS NOT NULL
+              AND e.starred_at IS NULL
+              AND e.read_at < datetime('now', '-' || us.retention_read_days || ' days')
+            LIMIT ?1
+            "#,
+        )?;
+        stmt.query_map(params![batch_size as i64], |row| {
+            Ok((row.get(0)?, row.get(1)?, row.get(2)?))
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?
+    };
+
+    if victims.is_empty() {
+        return Ok(0);
+    }
+
+    {
+        let mut ins = tx.prepare_cached(
+            "INSERT INTO entry_tombstone (feed_id, guid) VALUES (?1, ?2)
+             ON CONFLICT(feed_id, guid) DO NOTHING",
+        )?;
+        let mut del = tx.prepare_cached("DELETE FROM entry WHERE id = ?1")?;
+        for (id, feed_id, guid) in &victims {
+            ins.execute(params![feed_id, guid])?;
+            del.execute(params![id])?;
+        }
+    }
+
+    tx.commit()?;
+    Ok(victims.len() as u64)
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `source /tmp/rdrs-env.sh && cargo nextest run -p rdrs entry::`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/nixos/Develop/claude/rdrs && cargo fmt
+git add src/models/entry/mod.rs
+git commit -m "feat(entry): prune_read_retention_batch (delete + tombstone)"
+```
+
+---
+
+### Task 6: Retention worker + maintenance
+
+**Files:**
+- Create: `src/services/entry_retention.rs`
+- Modify: `src/services/mod.rs` (add `pub mod` + `pub use`)
+
+- [ ] **Step 1: Write the worker module with failing tests**
+
+Create `src/services/entry_retention.rs`:
+
+```rust
+use std::time::Duration;
+
+use rusqlite::Connection;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+use crate::db::DbPool;
+use crate::error::AppResult;
+use crate::models::entry;
+
+/// Entries deleted per transaction during a drain.
+const BATCH_SIZE: usize = 500;
+/// Run a full VACUUM only when freed pages reach this fraction of the file. A
+/// full VACUUM rewrites the whole database under a write lock (~db_size/650
+/// seconds), so it is not worth doing for the handful of pages a routine prune
+/// frees — only after a large drain.
+const VACUUM_FREELIST_RATIO: f64 = 0.20;
+
+/// Start the retention worker. Every `interval_hours` it prunes read+aged
+/// +non-starred entries for users who opted in (`user_settings.retention_read_days
+/// > 0`), then runs maintenance. A no-op when nobody opted in.
+pub fn start_retention_worker(
+    db: DbPool,
+    interval_hours: u64,
+    cancel_token: CancellationToken,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        tracing::info!("Retention worker started: interval={}h", interval_hours);
+        let mut interval = tokio::time::interval(Duration::from_secs(interval_hours * 3600));
+
+        loop {
+            tokio::select! {
+                _ = cancel_token.cancelled() => {
+                    tracing::info!("Retention worker stopping...");
+                    break;
+                }
+                _ = interval.tick() => {
+                    let mut total = 0u64;
+                    loop {
+                        if cancel_token.is_cancelled() {
+                            break;
+                        }
+                        let deleted = match db
+                            .background(move |conn| entry::prune_read_retention_batch(conn, BATCH_SIZE))
+                            .await
+                        {
+                            Ok(Ok(n)) => n,
+                            Ok(Err(e)) => { tracing::error!("Retention prune failed: {}", e); break; }
+                            Err(e) => { tracing::error!("Retention DB access failed: {}", e); break; }
+                        };
+                        total += deleted;
+                        if deleted < BATCH_SIZE as u64 {
+                            break;
+                        }
+                    }
+
+                    if total > 0 {
+                        tracing::info!("Retention pruned {} read entries", total);
+                        match db.background(run_maintenance).await {
+                            Ok(Ok(true)) => tracing::info!("Retention maintenance: VACUUM ran"),
+                            Ok(Ok(false)) => {}
+                            Ok(Err(e)) => tracing::error!("Retention maintenance failed: {}", e),
+                            Err(e) => tracing::error!("Retention maintenance DB access failed: {}", e),
+                        }
+                    }
+                }
+            }
+        }
+
+        tracing::info!("Retention worker stopped");
+    })
+}
+
+/// Post-prune maintenance: refresh planner stats, gated full VACUUM, truncating
+/// WAL checkpoint. Returns whether a VACUUM ran. Must run outside a transaction.
+pub fn run_maintenance(conn: &Connection) -> AppResult<bool> {
+    conn.execute_batch("PRAGMA optimize;")?;
+
+    let page_count: i64 = conn.pragma_query_value(None, "page_count", |r| r.get(0))?;
+    let freelist: i64 = conn.pragma_query_value(None, "freelist_count", |r| r.get(0))?;
+    let vacuumed = page_count > 0 && (freelist as f64 / page_count as f64) >= VACUUM_FREELIST_RATIO;
+    if vacuumed {
+        conn.execute_batch("VACUUM;")?;
+    }
+
+    conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);")?;
+    Ok(vacuumed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::init_db;
+    use crate::models::{category, feed, user, user_settings};
+    use crate::models::user::Role;
+
+    fn setup_db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        init_db(&conn).unwrap();
+        conn
+    }
+
+    fn setup_pool() -> DbPool {
+        let conn = setup_db();
+        let read_conn = Connection::open_in_memory().unwrap();
+        let (pool, _h) = DbPool::new(conn, read_conn);
+        pool
+    }
+
+    #[test]
+    fn test_run_maintenance_no_vacuum_below_ratio() {
+        let conn = setup_db();
+        // Fresh DB: ~0 freelist -> no VACUUM, but must not error.
+        assert!(!run_maintenance(&conn).unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_worker_stops_on_cancellation() {
+        let db = setup_pool();
+        let token = CancellationToken::new();
+        let handle = start_retention_worker(db, 1000, token.clone());
+        token.cancel();
+        let res = tokio::time::timeout(Duration::from_secs(5), handle).await;
+        assert!(res.is_ok(), "retention worker should stop after cancellation");
+    }
+
+    #[tokio::test]
+    async fn test_drain_deletes_opted_in_aged_read_entries() {
+        let db = setup_pool();
+        db.user(|conn| {
+            let uid = user::create_user(conn, "u", "h", Role::User).unwrap().id;
+            let cid = category::create_category(conn, uid, "C").unwrap().id;
+            let fid = feed::create_feed(conn, &feed::CreateFeedParams {
+                category_id: cid, url: "https://e.com/f.xml", title: Some("F"),
+                description: None, site_url: None, custom_user_agent: None,
+                http2_disabled: None, custom_referrer: None,
+            }).unwrap().id;
+            entry::upsert_entry_id(conn, fid, "old", Some("o"), None, None, None, None, None).unwrap();
+            conn.execute(
+                "UPDATE entry SET read_at = datetime('now','-40 days') WHERE guid='old' AND feed_id=?1",
+                rusqlite::params![fid],
+            ).unwrap();
+            user_settings::update_retention_read_days(conn, uid, 30).unwrap();
+        }).await.unwrap();
+
+        // Simulate one worker tick's drain.
+        let deleted: u64 = db
+            .background(|conn| entry::prune_read_retention_batch(conn, BATCH_SIZE).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(deleted, 1);
+    }
+}
+```
+
+- [ ] **Step 2: Register the module**
+
+In `src/services/mod.rs`, add (alphabetical, near `feed_sync`):
+
+```rust
+pub mod entry_retention;
+```
+
+and after the `feed_sync` re-export:
+
+```rust
+pub use entry_retention::start_retention_worker;
+```
+
+- [ ] **Step 3: Run to verify it builds and passes**
+
+Run: `source /tmp/rdrs-env.sh && cargo nextest run -p rdrs entry_retention`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/nixos/Develop/claude/rdrs && cargo fmt
+git add src/services/entry_retention.rs src/services/mod.rs
+git commit -m "feat(retention): background worker with batched prune + gated VACUUM"
+```
+
+---
+
+### Task 7: Start the worker in `main.rs`
+
+**Files:**
+- Modify: `src/main.rs` (start near the cleanup worker ~`:69-71`; shutdown join ~`:115`)
+
+- [ ] **Step 1: Start the worker after the summary cleanup worker**
+
+After the `cleanup_worker_handle` lines, add:
+
+```rust
+    // Start read-entry retention worker (every 24h; per-user opt-in via
+    // user_settings.retention_read_days, 0 = disabled). No-op when nobody opted in.
+    let retention_worker_handle =
+        services::start_retention_worker(db.clone(), 24, cancel_token.clone());
+```
+
+- [ ] **Step 2: Add it to the graceful-shutdown join set**
+
+In the `tokio::join!(...)` shutdown block, add `retention_worker_handle,`:
+
+```rust
+        let _ = tokio::join!(
+            background_handle,
+            summary_worker_handle,
+            cleanup_worker_handle,
+            retention_worker_handle,
+        );
+```
+
+- [ ] **Step 3: Build**
+
+Run: `source /tmp/rdrs-env.sh && cargo build -p rdrs`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/nixos/Develop/claude/rdrs && cargo fmt
+git add src/main.rs
+git commit -m "feat(main): start retention worker, wire into graceful shutdown"
+```
+
+---
+
+### Task 8: Settings UI — expose `retention_read_days`
+
+**Files:**
+- Modify: `src/handlers/pages/mod.rs` (read closure ~`:656-700`, struct `UserSettingsTemplate` ~`:1998-2015`, construction ~`:725-742`)
+- Modify: `src/handlers/user.rs` (`UpdatePreferencesForm` ~`:413-417`, `update_preferences_form` ~`:419-450`)
+- Modify: `templates/user_settings.html` (preferences form ~`:72-76`)
+
+- [ ] **Step 1: Add the field to the page template struct**
+
+In `UserSettingsTemplate` (`src/handlers/pages/mod.rs:1998`), after `entries_per_page`:
+
+```rust
+    pub retention_read_days: i64,
+```
+
+- [ ] **Step 2: Load it in the page read closure and construct it**
+
+In the `read_user` closure (~`:664-689`), add to the loaded tuple. Change the tuple binding, the closure return, the `unwrap_or` default, and the struct construction to thread `retention_read_days`:
+
+```rust
+    let (
+        theme,
+        entries_per_page,
+        retention_read_days,
+        linkding_configured,
+        linkding_api_url,
+        kagi_configured,
+        kagi_language,
+    ) = state
+        .db
+        .read_user(move |conn| {
+            let theme = user_settings::get_theme(conn, user_id).unwrap_or(None);
+            let entries_per_page = user_settings::get_entries_per_page(conn, user_id)
+                .unwrap_or(user_settings::DEFAULT_ENTRIES_PER_PAGE);
+            let retention_read_days =
+                user_settings::get_retention_read_days(conn, user_id).unwrap_or(0);
+            let save_config =
+                user_settings::get_save_services_config(conn, user_id).unwrap_or_default();
+
+            let linkding = save_config.linkding.as_ref();
+            let linkding_configured = linkding.map(|c| c.is_configured()).unwrap_or(false);
+            let linkding_api_url = linkding.map(|c| c.api_url.clone()).unwrap_or_default();
+
+            let kagi = save_config.kagi.as_ref();
+            let kagi_configured = kagi.map(|c| c.is_configured()).unwrap_or(false);
+            let kagi_language = kagi.and_then(|c| c.language.clone());
+
+            Ok::<_, AppError>((
+                theme,
+                entries_per_page,
+                retention_read_days,
+                linkding_configured,
+                linkding_api_url,
+                kagi_configured,
+                kagi_language,
+            ))
+        })
+        .await
+        .ok()
+        .and_then(|r| r.ok())
+        .unwrap_or((
+            None,
+            user_settings::DEFAULT_ENTRIES_PER_PAGE,
+            0,
+            false,
+            String::new(),
+            false,
+            None,
+        ));
+```
+
+In the `UserSettingsTemplate { ... }` construction (~`:725`), add after `entries_per_page,`:
+
+```rust
+            retention_read_days,
+```
+
+- [ ] **Step 3: Accept the field in the preferences form handler**
+
+In `src/handlers/user.rs`, extend `UpdatePreferencesForm`:
+
+```rust
+#[derive(Debug, Deserialize)]
+pub struct UpdatePreferencesForm {
+    pub theme: String,
+    pub entries_per_page: i64,
+    pub retention_read_days: i64,
+}
+```
+
+In `update_preferences_form`, persist it alongside theme/epp:
+
+```rust
+    let epp = req.entries_per_page;
+    let retention_read_days = req.retention_read_days;
+
+    let result = state
+        .db
+        .user(move |conn| {
+            user_settings::upsert(conn, user_id, epp)?;
+            user_settings::update_theme(conn, user_id, theme)?;
+            user_settings::update_retention_read_days(conn, user_id, retention_read_days)?;
+            Ok::<_, AppError>(())
+        })
+        .await;
+```
+
+(The existing `match` already maps `AppError::Validation` to a flash error, so a negative value surfaces a message.)
+
+- [ ] **Step 4: Add the input to the template**
+
+In `templates/user_settings.html`, inside the preferences `<form>` after the entries-per-page `form-group` (~`:76`):
+
+```html
+                    <div class="form-group">
+                        <label for="retention-read-days">Delete read articles older than (days)</label>
+                        <input type="number" id="retention-read-days" name="retention_read_days" value="{{ retention_read_days }}" min="0" data-testid="retention-read-days" required>
+                        <span class="muted" style="font-size:var(--font-xs);">(0 = never delete)</span>
+                    </div>
+```
+
+- [ ] **Step 5: Build and run the handler/page tests**
+
+Run: `source /tmp/rdrs-env.sh && cargo build -p rdrs && cargo nextest run -p rdrs pages user`
+Expected: PASS (Askama compiles the template against the struct; a missing/renamed field fails the build).
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/nixos/Develop/claude/rdrs && cargo fmt
+git add src/handlers/pages/mod.rs src/handlers/user.rs templates/user_settings.html
+git commit -m "feat(settings-ui): retention days field in preferences form"
+```
+
+---
+
+### Task 9: BDD scenario for the settings field
+
+**Files:**
+- Modify: `e2e/features/preferences.feature` (add a scenario)
+- Modify: `e2e/steps/preferences.steps.js` (add two step defs)
+
+The `preferences.feature` `Background` already does `Given I am signed in` + `And I am on the user settings page`, so the scenario reuses it.
+
+- [ ] **Step 1: Add the scenario**
+
+Append to `e2e/features/preferences.feature`:
+
+```gherkin
+  Scenario: Setting a read-article retention period persists
+    When I set the retention period to "30" days
+    Then the retention period field shows "30"
+```
+
+- [ ] **Step 2: Add the step definitions**
+
+Append to `e2e/steps/preferences.steps.js` (mirrors the existing `I switch the theme to` step — same form selector + `waitForURL`):
+
+```js
+When("I set the retention period to {string} days", async ({ page, serverUrl }, days) => {
+  await page.getByTestId("retention-read-days").fill(days);
+  await page.locator('form[action="/user-settings/preferences"] button[type=submit]').click();
+  await page.waitForURL(`${serverUrl}/user-settings`);
+});
+
+Then("the retention period field shows {string}", async ({ page }, value) => {
+  await expect(page.getByTestId("retention-read-days")).toHaveValue(value);
+});
+```
+
+- [ ] **Step 3: Run the BDD suite for this feature**
+
+Run: `cd /home/nixos/Develop/claude/rdrs/e2e && npm test -- preferences`
+Expected: all `Preferences` scenarios PASS, including the new one. (The e2e runner builds and launches the app via `global-setup.js`; if it shells out to cargo, ensure `/tmp/rdrs-env.sh` is sourced in the environment first.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/nixos/Develop/claude/rdrs
+git add e2e/features/preferences.feature e2e/steps/preferences.steps.js
+git commit -m "test(e2e): retention days settings field round-trips"
+```
+
+---
+
+### Task 10: Full verification + docs
+
+**Files:**
+- Modify: `README.md` (document the per-user retention setting, if README documents user settings — check first; do not add a new doc file)
+
+- [ ] **Step 1: Full test + lint sweep**
+
+Run:
+```
+source /tmp/rdrs-env.sh && cargo fmt --check && cargo clippy -p rdrs --all-targets -- -D warnings && cargo nextest run -p rdrs
+```
+Expected: all green.
+
+- [ ] **Step 2: Manual smoke (optional but recommended)**
+
+Start the app, set retention to a small value in user settings, seed an old read entry (or set one's `read_at` back), wait for / trigger the worker tick, confirm the entry is gone, an `entry_tombstone` row exists, and a refresh that still serves that guid does not re-create it. Confirm the `.sqlite3` file shrinks only when freelist ≥ 20%.
+
+- [ ] **Step 3: Docs**
+
+If `README.md` has a settings/configuration section, add a line describing `retention_read_days` (per-user, `0` = disabled, deletes read non-starred entries older than N days, file space reclaimed via gated VACUUM). If it does not, skip — do not create a new doc file.
+
+- [ ] **Step 4: Commit (if README changed)**
+
+```bash
+cd /home/nixos/Develop/claude/rdrs
+git add README.md
+git commit -m "docs: document per-user read-entry retention setting"
+```
+
+---
+
+## Notes for the implementer
+
+- **Atomicity:** every prune batch and the refresh guard rely on single-statement / single-transaction execution on the actor's serialized write connection. Do not split the tombstone-insert and entry-delete across transactions.
+- **VACUUM constraints:** `VACUUM` cannot run inside a transaction and needs ~`db_size` free temp disk; it briefly holds an exclusive lock. The 20% gate keeps it rare. `run_maintenance` must therefore be called outside any open transaction (it is — via its own `db.background` closure).
+- **Why `upsert_entry` still returns `(Entry, bool)`:** to avoid churning its ~30 (mostly test) call sites. Its tombstone branch errors loudly because no live caller upserts a tombstoned guid.
+- **No new index:** benchmarks (in the spec) show `idx_entry_read_at` already serves the victim query at ~0.75 ms/500-row batch over 1M entries; do not add a retention index.

--- a/docs/superpowers/plans/2026-06-12-per-user-retention-tombstone.md
+++ b/docs/superpowers/plans/2026-06-12-per-user-retention-tombstone.md
@@ -4,7 +4,7 @@
 
 **Goal:** Add an opt-in, per-user retention policy that deletes old *read* entries, backed by an `entry_tombstone` table that prevents deleted entries from being re-imported as unread on the next feed refresh, plus a gated-VACUUM maintenance step so the database file actually shrinks.
 
-**Architecture:** A new `entry_tombstone(feed_id, guid, created_at)` table records deletions. The feed-sync insert path gains an atomic `WHERE NOT EXISTS (entry_tombstone)` guard. A new background worker (`entry_retention`) periodically prunes read+aged+non-starred entries per each user's `user_settings.retention_read_days` threshold (batches of 500, tombstone+delete per batch in one transaction), then runs maintenance (`PRAGMA optimize`, a `VACUUM` gated at ≥20% freelist, `wal_checkpoint(TRUNCATE)`). Opt-in lives in the existing user-settings UI; `0` = disabled (default).
+**Architecture:** A new `entry_tombstone(feed_id, guid, created_at)` table records deletions. The feed-sync insert path gains an atomic `WHERE NOT EXISTS (entry_tombstone)` guard. A new background worker (`entry_retention`) periodically prunes read+aged+non-starred entries per each user's `user_settings.retention_read_days` threshold (batches of 500, tombstone+delete per batch in one transaction), then runs maintenance (`PRAGMA optimize`, a `VACUUM` gated at ≥20% freelist, `wal_checkpoint(TRUNCATE)`). Opt-in lives in the existing user-settings UI; `0` = disabled (default). Also folds in an unrelated optimization found while benchmarking this work: an ordered `idx_entry_unread_sort` partial index + `INDEXED BY` hint that takes the unread list page from a whole-inbox temp sort to a range scan (143 ms → 0.03 ms at 1M entries).
 
 **Tech Stack:** Rust, rusqlite (raw SQL, `prepare_cached`), SQLite (WAL), tokio background worker + `CancellationToken`, Askama SSR template, playwright-bdd.
 
@@ -33,6 +33,7 @@
 - `src/handlers/user.rs` — accept `retention_read_days` in `UpdatePreferencesForm`.
 - `templates/user_settings.html` — number input in the preferences form.
 - `e2e/` — a BDD scenario for the new settings field.
+- `src/models/entry/filters.rs` — `published_sort_entry_hint` gains an unread branch (`INDEXED BY idx_entry_unread_sort`). The index itself is added in Task 1's schema batch. (Unread-list planner optimization, found while benchmarking.)
 
 ---
 
@@ -93,6 +94,18 @@ And add the tombstone table near the `entry` indexes (anywhere inside the batch)
         ) WITHOUT ROWID;
 ```
 
+Also add the unread-list ordered index alongside the other `entry` indexes (used by Task 10; mirrors the existing `idx_entry_read_sort`):
+
+```sql
+        -- Ordered partial index over unread entries for the unread list page,
+        -- mirroring idx_entry_read_sort. Without it the unread list does a
+        -- whole-inbox temp-B-tree sort (~143ms at 1M entries). Used via an
+        -- INDEXED BY hint in published_sort_entry_hint (Task 10).
+        CREATE INDEX IF NOT EXISTS idx_entry_unread_sort
+            ON entry(COALESCE(published_at, created_at))
+            WHERE read_at IS NULL;
+```
+
 - [ ] **Step 4: Add the v8 migration block and bump `LATEST_VERSION`**
 
 Replace the `if version < 7 { ... }` ... `const LATEST_VERSION: i64 = 7;` tail with an added block and bumped constant:
@@ -100,8 +113,9 @@ Replace the `if version < 7 { ... }` ... `const LATEST_VERSION: i64 = 7;` tail w
 ```rust
     if version < 8 {
         // Add the per-user retention threshold to existing databases. The
-        // entry_tombstone table is created via CREATE TABLE IF NOT EXISTS in the
-        // main batch above (picked up on restart). `let _ =` swallows the
+        // entry_tombstone table and idx_entry_unread_sort index are created via
+        // CREATE ... IF NOT EXISTS in the main batch above (picked up on
+        // restart, like the v5/v6/v7 indexes). `let _ =` swallows the
         // duplicate-column error on fresh DBs where the main batch already added
         // the column (mirrors the v1/v2 legacy ALTERs).
         let _ = conn.execute(
@@ -1097,7 +1111,92 @@ git commit -m "test(e2e): retention days settings field round-trips"
 
 ---
 
-### Task 10: Full verification + docs
+### Task 10: Unread-list ordered index hint (planner optimization)
+
+Discovered while benchmarking this work: the unread list page does a whole-inbox
+`USE TEMP B-TREE FOR ORDER BY` (~143 ms at 1M entries) because, unlike the read
+and starred filters, `published_sort_entry_hint` has no unread branch. The index
+itself was already added in Task 1; this task wires the `INDEXED BY` hint so the
+planner actually uses it (the index alone is not chosen). Per project rules,
+capture a before/after benchmark for this perf change.
+
+**Files:**
+- Modify: `src/models/entry/filters.rs` (`published_sort_entry_hint` ~`:26`, tests)
+
+- [ ] **Step 1: Write a failing planner test**
+
+In `src/models/entry/filters.rs` tests (follow the existing planner-shape tests in `src/models/entry/mod.rs:2441-2524` that assert `EXPLAIN QUERY PLAN` contains an index name — mirror that style; build a small in-memory DB via `init_db`, insert a couple of unread entries, and assert the plan for the strict-unread published-sort page-0 query):
+
+```rust
+    #[test]
+    fn test_unread_hint_uses_unread_sort_index() {
+        let filter = EntryFilter { unread_only: true, read_after: None, ..Default::default() };
+        assert_eq!(published_sort_entry_hint(&filter), " INDEXED BY idx_entry_unread_sort");
+    }
+
+    #[test]
+    fn test_unread_snapshot_gets_no_unread_sort_hint() {
+        // Snapshot OR predicate is not covered by a WHERE read_at IS NULL index.
+        let filter = EntryFilter {
+            unread_only: true,
+            read_after: Some("2026-01-01 00:00:00".to_string()),
+            ..Default::default()
+        };
+        assert_ne!(published_sort_entry_hint(&filter), " INDEXED BY idx_entry_unread_sort");
+    }
+```
+
+(If `EntryFilter` has no `Default`, construct it explicitly with all fields — copy the field list from `src/models/entry/mod.rs:59-74`.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `source /tmp/rdrs-env.sh && cargo nextest run -p rdrs filters`
+Expected: FAIL — hint returns `""` for unread.
+
+- [ ] **Step 3: Add the unread branch**
+
+In `published_sort_entry_hint` (`src/models/entry/filters.rs:26`), add the branch between `read_only` and `is_no_entry_side_predicate` (order matters — strict unread before the no-predicate fallback):
+
+```rust
+pub(super) fn published_sort_entry_hint(filter: &EntryFilter) -> &'static str {
+    if filter.starred_only {
+        " INDEXED BY idx_entry_starred_sort"
+    } else if filter.read_only {
+        " INDEXED BY idx_entry_read_sort"
+    } else if filter.unread_only && filter.read_after.is_none() {
+        // Strict unread only. The snapshot case (read_after set) widens the
+        // predicate to `(read_at IS NULL OR read_at >= ?)`, which a
+        // `WHERE read_at IS NULL` partial index does not cover — leave it to
+        // its existing plan.
+        " INDEXED BY idx_entry_unread_sort"
+    } else if is_no_entry_side_predicate(filter) {
+        " INDEXED BY idx_entry_sort_ts"
+    } else {
+        ""
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `source /tmp/rdrs-env.sh && cargo nextest run -p rdrs filters entry::`
+Expected: PASS (and the existing `find_neighbors` / list planner tests still pass — `find_neighbors` pins its own indexes explicitly and is unaffected).
+
+- [ ] **Step 5: Benchmark gate (before/after)**
+
+Confirm the win and check for regressions. With the in-memory or a seeded file DB, capture `EXPLAIN QUERY PLAN` for the strict-unread page-0 list (must now show `SCAN ... USING INDEX idx_entry_unread_sort`, not `USE TEMP B-TREE FOR ORDER BY`), and verify the unhinted `count_unread_by_user` plan did not regress. Reference numbers from the design benchmark: **143 ms → 0.03 ms** at 1M entries. (Reuse `/tmp/query_speedup_bench.sh`-style probing if a large dataset is wanted; record the before/after in the commit message per project perf-change rules.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/nixos/Develop/claude/rdrs && cargo fmt
+git add src/models/entry/filters.rs
+git commit -m "perf(entry): ordered unread index hint, unread list 143ms->0.03ms"
+```
+
+---
+
+### Task 11: Full verification + docs
 
 **Files:**
 - Modify: `README.md` (document the per-user retention setting, if README documents user settings — check first; do not add a new doc file)

--- a/docs/superpowers/specs/2026-06-12-per-user-retention-tombstone-design.md
+++ b/docs/superpowers/specs/2026-06-12-per-user-retention-tombstone-design.md
@@ -158,6 +158,28 @@ SQL pass covers all users — no per-user loop.
 Started in `src/main.rs` alongside `start_cleanup_worker`, and added to the
 graceful-shutdown handle list (`src/main.rs:115`).
 
+**Maintenance after the prune (reclaim disk).** Deleting rows does not shrink
+the `.sqlite3` file — freed pages go to the freelist and are reused, but never
+returned to the OS (rdrs sets no `auto_vacuum`; today it only runs
+`wal_checkpoint(TRUNCATE)` at shutdown, `src/db/pool.rs:128`). So after the
+batch loop finishes, the worker runs a maintenance step mirroring the
+**noadd** pattern (`noadd/src/db.rs:559` `run_maintenance`), on the write
+connection, **outside any transaction** (VACUUM cannot run in one):
+
+1. `PRAGMA optimize;` — refresh planner stats (≈0 ms).
+2. **Gated** `VACUUM;` — only when `freelist_count / page_count >= 0.20`
+   (reuse noadd's `VACUUM_FREELIST_RATIO = 0.20`). A normal tick deletes a
+   small fraction and stays under the gate, so VACUUM rarely fires; it triggers
+   after a big drain (first enable / long backlog).
+3. `PRAGMA wal_checkpoint(TRUNCATE);` — truncate the WAL a large prune or the
+   VACUUM can otherwise inflate (also fixes today's "WAL only truncated at
+   shutdown").
+
+Cost (benchmarked below): `optimize` and the checkpoint are ≈0 ms; VACUUM is a
+full-file rewrite holding an exclusive lock for ~`db_size_MB / 650` seconds
+(~0.5 s per 350 MB) and needs ~`db_size` free temp disk. The 20% gate keeps
+this rare; the stall is acceptable for a background worker.
+
 ### D. Opt-in: per-user setting + UI (default off)
 
 Retention is **opt-in, per user**, configured in the existing settings UI.
@@ -225,6 +247,18 @@ Plan drives from `user_settings`, then range-scans `idx_entry_read_at`
 partial index gave no measurable improvement and is not added. Disabled installs
 pay nothing per tick. First full drain (~597k victims ≈ 1194 batches) does not
 degrade: deleted rows leave the index front, so each batch stays ~0.75 ms.
+
+**C. Maintenance step** (DB at ~1 KB content/entry, after a 60% prune →
+~60% freelist, so the 20% gate fires):
+
+| entries | DB before | `optimize` | `VACUUM` | DB after | `wal_checkpoint(TRUNCATE)` |
+| --- | --- | --- | --- | --- | --- |
+| 250k | 347 MB | 0.00s | 0.56s | 138 MB | 0.00s |
+| 1M | 1385 MB | 0.01s | 2.10s | 551 MB | 0.00s |
+
+VACUUM reclaims the freed ~60% and scales linearly at **~650 MB/s** (stall ≈
+`db_size_MB / 650`). `optimize` and the checkpoint are effectively free. The
+20% gate means VACUUM only runs after a large drain, not on routine ticks.
 
 ## Testing plan
 

--- a/docs/superpowers/specs/2026-06-12-per-user-retention-tombstone-design.md
+++ b/docs/superpowers/specs/2026-06-12-per-user-retention-tombstone-design.md
@@ -204,6 +204,46 @@ field to `UserSettingsResponse` (`:74`).
 `entries_per_page` — label e.g. *"Delete read articles older than N days
 (0 = never)"*, min 0. SSR + vanilla JS, no new build tooling.
 
+### E. Unread-list ordered index (found while benchmarking this work)
+
+Benchmarking the retention speedup (below) surfaced a pre-existing, unrelated
+hot-path gap, **folded in here because the benchmark that found it lives in this
+work**: the **unread** list page — often the default home view — runs
+`USE TEMP B-TREE FOR ORDER BY` over *all* of a user's unread entries before
+`LIMIT`, ~143–162 ms on a 1M-entry instance. The read and starred list pages do
+not: `published_sort_entry_hint` (`src/models/entry/filters.rs:26`) already pins
+`idx_entry_read_sort` / `idx_entry_starred_sort` for those filters, but has **no
+unread branch**, so the unread list gets no ordered index.
+
+Fix (symmetric with the existing read/starred handling):
+
+1. Partial index mirroring `idx_entry_read_sort`:
+   ```sql
+   CREATE INDEX IF NOT EXISTS idx_entry_unread_sort
+       ON entry(COALESCE(published_at, created_at)) WHERE read_at IS NULL;
+   ```
+2. Extend `published_sort_entry_hint` to emit ` INDEXED BY idx_entry_unread_sort`
+   for the **strict** unread case only (`unread_only && read_after.is_none()`):
+
+   ```rust
+   } else if filter.unread_only && filter.read_after.is_none() {
+       " INDEXED BY idx_entry_unread_sort"
+   ```
+
+   The `INDEXED BY` hint is **required** — the index alone is not chosen; the
+   planner sticks to `idx_entry_read_at` + temp sort (the same documented bias
+   that forces `INDEXED BY idx_entry_unread_feed` elsewhere). The snapshot case
+   (`read_after.is_some()`) is excluded: its `(read_at IS NULL OR read_at >= ?)`
+   predicate is not covered by a `WHERE read_at IS NULL` partial index, so it
+   keeps its current plan (correctness over speed). The hint is applied only on
+   page-0 (cursorless); at depth the continuation predicate drives the sort.
+
+Effect: page-0 unread list goes from a whole-inbox temp sort to an ordered range
+scan that stops at `LIMIT` — **143 ms → 0.03 ms** at 1M entries (benchmarked).
+A regression check on the unhinted unread queries (e.g. `count_unread_by_user`)
+via `EXPLAIN QUERY PLAN` is part of the task — adding the index must not worsen
+their plans.
+
 ## Future expansion (not built, design-compatible)
 
 - **Unread retention:** add `retention_unread_days` column + form field; the
@@ -259,6 +299,36 @@ degrade: deleted rows leave the index front, so each batch stays ~0.75 ms.
 VACUUM reclaims the freed ~60% and scales linearly at **~650 MB/s** (stall ≈
 `db_size_MB / 650`). `optimize` and the checkpoint are effectively free. The
 20% gate means VACUUM only runs after a large drain, not on routine ticks.
+
+**D. Retention's effect on common home-page queries** (BEFORE: 1M entries, 85%
+old read; AFTER: 30-day retention applied → 174k entries, VACUUMed 1.5 GB →
+256 MB; warm cache, 300 iterations):
+
+| query | BEFORE | AFTER | speedup |
+| --- | --- | --- | --- |
+| keyset list page-0 (all / read) | 0.033 ms | 0.033 ms | **1.0×** |
+| `count_by_user` (all) | 19.3 ms | 3.0 ms | 6.5× |
+| unread list page-0 | 162 ms | 88 ms | 1.8× |
+| `count_unread_by_user` | 139 ms | 68 ms | 2.1× |
+| sidebar unread-by-category | 156 ms | 126 ms | 1.2× |
+
+Honest read: the **dominant query — first-page list load — does not speed up**
+(keyset + sort indexes are already table-size-independent). Speedups split into
+(a) genuine row-count reduction (only full-corpus `count`, 6.5×) and (b) VACUUM
+file compaction improving locality for the unread queries (1.2–2.1×) — the
+unread rows are *never deleted* (count identical before/after), so that gain is
+the maintenance VACUUM, not retention's delete. Net: retention is not a
+page-load speedup; section E is the real query win.
+
+**E. Unread-list page-0** (1M entries, ~100k unread):
+
+| plan | per query |
+| --- | --- |
+| current (`idx_entry_read_at` + `USE TEMP B-TREE`) | ~143 ms |
+| + `idx_entry_unread_sort` **with** `INDEXED BY` | ~0.03 ms |
+
+The index alone is not chosen (planner bias to `idx_entry_read_at`); the
+`INDEXED BY` hint is required. >1000× on the default home view at scale.
 
 ## Testing plan
 

--- a/docs/superpowers/specs/2026-06-12-per-user-retention-tombstone-design.md
+++ b/docs/superpowers/specs/2026-06-12-per-user-retention-tombstone-design.md
@@ -1,0 +1,221 @@
+# Per-User Read-Entry Retention + Tombstones — Design
+
+Date: 2026-06-12
+Branch: `feat/per-user-retention-tombstone`
+
+## Goal
+
+Give rdrs a way to bound unbounded entry growth: a **per-user, opt-in
+retention policy** that deletes old *read* entries, backed by a **tombstone**
+table that stops deleted entries from being re-imported as unread on the next
+feed refresh.
+
+Today rdrs never deletes entries — they accumulate forever, removed only when
+their feed is deleted (`ON DELETE CASCADE`). There is no retention, no manual
+"flush history", and therefore no tombstone. This design adds the first
+deletion source (retention) **and its mandatory tombstone companion** in one
+change.
+
+Modeled on miniflux's tombstone design (`entry_tombstones` table + atomic
+`WHERE NOT EXISTS` insert guard), adapted to rdrs's data model.
+
+## Out of scope (deliberate, expandable later)
+
+- **Unread retention.** miniflux also archives *unread* entries past a longer
+  threshold (`CLEANUP_ARCHIVE_UNREAD_DAYS`, default 180d). Riskier (deletes
+  things never seen). v1 does read-only. The design is forward-compatible: add
+  a sibling `retention_unread_days` column + form field + a second worker pass;
+  the tombstone mechanism is unchanged. See "Future expansion".
+- **Manual flush-history** (user-triggered "remove all read"). A second
+  deletion source that would reuse the same tombstone machinery. Not built now.
+- **Tombstone garbage collection.** Tombstones are kept forever (they are
+  `(feed_id, guid)` + a timestamp — lightweight). No TTL/GC worker.
+
+## Key facts grounding this design
+
+- Entry identity is `UNIQUE(feed_id, guid)` (`src/db/schema.rs:76`); rdrs uses
+  the feed item's GUID directly — **no hashing** (unlike miniflux's SHA256).
+- Entries are feed-scoped; a feed belongs to one user via
+  `entry → feed → category → user`. `entry` has **no `user_id`**;
+  `read_at`/`starred_at` live directly on `entry`.
+- Migrations are in-process via `PRAGMA user_version` (`src/db/schema.rs:182`),
+  currently at **7**; this change introduces **version 8**.
+- Existing periodic-worker pattern: `start_cleanup_worker(db, interval_hours,
+  ttl_hours, cancel_token)` (`src/services/summary_cleanup.rs`), started in
+  `src/main.rs:71`, graceful shutdown via `CancellationToken`.
+- Existing per-user setting pattern: `user_settings` table with a later-added
+  nullable `theme` column + dedicated `update_theme()` fn
+  (`src/models/user_settings.rs:140`); settings form is
+  `templates/user_settings.html`, update handler `update_user_settings`
+  (`src/handlers/user.rs:431`).
+- **Every table in the schema carries `created_at TEXT NOT NULL DEFAULT
+  (datetime('now'))`** — a universal convention the tombstone table follows.
+
+## Design
+
+### A. Tombstone table (foundation)
+
+New migration block `if version < 8` in `src/db/schema.rs`, plus bump
+`LATEST_VERSION` to 8:
+
+```sql
+CREATE TABLE IF NOT EXISTS entry_tombstone (
+    feed_id    INTEGER NOT NULL REFERENCES feed(id) ON DELETE CASCADE,
+    guid       TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (feed_id, guid)
+) WITHOUT ROWID;
+```
+
+- Key `(feed_id, guid)` mirrors `entry`'s `UNIQUE(feed_id, guid)` — reuse GUID
+  directly, no hashing.
+- `ON DELETE CASCADE` on `feed`: deleting a feed drops its tombstones too,
+  consistent with `entry`'s cascade.
+- `WITHOUT ROWID`: lightweight composite-PK table.
+- `created_at` matches the universal schema convention (for a tombstone, row
+  creation == the moment the entry was purged). **No index on it** — there is
+  no GC and no query reads it; an index would be speculative future-proofing.
+  If GC is ever wanted, adding the index is a one-line migration.
+
+### B. Refresh protection (the other half of the foundation)
+
+Modify `entry::upsert_entry_id` (`src/models/entry/mod.rs:484`). Current logic:
+look up existing by `(guid, feed_id)`; if present `UPDATE`, else `INSERT`. Only
+the **INSERT path** changes — guard it atomically against the tombstone:
+
+```sql
+INSERT INTO entry (feed_id, guid, title, link, content, summary, author, published_at)
+SELECT ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8
+WHERE NOT EXISTS (
+    SELECT 1 FROM entry_tombstone WHERE feed_id = ?1 AND guid = ?2
+);
+```
+
+- `WHERE NOT EXISTS` makes the tombstone check atomic with the insert — a
+  retention delete committing between a separate check and the insert cannot
+  resurrect the entry as unread (same guarantee as miniflux).
+- After the statement, inspect `changes()`: `0` rows ⇒ the GUID is tombstoned
+  ⇒ report "skipped".
+- Return type changes from `(i64, bool)` (`id`, `is_new`) to an enum:
+  ```rust
+  pub enum UpsertOutcome {
+      Inserted(i64),
+      Updated(i64),
+      SkippedTombstoned,
+  }
+  ```
+  `feed_sync.rs` (entry loop ~`src/services/feed_sync.rs:299`) maps the three
+  arms to `new_entries` / `updated_entries` / a new `skipped_entries` counter
+  (logged, for observability).
+- The **UPDATE path is untouched**: an entry cannot be simultaneously alive and
+  tombstoned, because deletion removes the entry and inserts the tombstone in
+  one transaction (see C).
+
+### C. Retention worker (first consumer)
+
+New service `src/services/entry_retention.rs`, mirroring `summary_cleanup.rs`:
+
+```rust
+pub fn start_retention_worker(
+    db: DbPool,
+    interval_hours: u64,
+    cancel_token: CancellationToken,
+) -> JoinHandle<()>
+```
+
+Note: the per-user *threshold* lives in `user_settings` (D), so the worker
+takes no `days` argument — it reads each user's value via a join. The worker
+always runs on its interval; it is a cheap no-op when no user has retention
+enabled.
+
+Each tick, in **batches of 500** inside a single write transaction per batch
+(actor pool serializes writes; the transaction gives atomicity so a concurrent
+`feed_sync` cannot resurrect a victim):
+
+1. Select up to 500 victims (Rust-side, to avoid SQLite `LIMIT`-without-`ORDER
+   BY` picking different rows across two statements):
+   ```sql
+   SELECT e.id, e.feed_id, e.guid
+   FROM entry e
+   JOIN feed f           ON f.id = e.feed_id
+   JOIN category c       ON c.id = f.category_id
+   JOIN user_settings us ON us.user_id = c.user_id
+   WHERE us.retention_read_days > 0
+     AND e.read_at    IS NOT NULL
+     AND e.starred_at IS NULL
+     AND e.read_at < datetime('now', '-' || us.retention_read_days || ' days')
+   LIMIT 500;
+   ```
+2. `INSERT INTO entry_tombstone (feed_id, guid) VALUES … ON CONFLICT DO
+   NOTHING` for the batch.
+3. `DELETE FROM entry WHERE id IN (…batch ids…)`.
+4. Loop until a batch returns 0 rows.
+
+`starred_at IS NULL` ⇒ starred entries are **never** deleted. The per-user
+threshold is applied per row via the join (`us.retention_read_days`), so one
+SQL pass covers all users — no per-user loop.
+
+Started in `src/main.rs` alongside `start_cleanup_worker`, and added to the
+graceful-shutdown handle list (`src/main.rs:115`).
+
+### D. Opt-in: per-user setting + UI (default off)
+
+Retention is **opt-in, per user**, configured in the existing settings UI.
+
+**Schema (version 8):**
+```sql
+ALTER TABLE user_settings ADD COLUMN retention_read_days INTEGER NOT NULL DEFAULT 0;
+```
+`0` = disabled = the opt-in default. `> 0` = delete read entries older than N
+days.
+
+**Model (`src/models/user_settings.rs`):** add `retention_read_days` to the
+`UserSettings` struct and `row_to_settings` mapping; add
+`update_retention_read_days()` following the `update_theme()` `INSERT … ON
+CONFLICT` pattern. Validate `>= 0` (reject negatives); `0` is the off sentinel.
+
+**Handler (`src/handlers/user.rs`):** extend the settings update path
+(`update_user_settings`, ~`:431`) to accept `retention_read_days`; add the
+field to `UserSettingsResponse` (`:74`).
+
+**UI (`templates/user_settings.html`):** add a number input next to
+`entries_per_page` — label e.g. *"Delete read articles older than N days
+(0 = never)"*, min 0. SSR + vanilla JS, no new build tooling.
+
+## Future expansion (not built, design-compatible)
+
+- **Unread retention:** add `retention_unread_days` column + form field; the
+  worker runs a second pass with `read_at IS NULL` and the unread threshold.
+  Tombstone path unchanged.
+- **Manual flush-history:** a button that runs the C-style delete-plus-tombstone
+  for *all* of a user's read entries (no age filter), reusing `entry_tombstone`
+  and the same refresh guard.
+- **Tombstone GC:** if tombstones ever need pruning, add an index on
+  `created_at` and a TTL sweep. Deliberately deferred.
+
+## Testing plan
+
+- **Unit (`cargo nextest run`):**
+  - `entry_tombstone` migration creates the table (extend the existing
+    `test_init_db_*` / version tests in `src/db/schema.rs`).
+  - `upsert_entry_id`: returns `SkippedTombstoned` when a `(feed_id, guid)`
+    tombstone exists; `Inserted`/`Updated` otherwise; the UPDATE path ignores
+    tombstones (cannot happen in practice but assert the INSERT-only guard).
+  - `user_settings`: `update_retention_read_days` upserts; default is `0`;
+    negatives rejected.
+  - retention worker logic (mirroring `summary_cleanup.rs` tests): deletes only
+    read + aged + non-starred entries belonging to users with
+    `retention_read_days > 0`; writes matching tombstones; respects each user's
+    own threshold; no-op when all users are at `0`; stops on cancellation.
+  - End-to-end invariant: delete via retention → re-run `feed_sync` with the
+    same GUID still present in the feed → entry does **not** reappear.
+- **BDD (playwright-bdd):** a settings scenario toggling retention days
+  (persists + round-trips in the form). (Worker timing is covered by unit
+  tests, not BDD.)
+
+## Verification
+
+- `cargo build` + `cargo nextest run` green; `cargo fmt` before commit.
+- Manual: set `retention_read_days` in the UI, seed an old read entry, run the
+  worker, confirm deletion + tombstone row + non-resurrection after refresh.
+- (Re-source `/tmp/rdrs-env.sh` for OpenSSL env before cargo/e2e on this box.)

--- a/docs/superpowers/specs/2026-06-12-per-user-retention-tombstone-design.md
+++ b/docs/superpowers/specs/2026-06-12-per-user-retention-tombstone-design.md
@@ -193,6 +193,39 @@ field to `UserSettingsResponse` (`:74`).
 - **Tombstone GC:** if tombstones ever need pruning, add an index on
   `created_at` and a TTL sweep. Deliberately deferred.
 
+## Benchmarks (pre-implementation, SQLite 3.51.2)
+
+Synthetic probes on faithful schema + indexes; the SQLite engine is the same as
+the bundled rusqlite, so query-planner/B-tree behavior is representative.
+
+**B. Refresh guard — `INSERT … WHERE NOT EXISTS (entry_tombstone)`** (50k new
+inserts, ~500B content; marginal cost of the tombstone probe vs a plain INSERT):
+
+| tombstone rows | plain INSERT | INSERT + guard | per-insert overhead |
+| --- | --- | --- | --- |
+| 0 | 0.123s | 0.129s | 0.13 µs |
+| 100k | 0.123s | 0.192s | 1.37 µs |
+| 1M | 0.120s | 0.213s | 1.86 µs |
+
+Worst case ~1.9 µs per *new* entry even against a 1M-row tombstone table;
+existing entries (UPDATE path) pay nothing. A refresh inserting ~100 new
+entries adds <0.2 ms. **Guard kept** — race-proof and negligible.
+
+**C. Retention victim SELECT** (1M entries, ~597k victims, 1 user / 10
+categories / 200 feeds; 2000 iterations of the `LIMIT 500` fetch):
+
+| case | per 500-row batch |
+| --- | --- |
+| disabled (`retention_read_days = 0`) | ~0.075 ms (short-circuits at `SCAN us`) |
+| enabled, current indexes | ~0.75 ms |
+| enabled, + candidate `idx_entry_retention` | ~0.73 ms (no gain) |
+
+Plan drives from `user_settings`, then range-scans `idx_entry_read_at`
+(`read_at > ? AND read_at < ?`). **No new index needed** — the candidate
+partial index gave no measurable improvement and is not added. Disabled installs
+pay nothing per tick. First full drain (~597k victims ≈ 1194 batches) does not
+degrade: deleted rows leave the index front, so each batch stays ~0.75 ms.
+
 ## Testing plan
 
 - **Unit (`cargo nextest run`):**

--- a/e2e/features/preferences.feature
+++ b/e2e/features/preferences.feature
@@ -22,3 +22,7 @@ Feature: Preferences
   Scenario: Changing my password lets me sign in with the new password
     When I change my password to "newpassword123"
     Then I can sign in with "newpassword123"
+
+  Scenario: Setting a read-article retention period persists
+    When I set the retention period to "30" days
+    Then the retention period field shows "30"

--- a/e2e/steps/preferences.steps.js
+++ b/e2e/steps/preferences.steps.js
@@ -40,3 +40,13 @@ Then("I can sign in with {string}", async ({ page, currentUser, serverUrl }, pas
   await page.getByTestId("login-submit").click();
   await page.waitForURL(`${serverUrl}/`);
 });
+
+When("I set the retention period to {string} days", async ({ page, serverUrl }, days) => {
+  await page.getByTestId("retention-read-days").fill(days);
+  await page.locator('form[action="/user-settings/preferences"] button[type=submit]').click();
+  await page.waitForURL(`${serverUrl}/user-settings`);
+});
+
+Then("the retention period field shows {string}", async ({ page }, value) => {
+  await expect(page.getByTestId("retention-read-days")).toHaveValue(value);
+});

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -162,7 +162,6 @@ pub fn init_db(conn: &Connection) -> AppResult<()> {
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             user_id INTEGER NOT NULL UNIQUE REFERENCES user(id) ON DELETE CASCADE,
             entries_per_page INTEGER NOT NULL DEFAULT 30,
-            retention_read_days INTEGER NOT NULL DEFAULT 0,
             save_services TEXT,
             created_at TEXT NOT NULL DEFAULT (datetime('now')),
             updated_at TEXT NOT NULL DEFAULT (datetime('now'))
@@ -262,16 +261,15 @@ pub fn init_db(conn: &Connection) -> AppResult<()> {
     }
 
     if version < 8 {
-        // Add the per-user retention threshold to existing databases. The
-        // entry_tombstone table and idx_entry_unread_sort index are created via
-        // CREATE ... IF NOT EXISTS in the main batch above (picked up on
-        // restart, like the v5/v6/v7 indexes). `let _ =` swallows the
-        // duplicate-column error on fresh DBs where the main batch already added
-        // the column (mirrors the v1/v2 legacy ALTERs).
-        let _ = conn.execute(
+        // The entry_tombstone table and idx_entry_unread_sort index are created
+        // via CREATE ... IF NOT EXISTS in the main batch above (picked up on
+        // restart, like the v5/v6/v7 indexes). retention_read_days is added here
+        // only (mirrors how v4 adds `bucket`): the block runs exactly once per DB
+        // when version < 8, so the column is never already present — no swallow.
+        conn.execute(
             "ALTER TABLE user_settings ADD COLUMN retention_read_days INTEGER NOT NULL DEFAULT 0",
             [],
-        );
+        )?;
     }
 
     const LATEST_VERSION: i64 = 8;
@@ -463,5 +461,47 @@ mod tests {
             .filter_map(Result::ok)
             .collect();
         assert_eq!(indexes, vec!["idx_entry_feed_sort".to_string()]);
+    }
+
+    #[test]
+    fn test_init_db_user_settings_has_retention_read_days_column() {
+        let conn = Connection::open_in_memory().unwrap();
+        init_db(&conn).unwrap();
+
+        // Verify retention_read_days column exists and defaults to 0
+        conn.execute(
+            "INSERT INTO user (username, password_hash) VALUES ('test', 'hash')",
+            [],
+        )
+        .unwrap();
+        conn.execute("INSERT INTO user_settings (user_id) VALUES (1)", [])
+            .unwrap();
+
+        let retention_read_days: i64 = conn
+            .query_row(
+                "SELECT retention_read_days FROM user_settings WHERE user_id = 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(retention_read_days, 0);
+    }
+
+    #[test]
+    fn test_init_db_unread_sort_index_exists() {
+        let conn = Connection::open_in_memory().unwrap();
+        init_db(&conn).unwrap();
+
+        let indexes: Vec<String> = conn
+            .prepare(
+                "SELECT name FROM sqlite_master \
+                 WHERE type='index' AND name='idx_entry_unread_sort'",
+            )
+            .unwrap()
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .filter_map(Result::ok)
+            .collect();
+        assert_eq!(indexes, vec!["idx_entry_unread_sort".to_string()]);
     }
 }

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -108,6 +108,25 @@ pub fn init_db(conn: &Connection) -> AppResult<()> {
         -- order together as a range scan. See migration v7.
         CREATE INDEX IF NOT EXISTS idx_entry_feed_sort
             ON entry(feed_id, COALESCE(published_at, created_at));
+        -- Ordered partial index over unread entries for the unread list page,
+        -- mirroring idx_entry_read_sort. Without it the unread list does a
+        -- whole-inbox temp-B-tree sort (~143ms at 1M entries). Used via an
+        -- INDEXED BY hint in published_sort_entry_hint (a later task).
+        CREATE INDEX IF NOT EXISTS idx_entry_unread_sort
+            ON entry(COALESCE(published_at, created_at))
+            WHERE read_at IS NULL;
+
+        -- Tombstones for entries deleted by retention. Keyed by (feed_id, guid),
+        -- mirroring entry's UNIQUE(feed_id, guid). The refresh insert path checks
+        -- this so a deleted entry the feed still serves is not re-imported as
+        -- unread. created_at follows the schema-wide convention; kept forever
+        -- (lightweight, no GC). Cascades when the feed is deleted.
+        CREATE TABLE IF NOT EXISTS entry_tombstone (
+            feed_id    INTEGER NOT NULL REFERENCES feed(id) ON DELETE CASCADE,
+            guid       TEXT NOT NULL,
+            created_at TEXT NOT NULL DEFAULT (datetime('now')),
+            PRIMARY KEY (feed_id, guid)
+        ) WITHOUT ROWID;
 
         CREATE TABLE IF NOT EXISTS entry_summary (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -143,6 +162,7 @@ pub fn init_db(conn: &Connection) -> AppResult<()> {
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             user_id INTEGER NOT NULL UNIQUE REFERENCES user(id) ON DELETE CASCADE,
             entries_per_page INTEGER NOT NULL DEFAULT 30,
+            retention_read_days INTEGER NOT NULL DEFAULT 0,
             save_services TEXT,
             created_at TEXT NOT NULL DEFAULT (datetime('now')),
             updated_at TEXT NOT NULL DEFAULT (datetime('now'))
@@ -241,7 +261,20 @@ pub fn init_db(conn: &Connection) -> AppResult<()> {
         // per-feed list query can rely on it.
     }
 
-    const LATEST_VERSION: i64 = 7;
+    if version < 8 {
+        // Add the per-user retention threshold to existing databases. The
+        // entry_tombstone table and idx_entry_unread_sort index are created via
+        // CREATE ... IF NOT EXISTS in the main batch above (picked up on
+        // restart, like the v5/v6/v7 indexes). `let _ =` swallows the
+        // duplicate-column error on fresh DBs where the main batch already added
+        // the column (mirrors the v1/v2 legacy ALTERs).
+        let _ = conn.execute(
+            "ALTER TABLE user_settings ADD COLUMN retention_read_days INTEGER NOT NULL DEFAULT 0",
+            [],
+        );
+    }
+
+    const LATEST_VERSION: i64 = 8;
     if version < LATEST_VERSION {
         conn.pragma_update(None, "user_version", LATEST_VERSION)?;
     }
@@ -271,6 +304,7 @@ mod tests {
         assert!(tables.contains(&"passkey".to_string()));
         assert!(tables.contains(&"webauthn_challenge".to_string()));
         assert!(tables.contains(&"entry_summary".to_string()));
+        assert!(tables.contains(&"entry_tombstone".to_string()));
     }
 
     #[test]
@@ -283,7 +317,7 @@ mod tests {
         let version: i64 = conn
             .pragma_query_value(None, "user_version", |row| row.get(0))
             .unwrap();
-        assert_eq!(version, 7);
+        assert_eq!(version, 8);
     }
 
     #[test]
@@ -294,7 +328,7 @@ mod tests {
         let version: i64 = conn
             .pragma_query_value(None, "user_version", |row| row.get(0))
             .unwrap();
-        assert_eq!(version, 7);
+        assert_eq!(version, 8);
     }
 
     #[test]

--- a/src/handlers/pages/mod.rs
+++ b/src/handlers/pages/mod.rs
@@ -657,6 +657,7 @@ pub async fn user_settings_page(
     let (
         theme,
         entries_per_page,
+        retention_read_days,
         linkding_configured,
         linkding_api_url,
         kagi_configured,
@@ -667,6 +668,8 @@ pub async fn user_settings_page(
             let theme = user_settings::get_theme(conn, user_id).unwrap_or(None);
             let entries_per_page = user_settings::get_entries_per_page(conn, user_id)
                 .unwrap_or(user_settings::DEFAULT_ENTRIES_PER_PAGE);
+            let retention_read_days =
+                user_settings::get_retention_read_days(conn, user_id).unwrap_or(0);
             let save_config =
                 user_settings::get_save_services_config(conn, user_id).unwrap_or_default();
 
@@ -681,6 +684,7 @@ pub async fn user_settings_page(
             Ok::<_, AppError>((
                 theme,
                 entries_per_page,
+                retention_read_days,
                 linkding_configured,
                 linkding_api_url,
                 kagi_configured,
@@ -693,6 +697,7 @@ pub async fn user_settings_page(
         .unwrap_or((
             None,
             user_settings::DEFAULT_ENTRIES_PER_PAGE,
+            0,
             false,
             String::new(),
             false,
@@ -735,6 +740,7 @@ pub async fn user_settings_page(
             public_base_url,
             theme,
             entries_per_page,
+            retention_read_days,
             linkding_configured,
             linkding_api_url,
             kagi_configured,
@@ -2008,6 +2014,7 @@ pub struct UserSettingsTemplate {
     pub public_base_url: String,
     pub theme: Option<String>,
     pub entries_per_page: i64,
+    pub retention_read_days: i64,
     pub linkding_configured: bool,
     pub linkding_api_url: String,
     pub kagi_configured: bool,

--- a/src/handlers/user.rs
+++ b/src/handlers/user.rs
@@ -414,6 +414,7 @@ pub async fn change_password_form(
 pub struct UpdatePreferencesForm {
     pub theme: String,
     pub entries_per_page: i64,
+    pub retention_read_days: i64,
 }
 
 pub async fn update_preferences_form(
@@ -429,12 +430,14 @@ pub async fn update_preferences_form(
         _ => None,
     };
     let epp = req.entries_per_page;
+    let retention_read_days = req.retention_read_days;
 
     let result = state
         .db
         .user(move |conn| {
             user_settings::upsert(conn, user_id, epp)?;
             user_settings::update_theme(conn, user_id, theme)?;
+            user_settings::update_retention_read_days(conn, user_id, retention_read_days)?;
             Ok::<_, AppError>(())
         })
         .await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,6 +70,11 @@ async fn main() {
     let cleanup_worker_handle =
         services::start_cleanup_worker(db.clone(), 1, 24, cancel_token.clone());
 
+    // Start read-entry retention worker (every 24h; per-user opt-in via
+    // user_settings.retention_read_days, 0 = disabled). No-op when nobody opted in.
+    let retention_worker_handle =
+        services::start_retention_worker(db.clone(), 24, cancel_token.clone());
+
     let state = AppState {
         db: db.clone(),
         config: Arc::new(config.clone()),
@@ -113,6 +118,7 @@ async fn main() {
             background_handle,
             summary_worker_handle,
             cleanup_worker_handle,
+            retention_worker_handle,
         );
     });
 

--- a/src/models/entry/filters.rs
+++ b/src/models/entry/filters.rs
@@ -127,38 +127,6 @@ pub(super) fn apply_time_conditions(
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_unread_hint_uses_unread_sort_index() {
-        let filter = EntryFilter {
-            unread_only: true,
-            read_after: None,
-            ..Default::default()
-        };
-        assert_eq!(
-            published_sort_entry_hint(&filter),
-            " INDEXED BY idx_entry_unread_sort"
-        );
-    }
-
-    #[test]
-    fn test_unread_snapshot_gets_no_unread_sort_hint() {
-        // Snapshot OR predicate is not covered by a WHERE read_at IS NULL index.
-        let filter = EntryFilter {
-            unread_only: true,
-            read_after: Some("2026-01-01 00:00:00".to_string()),
-            ..Default::default()
-        };
-        assert_ne!(
-            published_sort_entry_hint(&filter),
-            " INDEXED BY idx_entry_unread_sort"
-        );
-    }
-}
-
 /// Apply continuation-based pagination condition.
 ///
 /// Composite cursor uses the V2 bounded-OR form, which the SQLite planner
@@ -209,5 +177,37 @@ pub(super) fn apply_continuation_condition(
             conditions.push(format!("e.id {} ?{}", cmp, id_idx));
             params_vec.push(Box::new(*id));
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_unread_hint_uses_unread_sort_index() {
+        let filter = EntryFilter {
+            unread_only: true,
+            read_after: None,
+            ..Default::default()
+        };
+        assert_eq!(
+            published_sort_entry_hint(&filter),
+            " INDEXED BY idx_entry_unread_sort"
+        );
+    }
+
+    #[test]
+    fn test_unread_snapshot_gets_no_unread_sort_hint() {
+        // Snapshot OR predicate is not covered by a WHERE read_at IS NULL index.
+        let filter = EntryFilter {
+            unread_only: true,
+            read_after: Some("2026-01-01 00:00:00".to_string()),
+            ..Default::default()
+        };
+        assert_ne!(
+            published_sort_entry_hint(&filter),
+            " INDEXED BY idx_entry_unread_sort"
+        );
     }
 }

--- a/src/models/entry/filters.rs
+++ b/src/models/entry/filters.rs
@@ -28,6 +28,12 @@ pub(super) fn published_sort_entry_hint(filter: &EntryFilter) -> &'static str {
         " INDEXED BY idx_entry_starred_sort"
     } else if filter.read_only {
         " INDEXED BY idx_entry_read_sort"
+    } else if filter.unread_only && filter.read_after.is_none() {
+        // Strict unread only. The snapshot case (read_after set) widens the
+        // predicate to `(read_at IS NULL OR read_at >= ?)`, which a
+        // `WHERE read_at IS NULL` partial index does not cover — leave it to
+        // its existing plan.
+        " INDEXED BY idx_entry_unread_sort"
     } else if is_no_entry_side_predicate(filter) {
         " INDEXED BY idx_entry_sort_ts"
     } else {
@@ -118,6 +124,38 @@ pub(super) fn apply_time_conditions(
             param_idx
         ));
         params_vec.push(Box::new(newest_ts));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_unread_hint_uses_unread_sort_index() {
+        let filter = EntryFilter {
+            unread_only: true,
+            read_after: None,
+            ..Default::default()
+        };
+        assert_eq!(
+            published_sort_entry_hint(&filter),
+            " INDEXED BY idx_entry_unread_sort"
+        );
+    }
+
+    #[test]
+    fn test_unread_snapshot_gets_no_unread_sort_hint() {
+        // Snapshot OR predicate is not covered by a WHERE read_at IS NULL index.
+        let filter = EntryFilter {
+            unread_only: true,
+            read_after: Some("2026-01-01 00:00:00".to_string()),
+            ..Default::default()
+        };
+        assert_ne!(
+            published_sort_entry_hint(&filter),
+            " INDEXED BY idx_entry_unread_sort"
+        );
     }
 }
 

--- a/src/models/entry/mod.rs
+++ b/src/models/entry/mod.rs
@@ -568,6 +568,60 @@ pub fn insert_tombstone(conn: &Connection, feed_id: i64, guid: &str) -> AppResul
     Ok(())
 }
 
+/// Delete up to `batch_size` read, aged, non-starred entries belonging to users
+/// who have opted into retention (`user_settings.retention_read_days > 0`),
+/// recording a tombstone for each. Returns the number of entries deleted.
+///
+/// One batch runs in a single transaction so the tombstone+delete pair is
+/// atomic against a concurrent feed refresh. Victims are gathered first (Rust
+/// side) so the delete targets exact ids rather than re-running a `LIMIT`
+/// without `ORDER BY`. Each user's own threshold is applied via the join.
+pub fn prune_read_retention_batch(conn: &Connection, batch_size: usize) -> AppResult<u64> {
+    let tx = conn.unchecked_transaction()?;
+
+    let victims: Vec<(i64, i64, String)> = {
+        let mut stmt = tx.prepare_cached(
+            r#"
+            SELECT e.id, e.feed_id, e.guid
+            FROM entry e
+            JOIN feed f           ON f.id = e.feed_id
+            JOIN category c       ON c.id = f.category_id
+            JOIN user_settings us ON us.user_id = c.user_id
+            WHERE us.retention_read_days > 0
+              AND e.read_at    IS NOT NULL
+              AND e.starred_at IS NULL
+              AND e.read_at < datetime('now', '-' || us.retention_read_days || ' days')
+            LIMIT ?1
+            "#,
+        )?;
+        let rows = stmt
+            .query_map(params![batch_size as i64], |row| {
+                Ok((row.get(0)?, row.get(1)?, row.get(2)?))
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        rows
+    };
+
+    if victims.is_empty() {
+        return Ok(0);
+    }
+
+    {
+        let mut ins = tx.prepare_cached(
+            "INSERT INTO entry_tombstone (feed_id, guid) VALUES (?1, ?2)
+             ON CONFLICT(feed_id, guid) DO NOTHING",
+        )?;
+        let mut del = tx.prepare_cached("DELETE FROM entry WHERE id = ?1")?;
+        for (id, feed_id, guid) in &victims {
+            ins.execute(params![feed_id, guid])?;
+            del.execute(params![id])?;
+        }
+    }
+
+    tx.commit()?;
+    Ok(victims.len() as u64)
+}
+
 /// Upsert an entry and return the resulting [`Entry`] plus whether it was new.
 ///
 /// Thin wrapper over [`upsert_entry_id`] for callers that need the full record
@@ -2804,5 +2858,123 @@ mod tests {
         uniq.sort_unstable();
         uniq.dedup();
         assert_eq!(uniq.len(), 5, "no duplicates across pages: {seen:?}");
+    }
+
+    #[test]
+    fn test_prune_respects_threshold_star_and_optin() {
+        let conn = setup_db();
+        let user_id = create_test_user(&conn, "pruneuser");
+        let cat_id = create_test_category(&conn, user_id, "PruneCat");
+        let feed_id = create_test_feed(&conn, cat_id, "https://example.com/prune.xml");
+
+        // Helper: insert a read entry aged `days_old` (and optionally starred).
+        let mk = |guid: &str, days: i64, starred: bool| {
+            upsert_entry_id(
+                &conn,
+                feed_id,
+                guid,
+                Some(guid),
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .unwrap();
+            conn.execute(
+                "UPDATE entry SET read_at = datetime('now', ?2) WHERE guid = ?1 AND feed_id = ?3",
+                rusqlite::params![guid, format!("-{days} days"), feed_id],
+            )
+            .unwrap();
+            if starred {
+                conn.execute(
+                    "UPDATE entry SET starred_at = datetime('now') WHERE guid = ?1 AND feed_id = ?2",
+                    rusqlite::params![guid, feed_id],
+                ).unwrap();
+            }
+        };
+        mk("old", 40, false); // read, 40d, not starred -> victim once enabled
+        mk("oldstar", 40, true); // starred -> never deleted
+        mk("fresh", 1, false); // too recent -> kept
+        upsert_entry_id(
+            &conn,
+            feed_id,
+            "unread",
+            Some("u"),
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap(); // unread
+
+        // Opt-in disabled (default 0): nothing pruned.
+        assert_eq!(prune_read_retention_batch(&conn, 500).unwrap(), 0);
+
+        // Enable retention at 30 days for the feed's owner.
+        let user_id_check: i64 = conn.query_row(
+            "SELECT c.user_id FROM feed f JOIN category c ON c.id = f.category_id WHERE f.id = ?1",
+            rusqlite::params![feed_id], |r| r.get(0),
+        ).unwrap();
+        crate::models::user_settings::update_retention_read_days(&conn, user_id_check, 30).unwrap();
+
+        // Only "old" is pruned; a tombstone is written for it.
+        assert_eq!(prune_read_retention_batch(&conn, 500).unwrap(), 1);
+        assert!(find_by_guid_and_feed(&conn, "old", feed_id)
+            .unwrap()
+            .is_none());
+        assert!(find_by_guid_and_feed(&conn, "oldstar", feed_id)
+            .unwrap()
+            .is_some());
+        assert!(find_by_guid_and_feed(&conn, "fresh", feed_id)
+            .unwrap()
+            .is_some());
+        assert!(find_by_guid_and_feed(&conn, "unread", feed_id)
+            .unwrap()
+            .is_some());
+
+        // Tombstone present -> a refresh serving "old" again is skipped.
+        let outcome = upsert_entry_id(
+            &conn,
+            feed_id,
+            "old",
+            Some("Old"),
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+        assert!(matches!(outcome, UpsertOutcome::SkippedTombstoned));
+
+        // Idempotent: nothing left to prune.
+        assert_eq!(prune_read_retention_batch(&conn, 500).unwrap(), 0);
+    }
+
+    #[test]
+    fn test_prune_batch_size_limits_rows() {
+        let conn = setup_db();
+        let user_id = create_test_user(&conn, "batchuser");
+        let cat_id = create_test_category(&conn, user_id, "BatchCat");
+        let feed_id = create_test_feed(&conn, cat_id, "https://example.com/batch.xml");
+        let user_id_check: i64 = conn.query_row(
+            "SELECT c.user_id FROM feed f JOIN category c ON c.id = f.category_id WHERE f.id = ?1",
+            rusqlite::params![feed_id], |r| r.get(0),
+        ).unwrap();
+        crate::models::user_settings::update_retention_read_days(&conn, user_id_check, 1).unwrap();
+        for i in 0..5 {
+            let g = format!("g{i}");
+            upsert_entry_id(&conn, feed_id, &g, Some(&g), None, None, None, None, None).unwrap();
+            conn.execute(
+                "UPDATE entry SET read_at = datetime('now', '-10 days') WHERE guid = ?1 AND feed_id = ?2",
+                rusqlite::params![g, feed_id],
+            ).unwrap();
+        }
+        assert_eq!(prune_read_retention_batch(&conn, 2).unwrap(), 2);
+        assert_eq!(prune_read_retention_batch(&conn, 2).unwrap(), 2);
+        assert_eq!(prune_read_retention_batch(&conn, 2).unwrap(), 1);
+        assert_eq!(prune_read_retention_batch(&conn, 2).unwrap(), 0);
     }
 }

--- a/src/models/entry/mod.rs
+++ b/src/models/entry/mod.rs
@@ -472,10 +472,19 @@ pub fn count_unread_by_category(
     Ok(map)
 }
 
-/// Upsert an entry, returning `(rowid, is_new)` without re-reading the full row.
+/// Result of an entry upsert. The insert path is guarded against tombstones,
+/// so a third "skipped" state exists alongside insert/update.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UpsertOutcome {
+    Inserted(i64),
+    Updated(i64),
+    SkippedTombstoned,
+}
+
+/// Upsert an entry, returning [`UpsertOutcome`] without re-reading the full row.
 ///
 /// This is the lean variant used by the feed-sync hot loop, which only needs
-/// the `is_new` flag. It avoids the full-row `find_by_id` re-read that
+/// the outcome flag. It avoids the full-row `find_by_id` re-read that
 /// [`upsert_entry`] performs, looks the existing row up by `id` only, and uses
 /// `prepare_cached` so the three hot statements are compiled once per
 /// connection rather than once per entry. Wrap a sync loop in a single
@@ -491,7 +500,7 @@ pub fn upsert_entry_id(
     summary: Option<&str>,
     author: Option<&str>,
     published_at: Option<DateTime<Utc>>,
-) -> AppResult<(i64, bool)> {
+) -> AppResult<UpsertOutcome> {
     let published_at_str = published_at.map(|dt| dt.format("%Y-%m-%d %H:%M:%S").to_string());
 
     // Look up only the id of any existing row (not the full record).
@@ -515,27 +524,48 @@ pub fn upsert_entry_id(
         )?
         .execute(params![title, link, content, summary, author, id])?;
 
-        return Ok((id, false));
+        return Ok(UpsertOutcome::Updated(id));
     }
 
-    conn.prepare_cached(
-        r#"
-        INSERT INTO entry (feed_id, guid, title, link, content, summary, author, published_at)
-        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
-        "#,
-    )?
-    .execute(params![
-        feed_id,
-        guid,
-        title,
-        link,
-        content,
-        summary,
-        author,
-        published_at_str
-    ])?;
+    // Insert, but never resurrect a tombstoned guid. The WHERE NOT EXISTS makes
+    // the tombstone check atomic with the insert, so a retention delete that
+    // commits between a separate check and this statement cannot bring the
+    // entry back as unread.
+    let inserted = conn
+        .prepare_cached(
+            r#"
+            INSERT INTO entry (feed_id, guid, title, link, content, summary, author, published_at)
+            SELECT ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8
+            WHERE NOT EXISTS (
+                SELECT 1 FROM entry_tombstone WHERE feed_id = ?1 AND guid = ?2
+            )
+            "#,
+        )?
+        .execute(params![
+            feed_id,
+            guid,
+            title,
+            link,
+            content,
+            summary,
+            author,
+            published_at_str
+        ])?;
 
-    Ok((conn.last_insert_rowid(), true))
+    if inserted == 0 {
+        return Ok(UpsertOutcome::SkippedTombstoned);
+    }
+    Ok(UpsertOutcome::Inserted(conn.last_insert_rowid()))
+}
+
+/// Record a tombstone for `(feed_id, guid)`. Idempotent.
+pub fn insert_tombstone(conn: &Connection, feed_id: i64, guid: &str) -> AppResult<()> {
+    conn.execute(
+        "INSERT INTO entry_tombstone (feed_id, guid) VALUES (?1, ?2)
+         ON CONFLICT(feed_id, guid) DO NOTHING",
+        params![feed_id, guid],
+    )?;
+    Ok(())
 }
 
 /// Upsert an entry and return the resulting [`Entry`] plus whether it was new.
@@ -555,7 +585,7 @@ pub fn upsert_entry(
     author: Option<&str>,
     published_at: Option<DateTime<Utc>>,
 ) -> AppResult<(Entry, bool)> {
-    let (id, is_new) = upsert_entry_id(
+    let (id, is_new) = match upsert_entry_id(
         conn,
         feed_id,
         guid,
@@ -565,7 +595,15 @@ pub fn upsert_entry(
         summary,
         author,
         published_at,
-    )?;
+    )? {
+        UpsertOutcome::Inserted(id) => (id, true),
+        UpsertOutcome::Updated(id) => (id, false),
+        UpsertOutcome::SkippedTombstoned => {
+            return Err(AppError::Internal(
+                "upsert_entry called for a tombstoned guid".to_string(),
+            ))
+        }
+    };
     let entry = find_by_id(conn, id)?.ok_or(AppError::EntryNotFound)?;
     Ok((entry, is_new))
 }
@@ -1755,11 +1793,11 @@ mod tests {
         let feed_id = create_test_feed(&conn, category_id, "https://example.com/feed.xml");
 
         // First upsert: new row
-        let (id1, is_new) = upsert_entry_id(
+        let first = upsert_entry_id(
             &conn,
             feed_id,
             "guid-1",
-            Some("T1"),
+            Some("Title"),
             None,
             None,
             None,
@@ -1767,16 +1805,19 @@ mod tests {
             None,
         )
         .unwrap();
-        assert!(is_new);
+        let id1 = match first {
+            UpsertOutcome::Inserted(id) => id,
+            o => panic!("expected Inserted, got {o:?}"),
+        };
         let row = find_by_id(&conn, id1).unwrap().unwrap();
-        assert_eq!(row.title.as_deref(), Some("T1"));
+        assert_eq!(row.title.as_deref(), Some("Title"));
 
-        // Second upsert with same guid+feed: update, same id, is_new=false
-        let (id2, is_new) = upsert_entry_id(
+        // Second upsert with same guid+feed: update, same id
+        let second = upsert_entry_id(
             &conn,
             feed_id,
             "guid-1",
-            Some("T2"),
+            Some("Title 2"),
             None,
             None,
             None,
@@ -1784,10 +1825,74 @@ mod tests {
             None,
         )
         .unwrap();
-        assert!(!is_new);
-        assert_eq!(id1, id2);
-        let row = find_by_id(&conn, id2).unwrap().unwrap();
-        assert_eq!(row.title.as_deref(), Some("T2"));
+        assert!(matches!(second, UpsertOutcome::Updated(id) if id == id1));
+        let row = find_by_id(&conn, id1).unwrap().unwrap();
+        assert_eq!(row.title.as_deref(), Some("Title 2"));
+    }
+
+    #[test]
+    fn test_upsert_skips_tombstoned_guid() {
+        let conn = setup_db();
+        let user_id = create_test_user(&conn, "testuser");
+        let category_id = create_test_category(&conn, user_id, "Tech");
+        let feed_id = create_test_feed(&conn, category_id, "https://example.com/feed.xml");
+
+        insert_tombstone(&conn, feed_id, "ghost").unwrap();
+        let outcome = upsert_entry_id(
+            &conn,
+            feed_id,
+            "ghost",
+            Some("Ghost"),
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+        assert!(matches!(outcome, UpsertOutcome::SkippedTombstoned));
+        assert!(find_by_guid_and_feed(&conn, "ghost", feed_id)
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn test_upsert_inserts_then_updates() {
+        let conn = setup_db();
+        let user_id = create_test_user(&conn, "testuser");
+        let category_id = create_test_category(&conn, user_id, "Tech");
+        let feed_id = create_test_feed(&conn, category_id, "https://example.com/feed.xml");
+
+        let first = upsert_entry_id(
+            &conn,
+            feed_id,
+            "g1",
+            Some("First"),
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+        let id = match first {
+            UpsertOutcome::Inserted(id) => id,
+            other => panic!("expected Inserted, got {other:?}"),
+        };
+
+        let second = upsert_entry_id(
+            &conn,
+            feed_id,
+            "g1",
+            Some("Updated"),
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap();
+        assert!(matches!(second, UpsertOutcome::Updated(uid) if uid == id));
     }
 
     #[test]

--- a/src/models/user_settings.rs
+++ b/src/models/user_settings.rs
@@ -14,6 +14,7 @@ pub struct UserSettings {
     pub id: i64,
     pub user_id: i64,
     pub entries_per_page: i64,
+    pub retention_read_days: i64,
     pub save_services: Option<String>,
     pub theme: Option<String>, // "dark", "light", or NULL (system)
     pub created_at: DateTime<Utc>,
@@ -41,15 +42,16 @@ fn parse_datetime(s: &str) -> DateTime<Utc> {
 }
 
 fn row_to_user_settings(row: &rusqlite::Row) -> rusqlite::Result<UserSettings> {
-    let created_at: String = row.get(5)?;
-    let updated_at: String = row.get(6)?;
+    let created_at: String = row.get(6)?;
+    let updated_at: String = row.get(7)?;
 
     Ok(UserSettings {
         id: row.get(0)?,
         user_id: row.get(1)?,
         entries_per_page: row.get(2)?,
-        save_services: row.get(3)?,
-        theme: row.get(4)?,
+        retention_read_days: row.get(3)?,
+        save_services: row.get(4)?,
+        theme: row.get(5)?,
         created_at: parse_datetime(&created_at),
         updated_at: parse_datetime(&updated_at),
     })
@@ -57,7 +59,7 @@ fn row_to_user_settings(row: &rusqlite::Row) -> rusqlite::Result<UserSettings> {
 
 pub fn find_by_user_id(conn: &Connection, user_id: i64) -> AppResult<Option<UserSettings>> {
     conn.query_row(
-        "SELECT id, user_id, entries_per_page, save_services, theme, created_at, updated_at FROM user_settings WHERE user_id = ?1",
+        "SELECT id, user_id, entries_per_page, retention_read_days, save_services, theme, created_at, updated_at FROM user_settings WHERE user_id = ?1",
         params![user_id],
         row_to_user_settings,
     )
@@ -151,6 +153,35 @@ pub fn update_theme(conn: &Connection, user_id: i64, theme: Option<String>) -> A
         params![theme, user_id],
     )?;
 
+    Ok(())
+}
+
+/// Get the per-user read-entry retention threshold in days (0 = disabled).
+pub fn get_retention_read_days(conn: &Connection, user_id: i64) -> AppResult<i64> {
+    match find_by_user_id(conn, user_id)? {
+        Some(settings) => Ok(settings.retention_read_days),
+        None => Ok(0),
+    }
+}
+
+/// Set the per-user read-entry retention threshold in days. `0` disables
+/// retention for the user; negative values are rejected.
+pub fn update_retention_read_days(conn: &Connection, user_id: i64, days: i64) -> AppResult<()> {
+    if days < 0 {
+        return Err(AppError::Validation(
+            "retention_read_days must be >= 0".to_string(),
+        ));
+    }
+    // Ensure a row exists, then update (mirrors update_theme).
+    conn.execute(
+        "INSERT INTO user_settings (user_id, entries_per_page) VALUES (?1, ?2)
+         ON CONFLICT(user_id) DO NOTHING",
+        params![user_id, DEFAULT_ENTRIES_PER_PAGE],
+    )?;
+    conn.execute(
+        "UPDATE user_settings SET retention_read_days = ?1, updated_at = datetime('now') WHERE user_id = ?2",
+        params![days, user_id],
+    )?;
     Ok(())
 }
 
@@ -267,5 +298,34 @@ mod tests {
         let settings = find_by_user_id(&conn, user.id).unwrap().unwrap();
         assert_eq!(settings.entries_per_page, 50);
         assert_eq!(settings.theme, Some("dark".to_string()));
+    }
+
+    #[test]
+    fn test_retention_read_days_default_zero() {
+        let conn = setup_db();
+        let user = user::create_user(&conn, "ret", "hash", Role::User).unwrap();
+        assert_eq!(get_retention_read_days(&conn, user.id).unwrap(), 0);
+    }
+
+    #[test]
+    fn test_update_retention_read_days() {
+        let conn = setup_db();
+        let user = user::create_user(&conn, "ret", "hash", Role::User).unwrap();
+
+        update_retention_read_days(&conn, user.id, 30).unwrap();
+        assert_eq!(get_retention_read_days(&conn, user.id).unwrap(), 30);
+
+        // Preserves other settings.
+        upsert(&conn, user.id, 50).unwrap();
+        update_retention_read_days(&conn, user.id, 14).unwrap();
+        let s = find_by_user_id(&conn, user.id).unwrap().unwrap();
+        assert_eq!(s.retention_read_days, 14);
+        assert_eq!(s.entries_per_page, 50);
+
+        // Negatives are rejected.
+        assert!(matches!(
+            update_retention_read_days(&conn, user.id, -1),
+            Err(AppError::Validation(_))
+        ));
     }
 }

--- a/src/services/entry_retention.rs
+++ b/src/services/entry_retention.rs
@@ -1,0 +1,171 @@
+use std::time::Duration;
+
+use rusqlite::Connection;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+use crate::db::DbPool;
+use crate::error::AppResult;
+use crate::models::entry;
+
+/// Entries deleted per transaction during a drain.
+const BATCH_SIZE: usize = 500;
+/// Run a full VACUUM only when freed pages reach this fraction of the file. A
+/// full VACUUM rewrites the whole database under a write lock (~db_size/650
+/// seconds), so it is not worth doing for the handful of pages a routine prune
+/// frees — only after a large drain.
+const VACUUM_FREELIST_RATIO: f64 = 0.20;
+
+/// Start the retention worker. Every `interval_hours` it prunes read+aged
+/// +non-starred entries for users who opted in (`user_settings.retention_read_days
+/// > 0`), then runs maintenance. A no-op when nobody opted in.
+pub fn start_retention_worker(
+    db: DbPool,
+    interval_hours: u64,
+    cancel_token: CancellationToken,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        tracing::info!("Retention worker started: interval={}h", interval_hours);
+        let mut interval = tokio::time::interval(Duration::from_secs(interval_hours * 3600));
+
+        loop {
+            tokio::select! {
+                _ = cancel_token.cancelled() => {
+                    tracing::info!("Retention worker stopping...");
+                    break;
+                }
+                _ = interval.tick() => {
+                    let mut total = 0u64;
+                    loop {
+                        if cancel_token.is_cancelled() {
+                            break;
+                        }
+                        let deleted = match db
+                            .background(move |conn| entry::prune_read_retention_batch(conn, BATCH_SIZE))
+                            .await
+                        {
+                            Ok(Ok(n)) => n,
+                            Ok(Err(e)) => { tracing::error!("Retention prune failed: {}", e); break; }
+                            Err(e) => { tracing::error!("Retention DB access failed: {}", e); break; }
+                        };
+                        total += deleted;
+                        if deleted < BATCH_SIZE as u64 {
+                            break;
+                        }
+                    }
+
+                    if total > 0 {
+                        tracing::info!("Retention pruned {} read entries", total);
+                        match db.background(run_maintenance).await {
+                            Ok(Ok(true)) => tracing::info!("Retention maintenance: VACUUM ran"),
+                            Ok(Ok(false)) => {}
+                            Ok(Err(e)) => tracing::error!("Retention maintenance failed: {}", e),
+                            Err(e) => tracing::error!("Retention maintenance DB access failed: {}", e),
+                        }
+                    }
+                }
+            }
+        }
+
+        tracing::info!("Retention worker stopped");
+    })
+}
+
+/// Post-prune maintenance: refresh planner stats, gated full VACUUM, truncating
+/// WAL checkpoint. Returns whether a VACUUM ran. Must run outside a transaction.
+pub fn run_maintenance(conn: &Connection) -> AppResult<bool> {
+    conn.execute_batch("PRAGMA optimize;")?;
+
+    let page_count: i64 = conn.pragma_query_value(None, "page_count", |r| r.get(0))?;
+    let freelist: i64 = conn.pragma_query_value(None, "freelist_count", |r| r.get(0))?;
+    let vacuumed = page_count > 0 && (freelist as f64 / page_count as f64) >= VACUUM_FREELIST_RATIO;
+    if vacuumed {
+        conn.execute_batch("VACUUM;")?;
+    }
+
+    conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);")?;
+    Ok(vacuumed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::init_db;
+    use crate::models::user::Role;
+    use crate::models::{category, feed, user, user_settings};
+    use rusqlite::Connection;
+
+    fn setup_db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        init_db(&conn).unwrap();
+        conn
+    }
+
+    fn setup_pool() -> DbPool {
+        let conn = setup_db();
+        let read_conn = Connection::open_in_memory().unwrap();
+        let (pool, _h) = DbPool::new(conn, read_conn);
+        pool
+    }
+
+    #[test]
+    fn test_run_maintenance_no_vacuum_below_ratio() {
+        let conn = setup_db();
+        // Fresh DB: ~0 freelist -> no VACUUM, but must not error.
+        assert!(!run_maintenance(&conn).unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_worker_stops_on_cancellation() {
+        let db = setup_pool();
+        let token = CancellationToken::new();
+        let handle = start_retention_worker(db, 1000, token.clone());
+        token.cancel();
+        let res = tokio::time::timeout(Duration::from_secs(5), handle).await;
+        assert!(
+            res.is_ok(),
+            "retention worker should stop after cancellation"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_drain_deletes_opted_in_aged_read_entries() {
+        let db = setup_pool();
+        db.user(|conn| {
+            let uid = user::create_user(conn, "u", "h", Role::User).unwrap().id;
+            let cid = category::create_category(conn, uid, "C").unwrap().id;
+            let fid = feed::create_feed(
+                conn,
+                &feed::CreateFeedParams {
+                    category_id: cid,
+                    url: "https://e.com/f.xml",
+                    title: Some("F"),
+                    description: None,
+                    site_url: None,
+                    custom_user_agent: None,
+                    http2_disabled: None,
+                    custom_referrer: None,
+                },
+            )
+            .unwrap()
+            .id;
+            entry::upsert_entry_id(conn, fid, "old", Some("o"), None, None, None, None, None)
+                .unwrap();
+            conn.execute(
+                "UPDATE entry SET read_at = datetime('now','-40 days') WHERE guid='old' AND feed_id=?1",
+                rusqlite::params![fid],
+            )
+            .unwrap();
+            user_settings::update_retention_read_days(conn, uid, 30).unwrap();
+        })
+        .await
+        .unwrap();
+
+        // Simulate one worker tick's drain.
+        let deleted: u64 = db
+            .background(|conn| entry::prune_read_retention_batch(conn, BATCH_SIZE).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(deleted, 1);
+    }
+}

--- a/src/services/feed_sync.rs
+++ b/src/services/feed_sync.rs
@@ -283,10 +283,11 @@ pub async fn refresh_feed(
     // Last-Modified; without this the feed's "last updated" would be misjudged.
     let http_last_modified = new_last_modified.as_deref().and_then(parse_timestamp);
 
-    let (new_entries, updated_entries) = db
+    let (new_entries, updated_entries, skipped_entries) = db
         .background(move |conn| {
             let mut new_entries = 0i64;
             let mut updated_entries = 0i64;
+            let mut skipped_entries = 0i64;
             let mut latest_entry_date: Option<chrono::DateTime<Utc>> = None;
 
             // Wrap the whole feed's upserts plus the fetch-result update in one
@@ -328,7 +329,7 @@ pub async fn refresh_feed(
                     });
                 }
 
-                let (_, is_new) = entry::upsert_entry_id(
+                match entry::upsert_entry_id(
                     &tx,
                     feed_id,
                     &guid,
@@ -338,12 +339,10 @@ pub async fn refresh_feed(
                     summary.as_deref(),
                     author.as_deref(),
                     published_at,
-                )?;
-
-                if is_new {
-                    new_entries += 1;
-                } else {
-                    updated_entries += 1;
+                )? {
+                    entry::UpsertOutcome::Inserted(_) => new_entries += 1,
+                    entry::UpsertOutcome::Updated(_) => updated_entries += 1,
+                    entry::UpsertOutcome::SkippedTombstoned => skipped_entries += 1,
                 }
             }
 
@@ -364,13 +363,13 @@ pub async fn refresh_feed(
 
             tx.commit()?;
 
-            Ok::<_, AppError>((new_entries, updated_entries))
+            Ok::<_, AppError>((new_entries, updated_entries, skipped_entries))
         })
         .await??;
 
     info!(
-        "Feed {} refreshed: {} new, {} updated",
-        feed_id, new_entries, updated_entries
+        "Feed {} refreshed: {} new, {} updated, {} skipped (tombstoned)",
+        feed_id, new_entries, updated_entries, skipped_entries
     );
 
     Ok(SyncResult {

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,4 +1,5 @@
 pub mod background;
+pub mod entry_retention;
 pub mod feed_discovery;
 pub mod feed_sync;
 pub mod html_entities;
@@ -17,6 +18,7 @@ pub mod summary_cleanup;
 pub mod summary_worker;
 
 pub use background::start_background_sync;
+pub use entry_retention::start_retention_worker;
 pub use feed_discovery::{discover_feed, DiscoveredFeed};
 pub use feed_sync::{refresh_feed, SyncResult};
 pub use html_entities::decode_html_entities;

--- a/templates/user_settings.html
+++ b/templates/user_settings.html
@@ -74,6 +74,11 @@
                         <input type="number" id="entries-per-page" name="entries_per_page" value="{{ entries_per_page }}" min="10" max="100" required>
                         <span class="muted" style="font-size:var(--font-xs);">(10-100)</span>
                     </div>
+                    <div class="form-group">
+                        <label for="retention-read-days">Delete read articles older than (days)</label>
+                        <input type="number" id="retention-read-days" name="retention_read_days" value="{{ retention_read_days }}" min="0" data-testid="retention-read-days" required>
+                        <span class="muted" style="font-size:var(--font-xs);">(0 = never delete)</span>
+                    </div>
                     <button type="submit">Save Preferences</button>
                 </form>
 

--- a/tests/handlers_test.rs
+++ b/tests/handlers_test.rs
@@ -2724,6 +2724,7 @@ async fn test_update_preferences_form() {
         .form(&json!({
             "theme": "dark",
             "entries_per_page": 50,
+            "retention_read_days": 0,
         }))
         .await;
 
@@ -2743,6 +2744,7 @@ async fn test_update_preferences_form_validation() {
         .form(&json!({
             "theme": "system",
             "entries_per_page": 5,
+            "retention_read_days": 0,
         }))
         .await;
 


### PR DESCRIPTION
## Summary

- **Per-user, opt-in retention.** A background worker (`entry_retention`) deletes read, non-starred entries older than each user's configured threshold (`user_settings.retention_read_days`; `0` = disabled, the default). Configured from the existing user-settings preferences form.
- **Tombstones.** A new `entry_tombstone(feed_id, guid)` table records deletions; the feed-sync insert path is guarded with `INSERT … WHERE NOT EXISTS (entry_tombstone)` so a feed that still serves a deleted item does not re-import it as unread. Schema migration → v8.
- **Gated VACUUM maintenance.** After a drain the worker runs `PRAGMA optimize`, a `VACUUM` gated at ≥20% freelist, and `wal_checkpoint(TRUNCATE)`, so on-disk space is actually reclaimed after a large prune (deletes alone never shrink the file). Modeled on the same pattern used elsewhere.
- **Folded-in query optimization** (found while benchmarking this work): a partial `idx_entry_unread_sort` index + an `INDEXED BY` hint in `published_sort_entry_hint` takes the unread list page from a whole-inbox `USE TEMP B-TREE FOR ORDER BY` to an ordered range scan — **~143 ms → ~0.03 ms at 1M entries**. Gated to the strict-unread case (`read_after.is_none()`) for correctness.

Design + benchmarks: `docs/superpowers/specs/2026-06-12-per-user-retention-tombstone-design.md`.

## Architecture notes

- Deletion and re-import can't race: both the prune batch (tombstone + delete in one transaction) and feed-sync inserts route through the single serialized write connection; the `WHERE NOT EXISTS` guard is belt-and-suspenders on top.
- The worker drains in batches of 500, checks cancellation between batches, and is awaited on graceful shutdown. VACUUM runs outside any transaction.
- Retention deletes only **read + aged + non-starred** entries; starred entries are never deleted.

## Test Plan

- [x] `cargo nextest run -p rdrs` — 801/801 pass
- [x] `cargo clippy -p rdrs --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] e2e: `npm test -- preferences` — retention field round-trips through the SSR form
- [ ] Manual smoke (reviewer):
  1. Set "Delete read articles older than (days)" to `1` in `/user-settings`.
  2. Pick a read, non-starred entry; age it: `UPDATE entry SET read_at = datetime('now','-2 days') WHERE id = <id>;` (note its `guid`/`feed_id`).
  3. Restart the app — the retention worker runs a pass on startup (tokio interval's first tick is immediate), then every 24h.
  4. Verify the entry is gone and a row exists in `entry_tombstone` for `(feed_id, guid)`; logs show `Retention pruned N read entries`.
  5. Refresh that feed so it re-serves the guid → the entry does **not** reappear; logs show `… N skipped (tombstoned)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)