### PR TITLE
refactor(retention): DRY tombstone INSERT and cap retention_read_days

### DIFF
--- a/src/models/entry/mod.rs
+++ b/src/models/entry/mod.rs
@@ -558,13 +558,15 @@ pub fn upsert_entry_id(
     Ok(UpsertOutcome::Inserted(conn.last_insert_rowid()))
 }
 
+/// Idempotent `(feed_id, guid)` tombstone insert. Shared by the single-shot
+/// [`insert_tombstone`] helper and the batched `prune_read_retention_batch`
+/// loop so the statement text lives in exactly one place.
+const INSERT_TOMBSTONE_SQL: &str = "INSERT INTO entry_tombstone (feed_id, guid) VALUES (?1, ?2)
+     ON CONFLICT(feed_id, guid) DO NOTHING";
+
 /// Record a tombstone for `(feed_id, guid)`. Idempotent.
 pub fn insert_tombstone(conn: &Connection, feed_id: i64, guid: &str) -> AppResult<()> {
-    conn.execute(
-        "INSERT INTO entry_tombstone (feed_id, guid) VALUES (?1, ?2)
-         ON CONFLICT(feed_id, guid) DO NOTHING",
-        params![feed_id, guid],
-    )?;
+    conn.execute(INSERT_TOMBSTONE_SQL, params![feed_id, guid])?;
     Ok(())
 }
 
@@ -607,10 +609,7 @@ pub fn prune_read_retention_batch(conn: &Connection, batch_size: usize) -> AppRe
     }
 
     {
-        let mut ins = tx.prepare_cached(
-            "INSERT INTO entry_tombstone (feed_id, guid) VALUES (?1, ?2)
-             ON CONFLICT(feed_id, guid) DO NOTHING",
-        )?;
+        let mut ins = tx.prepare_cached(INSERT_TOMBSTONE_SQL)?;
         let mut del = tx.prepare_cached("DELETE FROM entry WHERE id = ?1")?;
         for (id, feed_id, guid) in &victims {
             ins.execute(params![feed_id, guid])?;

--- a/src/models/user_settings.rs
+++ b/src/models/user_settings.rs
@@ -9,6 +9,11 @@ pub const DEFAULT_ENTRIES_PER_PAGE: i64 = 30;
 pub const MIN_ENTRIES_PER_PAGE: i64 = 10;
 pub const MAX_ENTRIES_PER_PAGE: i64 = 100;
 
+/// Upper bound for the per-user read-entry retention threshold, in days
+/// (~10 years). Guards against absurd inputs; values this large already mean
+/// "effectively never delete", which `0` expresses directly.
+pub const MAX_RETENTION_READ_DAYS: i64 = 3650;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UserSettings {
     pub id: i64,
@@ -165,12 +170,14 @@ pub fn get_retention_read_days(conn: &Connection, user_id: i64) -> AppResult<i64
 }
 
 /// Set the per-user read-entry retention threshold in days. `0` disables
-/// retention for the user; negative values are rejected.
+/// retention for the user; values outside `0..=MAX_RETENTION_READ_DAYS` are
+/// rejected.
 pub fn update_retention_read_days(conn: &Connection, user_id: i64, days: i64) -> AppResult<()> {
-    if days < 0 {
-        return Err(AppError::Validation(
-            "retention_read_days must be >= 0".to_string(),
-        ));
+    if !(0..=MAX_RETENTION_READ_DAYS).contains(&days) {
+        return Err(AppError::Validation(format!(
+            "retention_read_days must be between 0 and {}",
+            MAX_RETENTION_READ_DAYS
+        )));
     }
     // Ensure a row exists, then update (mirrors update_theme).
     conn.execute(
@@ -327,5 +334,18 @@ mod tests {
             update_retention_read_days(&conn, user.id, -1),
             Err(AppError::Validation(_))
         ));
+
+        // Values above the upper bound are rejected.
+        assert!(matches!(
+            update_retention_read_days(&conn, user.id, MAX_RETENTION_READ_DAYS + 1),
+            Err(AppError::Validation(_))
+        ));
+
+        // The boundary itself is accepted.
+        update_retention_read_days(&conn, user.id, MAX_RETENTION_READ_DAYS).unwrap();
+        assert_eq!(
+            get_retention_read_days(&conn, user.id).unwrap(),
+            MAX_RETENTION_READ_DAYS
+        );
     }
 }

--- a/templates/user_settings.html
+++ b/templates/user_settings.html
@@ -76,8 +76,8 @@
                     </div>
                     <div class="form-group">
                         <label for="retention-read-days">Delete read articles older than (days)</label>
-                        <input type="number" id="retention-read-days" name="retention_read_days" value="{{ retention_read_days }}" min="0" data-testid="retention-read-days" required>
-                        <span class="muted" style="font-size:var(--font-xs);">(0 = never delete)</span>
+                        <input type="number" id="retention-read-days" name="retention_read_days" value="{{ retention_read_days }}" min="0" max="3650" data-testid="retention-read-days" required>
+                        <span class="muted" style="font-size:var(--font-xs);">(0 = never delete, max 3650)</span>
                     </div>
                     <button type="submit">Save Preferences</button>
                 </form>


### PR DESCRIPTION
## Summary

Two non-blocking follow-ups from the per-user retention review (#292):

- **DRY tombstone INSERT** — `insert_tombstone` (single-shot) and `prune_read_retention_batch` (batch loop) each spelled out the same `INSERT ... ON CONFLICT DO NOTHING`. Hoisted into one `INSERT_TOMBSTONE_SQL` const. The batch loop keeps `prepare_cached`, so there is no behavioural or performance change — purely removes the duplicated literal. (Not folded into `insert_tombstone` because that would swap the hot loop from `prepare_cached` to an uncached `conn.execute`.)
- **Cap `retention_read_days`** — the input only had `min=0` and the model only rejected negatives, so an astronomically large value passed both checks. Harmless (the worker just never finds rows that old) but sloppy. Added `MAX_RETENTION_READ_DAYS` (3650, ~10 years), enforced the `0..=MAX` range in `update_retention_read_days`, and added `max=3650` to the HTML input.

## Test Plan

- [x] `cargo nextest run user_settings entry::` — 53 passed
- [x] `cargo clippy --all-targets` — clean
- [x] New unit tests: value above the upper bound is rejected; boundary value is accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)