### PR TITLE
test: raise coverage to >90% with wiremock service-layer and handler tests

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,15 @@
+# Coverage configuration. The binary entrypoint only executes in a live
+# process (socket bind, worker spawn) and is not unit-testable; exclude it
+# from the project coverage denominator.
+ignore:
+  - "src/main.rs"
+
+coverage:
+  status:
+    project:
+      default:
+        target: 90%
+        threshold: 1%
+    patch:
+      default:
+        target: 80%

--- a/docs/superpowers/plans/2026-06-12-coverage-to-90.md
+++ b/docs/superpowers/plans/2026-06-12-coverage-to-90.md
@@ -1,0 +1,757 @@
+# Test Coverage to >90% Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Raise Codecov *project* (line) coverage from ~86% to >90% by testing the untested HTTP-service layer with `wiremock`, filling pure-DB handler gaps with the existing `axum_test` harness, and excluding the binary entrypoint from the coverage denominator.
+
+**Architecture:** The coverage gap is concentrated in network-facing services whose code is never exercised by tests. The shared `reqwest` client is a global static and is *not* injectable, but every target except Kagi reaches its origin via a URL that a test controls (a function parameter, a DB `feed.url`, or a config `api_url`), so pointing that URL at a `wiremock::MockServer` exercises the real code with no production change. Kagi hardcodes its host and needs one small extract-a-parameter refactor. Handler gaps are covered with the established `axum_test::TestServer` + shared-memory-SQLite harness. The binary entrypoint `src/main.rs` (0% — only runs in a real process) is excluded via `codecov.yml`.
+
+**Tech Stack:** Rust, `cargo nextest`, `cargo llvm-cov`, `wiremock = "0.6"` (already a dev-dependency), `axum_test = "20"`, `rusqlite` in-memory SQLite, Codecov.
+
+---
+
+## Coverage Budget (why these tasks clear 90%)
+
+Baseline (measured 2026-06-12): **16,745 lines, 2,343 uncovered, 86.01%.** To reach 90% the uncovered count must drop to **≤1,674** — i.e. cover ~669 more lines (or shrink the denominator).
+
+| Task | File | Uncovered now | Realistic cover | Mechanism |
+|---|---|---|---|---|
+| 1 | `services/feed_discovery.rs` | 90 | ~80 | wiremock, URL param, no code change |
+| 2 | `services/icon_fetcher.rs` | 114 | ~95 | wiremock, URL param, no code change |
+| 3 | `services/save/linkding.rs` (+ `save/mod.rs`) | 71 (+3) | ~68 | wiremock, injectable `api_url`, no code change |
+| 4 | `services/summarize/kagi.rs` | 84 | ~70 | small refactor + wiremock |
+| 5 | `services/feed_sync.rs` | 307 | ~225 | wiremock + DB seeding |
+| 6 | `handlers/feeds.rs` | 138 | ~95 | axum_test; pure-DB + wiremock success arms |
+| 7 | `handlers/greader/subscription.rs` | 97 | ~70 | axum_test; pure validation + wiremock |
+| 8 | exclude `src/main.rs` | 119 (denominator) | — | `codecov.yml` ignore |
+
+Tasks 1–5 + 8 alone land ≈90.1%. Tasks 6–7 add ~1% margin → target ≈91%. **Task 9 is the gate: re-measure and confirm >90%.** Execute in order; if Task 9 confirms >90% after Task 8, Tasks 6–7 may be deferred to a follow-up (they remain valuable but are not required to clear the bar).
+
+## Conventions for every task (read once)
+
+- One file/area per task = one PR. Branch name `test/<area>-coverage` (e.g. `test/feed-discovery-coverage`).
+- Re-source the OpenSSL env before every cargo command on this box: `source /tmp/rdrs-env.sh`.
+- Run tests with `cargo nextest run` (never `cargo test`). Run `cargo fmt` before committing. Commits MUST be GPG-signed (`-S`). Stage files explicitly by name — never `git add -A`/`.`.
+- **Wiremock test skeleton** (the canonical pattern from `src/services/http.rs:384-571`):
+
+```rust
+let mock_server = wiremock::MockServer::start().await;
+wiremock::Mock::given(wiremock::matchers::method("GET"))
+    .respond_with(
+        wiremock::ResponseTemplate::new(200)
+            .insert_header("content-type", "application/rss+xml")
+            .set_body_string(BODY),
+    )
+    .expect(1)
+    .mount(&mock_server)
+    .await;
+let uri = mock_server.uri(); // http://127.0.0.1:<port>
+```
+
+- The production retry config inside these functions is the real `RetryConfig::default()` (1s backoff) and **cannot be injected**. Transient statuses (5xx/408/429) and connection errors retry and sleep seconds; 2xx/3xx/4xx (non-transient) return immediately. **Always mock immediate (200/304/4xx) responses unless a test specifically asserts retry/exhaustion.**
+- Tests that call async functions need `#[tokio::test]`.
+
+---
+
+## Task 1: `feed_discovery.rs` — wiremock + helper unit tests
+
+**Files:**
+- Test: `src/services/feed_discovery.rs` (add a new `#[cfg(test)] mod tests` at end of file)
+
+This file has **no existing tests** (14% coverage). `discover_feed(url: &str, user_agent: &str)` takes the URL as a parameter, so a test passes `&mock_server.uri()`. HTML-discovery does a *second* fetch of the `<link href>` resolved against the base URL, so those cases mount two mocks on the same server (different paths).
+
+**Public surface under test:**
+```rust
+pub async fn discover_feed(url: &str, user_agent: &str) -> AppResult<DiscoveredFeed>
+// DiscoveredFeed { feed_url: String, title: Option<String>, description: Option<String>, site_url: Option<String> }
+```
+Private helpers also tested directly (in-module): `is_feed_content_type(&str) -> bool`, `looks_like_feed(&str) -> bool`, `find_feed_link_in_html(html, &Url) -> AppResult<String>`.
+
+- [ ] **Step 1: Add the test module with one fully-written wiremock test (will fail to compile until written, then pass)**
+
+Append to `src/services/feed_discovery.rs`:
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    const RSS: &str = r#"<?xml version="1.0"?><rss version="2.0"><channel>
+        <title>Example Feed</title><description>Desc</description>
+        <link>https://example.com</link></channel></rss>"#;
+
+    #[tokio::test]
+    async fn discover_direct_feed_by_content_type() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "application/rss+xml")
+                    .set_body_string(RSS),
+            )
+            .mount(&server)
+            .await;
+
+        let result = discover_feed(&server.uri(), "RDRS-Test/1.0").await.unwrap();
+        assert_eq!(result.title.as_deref(), Some("Example Feed"));
+        assert_eq!(result.description.as_deref(), Some("Desc"));
+    }
+
+    #[tokio::test]
+    async fn discover_via_html_link() {
+        let server = MockServer::start().await;
+        let html = r#"<html><head>
+            <link rel="alternate" type="application/rss+xml" href="/feed.xml">
+            </head><body>hi</body></html>"#;
+        Mock::given(method("GET")).and(path("/"))
+            .respond_with(ResponseTemplate::new(200)
+                .insert_header("content-type", "text/html").set_body_string(html))
+            .mount(&server).await;
+        Mock::given(method("GET")).and(path("/feed.xml"))
+            .respond_with(ResponseTemplate::new(200)
+                .insert_header("content-type", "application/rss+xml").set_body_string(RSS))
+            .mount(&server).await;
+
+        let result = discover_feed(&format!("{}/", server.uri()), "RDRS-Test/1.0").await.unwrap();
+        assert_eq!(result.feed_url, format!("{}/feed.xml", server.uri()));
+        assert_eq!(result.title.as_deref(), Some("Example Feed"));
+    }
+}
+```
+
+- [ ] **Step 2: Run the two tests, confirm they pass**
+
+```bash
+source /tmp/rdrs-env.sh && cargo nextest run -p rdrs feed_discovery
+```
+Expected: 2 passed.
+
+- [ ] **Step 3: Add the remaining cases (one `#[tokio::test]`/`#[test]` each). Each is concrete — input on the left, assertion on the right:**
+
+| Test name | Setup | Assert |
+|---|---|---|
+| `rejects_invalid_url` | `discover_feed("not a url", ua)` | `Err(AppError::InvalidUrl)` (match via `matches!`) |
+| `rejects_non_http_scheme` | `discover_feed("ftp://example.com", ua)` | `Err(AppError::InvalidUrl)` |
+| `discover_by_body_sniffing` | mock returns `content-type: text/html` but body = `RSS` (starts `<?xml`) | Ok; title `Example Feed` (covers `looks_like_feed` true) |
+| `html_without_feed_link_errors` | mock `/` → html with no `<link rel=alternate>` | `Err(AppError::NoFeedFound)` |
+| `first_fetch_non_success_errors` | mock → `ResponseTemplate::new(404)` | `Err(AppError::FetchError(_))` |
+| `discovered_fetch_non_success_errors` | `/` html links `/feed.xml`; `/feed.xml` → 500 | `Err(AppError::FetchError(_))` |
+| `malformed_feed_body_errors` | content-type `application/rss+xml`, body `"<rss><broken"` | `Err(AppError::FeedParseError(_))` |
+| `sends_user_agent_header` | add `.and(wiremock::matchers::header("user-agent", "RDRS-Test/1.0"))` to the mock, `.expect(1)` | test passes (mock verified on drop) |
+| `is_feed_content_type_unit` (`#[test]`) | call helper with `application/rss+xml`, `application/atom+xml`, `application/xml`, `text/html` | first three true, last false |
+| `looks_like_feed_unit` (`#[test]`) | `<?xml`, `<rss`, `<feed`, `<RDF`, `random` | first four true, last false |
+| `find_feed_link_relative_resolution` (`#[test]`) | `find_feed_link_in_html(html_with_href="/f.xml", &Url::parse("https://x.com/a/b").unwrap())` | returns `https://x.com/f.xml` |
+
+- [ ] **Step 4: Run the whole file's tests**
+
+```bash
+source /tmp/rdrs-env.sh && cargo nextest run -p rdrs feed_discovery
+```
+Expected: all (~13) pass.
+
+- [ ] **Step 5: fmt + commit**
+
+```bash
+source /tmp/rdrs-env.sh && cargo fmt
+git add src/services/feed_discovery.rs
+git commit -S -m "test(feed_discovery): cover discover_feed via wiremock and helpers"
+```
+
+---
+
+## Task 2: `icon_fetcher.rs` — wiremock tests for image/favicon fetch
+
+**Files:**
+- Test: `src/services/icon_fetcher.rs` (extend the existing `#[cfg(test)] mod tests`)
+
+URLs are plain parameters (`icon_url`, `logo_url`, `site_url`); the shared client has no host restriction and connects to `127.0.0.1`. `fetch_image`/`fetch_favicon` are private but the test module already does `use super::*`, so call them directly; use the public `fetch_feed_icon` for the orchestration/fallback cases.
+
+**Public surface:**
+```rust
+pub async fn fetch_feed_icon(icon_url: Option<&str>, logo_url: Option<&str>,
+    site_url: Option<&str>, user_agent: &str) -> AppResult<Option<FetchedImage>>
+// FetchedImage { data: Vec<u8>, content_type: String, source_url: String }
+// private (in-module): async fn fetch_image(url, ua) -> AppResult<Option<FetchedImage>>
+//                       async fn fetch_favicon(site_url, ua) -> AppResult<Option<FetchedImage>>
+```
+
+- [ ] **Step 1: Add one fully-written success test for `fetch_image`**
+
+In the existing `mod tests` of `src/services/icon_fetcher.rs`:
+```rust
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const PNG_1X1: &[u8] = &[0x89, 0x50, 0x4E, 0x47]; // PNG magic; enough bytes, non-empty
+
+#[tokio::test]
+async fn fetch_image_success_returns_bytes_and_type() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200)
+            .insert_header("content-type", "image/png").set_body_bytes(PNG_1X1.to_vec()))
+        .mount(&server).await;
+
+    let img = fetch_image(&server.uri(), "RDRS-Test/1.0").await.unwrap().unwrap();
+    assert_eq!(img.content_type, "image/png");
+    assert_eq!(img.data, PNG_1X1);
+    assert_eq!(img.source_url, server.uri());
+}
+```
+
+- [ ] **Step 2: Run it, confirm pass**
+
+```bash
+source /tmp/rdrs-env.sh && cargo nextest run -p rdrs icon_fetcher::tests::fetch_image_success
+```
+Expected: PASS.
+
+- [ ] **Step 3: Add the remaining cases:**
+
+| Test name | Setup | Assert |
+|---|---|---|
+| `fetch_image_strips_content_type_params` | 200, `content-type: image/svg+xml; charset=utf-8`, non-empty body | `img.content_type == "image/svg+xml"` |
+| `fetch_image_non_success_is_none` | 404 | `Ok(None)` |
+| `fetch_image_non_image_type_is_none` | 200, `content-type: text/html`, body "hi" | `Ok(None)` |
+| `fetch_image_missing_type_is_none` | 200, no content-type header | `Ok(None)` |
+| `fetch_image_too_large_is_none` | 200, `image/png`, `set_body_bytes(vec![0u8; 300*1024])` (> 256 KB) | `Ok(None)` |
+| `fetch_image_empty_body_is_none` | 200, `image/png`, empty body | `Ok(None)` |
+| `fetch_favicon_uses_favicon_ico` | mock `/favicon.ico` → 200 `image/x-icon` bytes | `fetch_favicon(&server.uri(), ua)` returns `Some`, source ends `/favicon.ico` |
+| `fetch_favicon_falls_back_to_html_link` | `/favicon.ico` → 404; `/` → html `<link rel="icon" href="/icon.png">`; `/icon.png` → 200 image | returns `Some`, source ends `/icon.png` |
+| `fetch_favicon_no_icon_is_none` | `/favicon.ico` → 404; `/` → html with no icon link | `Ok(None)` |
+| `fetch_feed_icon_prefers_icon_url` | mount `/a` (image) and `/b` (image); call with `icon_url=Some(.../a)`, `logo_url=Some(.../b)` | source ends `/a` |
+| `fetch_feed_icon_falls_back_to_logo` | `/a` → 404, `/b` → image | source ends `/b` |
+| `fetch_feed_icon_all_none` | call with all `None` | `Ok(None)` |
+
+For `/favicon.ico`-derived tests, pass `site_url = &server.uri()` (the helper derives `{scheme}://{host}/favicon.ico`).
+
+- [ ] **Step 4: Run all icon_fetcher tests**
+
+```bash
+source /tmp/rdrs-env.sh && cargo nextest run -p rdrs icon_fetcher
+```
+Expected: all pass.
+
+- [ ] **Step 5: fmt + commit**
+
+```bash
+source /tmp/rdrs-env.sh && cargo fmt
+git add src/services/icon_fetcher.rs
+git commit -S -m "test(icon_fetcher): cover image/favicon fetch paths via wiremock"
+```
+
+---
+
+## Task 3: `save/linkding.rs` + `save/mod.rs` — wiremock + config tests
+
+**Files:**
+- Test: `src/services/save/linkding.rs` (extend existing `#[cfg(test)] mod tests`)
+- Test: `src/services/save/mod.rs` (add new `#[cfg(test)] mod tests`)
+
+`save_to_linkding` builds its POST URL from `config.api_url` via `normalize_api_url`, so set `api_url = mock_server.uri()` and the request goes to wiremock — **no production change**. `normalize_api_url(uri)` appends `/api/bookmarks/`; match on `method("POST")` in the mock.
+
+**Public surface:**
+```rust
+pub async fn save_to_linkding(config: &LinkdingConfig, bookmark: &BookmarkData) -> AppResult<SaveResult>
+// LinkdingConfig { api_url: String, api_token: String }
+// BookmarkData { url: String, title: Option<String>, description: Option<String>, tags: Vec<String> }  (from super::)
+// SaveResult { success: bool, message: String, ... }  (from super::)
+```
+
+- [ ] **Step 1: Add one success test**
+
+In `src/services/save/linkding.rs` test module:
+```rust
+use wiremock::matchers::{method, header};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+use super::super::{BookmarkData}; // adjust to actual import path of BookmarkData
+
+#[tokio::test]
+async fn save_success_returns_bookmark_url() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(header("authorization", "Token tok123"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({"id": 42})))
+        .expect(1)
+        .mount(&server).await;
+
+    let config = LinkdingConfig { api_url: server.uri(), api_token: "tok123".into() };
+    let bookmark = BookmarkData {
+        url: "https://example.com/post".into(),
+        title: Some("Title".into()), description: None, tags: vec!["rust".into()],
+    };
+    let result = save_to_linkding(&config, &bookmark).await.unwrap();
+    assert!(result.success);
+    assert!(result.message.contains("Saved"));
+}
+```
+(If `BookmarkData`/`SaveResult` field names differ, read `src/services/save/mod.rs:10-25` and adjust — do not invent fields.)
+
+- [ ] **Step 2: Run it**
+
+```bash
+source /tmp/rdrs-env.sh && cargo nextest run -p rdrs save::linkding::tests::save_success
+```
+Expected: PASS.
+
+- [ ] **Step 3: Add the remaining linkding cases:**
+
+| Test name | Mock response | Assert |
+|---|---|---|
+| `not_configured_short_circuits` | none (api_url/token empty) | `success == false`, message "not configured"; mock not needed |
+| `duplicate_returns_friendly_message` | 400, body text contains `"already exists"` | `success == false`, message contains "already exists" |
+| `bad_request_other` | 400, body `"bad field"` | message contains "Bad request" |
+| `invalid_token_401` | 401 | message contains "Invalid API token" |
+| `forbidden_403` | 403 | message contains "forbidden" |
+| `not_found_404` | 404 | message contains "endpoint not found" |
+| `server_error_500` | 500, body "boom" | message contains "Linkding error (500" |
+| `malformed_json_errors` | 201, body `"{not json"` | `Err(AppError::Internal(_))` |
+| `omits_empty_optional_fields` | 201 `{"id":1}`, add `.and(wiremock::matchers::body_json(...))` matching a body WITHOUT `title`/`description`/`tag_names` when bookmark has `title:None, description:None, tags:vec![]` | passes (body matcher verifies serialization) |
+
+- [ ] **Step 4: Add `save/mod.rs` config tests (pure, no network)**
+
+Add a `#[cfg(test)] mod tests` to `src/services/save/mod.rs`:
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn save_services_config_json_roundtrip() {
+        let json = r#"{"linkding":{"api_url":"https://l","api_token":"t"}}"#;
+        let cfg = SaveServicesConfig::from_json(json).unwrap();
+        assert!(cfg.has_any_service());
+        let back = cfg.to_json().unwrap();
+        assert!(back.contains("https://l"));
+    }
+    #[test]
+    fn empty_config_has_no_service() {
+        let cfg = SaveServicesConfig::from_json("{}").unwrap();
+        assert!(!cfg.has_any_service());
+        assert!(cfg.configured_services().is_empty());
+    }
+    #[test]
+    fn configured_services_lists_linkding() {
+        let cfg = SaveServicesConfig::from_json(
+            r#"{"linkding":{"api_url":"https://l","api_token":"t"}}"#).unwrap();
+        assert_eq!(cfg.configured_services(), vec!["linkding"]);
+    }
+}
+```
+
+- [ ] **Step 5: Run + fmt + commit**
+
+```bash
+source /tmp/rdrs-env.sh && cargo nextest run -p rdrs save::
+cargo fmt
+git add src/services/save/linkding.rs src/services/save/mod.rs
+git commit -S -m "test(save): cover linkding HTTP paths and SaveServicesConfig"
+```
+
+---
+
+## Task 4: `summarize/kagi.rs` — extract base URL, then wiremock tests
+
+**Files:**
+- Modify: `src/services/summarize/kagi.rs:61-62` (extract base URL into an inner function)
+- Test: `src/services/summarize/kagi.rs` (extend existing `#[cfg(test)] mod tests`)
+
+Kagi hardcodes `https://kagi.com/mother/summary_labs`. The **smallest** change that keeps the public signature stable: extract `summarize_url_with_base(base: &str, config, url)` and have `summarize_url` call it with the real host const.
+
+- [ ] **Step 1: Refactor — extract the base parameter (no behaviour change)**
+
+Replace the hardcoded URL build. Find:
+```rust
+let mut api_url = url::Url::parse("https://kagi.com/mother/summary_labs")
+    .map_err(|e| AppError::Internal(format!("Failed to parse Kagi API URL: {}", e)))?;
+```
+Change the function so the public entry delegates to an inner one carrying the base:
+```rust
+const KAGI_API_BASE: &str = "https://kagi.com";
+
+pub async fn summarize_url(config: &KagiConfig, url: &str) -> AppResult<SummarizeResult> {
+    summarize_url_with_base(KAGI_API_BASE, config, url).await
+}
+
+async fn summarize_url_with_base(base: &str, config: &KagiConfig, url: &str)
+    -> AppResult<SummarizeResult>
+{
+    // ... existing body, but build the endpoint from `base`:
+    let mut api_url = url::Url::parse(&format!("{}/mother/summary_labs", base))
+        .map_err(|e| AppError::Internal(format!("Failed to parse Kagi API URL: {}", e)))?;
+    // ... rest unchanged ...
+}
+```
+Move the entire existing body into `summarize_url_with_base`; keep the `not configured` early return there too.
+
+- [ ] **Step 2: Verify the refactor compiles and existing tests still pass**
+
+```bash
+source /tmp/rdrs-env.sh && cargo nextest run -p rdrs kagi
+```
+Expected: the 3 existing config tests pass; no behaviour change.
+
+- [ ] **Step 3: Add one success test against wiremock**
+
+```rust
+use wiremock::matchers::{method, header};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[tokio::test]
+async fn summarize_success_strips_title_prefix() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(header("authorization", "session-tok"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "output_data": {"markdown": "Title: Foo\n\nThe body."}
+        })))
+        .mount(&server).await;
+
+    let config = KagiConfig { session_token: "session-tok".into(), language: None };
+    let result = summarize_url_with_base(&server.uri(), &config, "https://x.com/a").await.unwrap();
+    assert!(result.success);
+    assert_eq!(result.output_text.as_deref(), Some("The body."));
+}
+```
+
+- [ ] **Step 4: Run it**
+
+```bash
+source /tmp/rdrs-env.sh && cargo nextest run -p rdrs kagi::tests::summarize_success
+```
+Expected: PASS.
+
+- [ ] **Step 5: Add the remaining cases (all via `summarize_url_with_base(&server.uri(), ...)`):**
+
+| Test name | Mock response | Assert |
+|---|---|---|
+| `not_configured` | none; `KagiConfig{session_token:"".into(), language:None}` | `success==false`, error "not configured" |
+| `markdown_without_title_prefix` | 200 `{"output_data":{"markdown":"Plain body"}}` | `output_text == Some("Plain body")` |
+| `error_field_in_body` | 200 `{"error":"nope"}` | `success==false`, error "nope" |
+| `no_output_data` | 200 `{}` | `success==false`, error contains "No summary" |
+| `invalid_token_401` | 401 | error contains "Invalid session token" |
+| `forbidden_403` | 403 | error contains "Access forbidden" |
+| `rate_limited_429` | 429 | error contains "Rate limit" |
+| `server_error_500` | 500, body "x" | error contains "Kagi error (500" |
+| `malformed_json` | 200, body `"{bad"` | `Err(AppError::Internal(_))` |
+| `language_adds_query_param` | 200 valid body; mock `.and(wiremock::matchers::query_param("target_language","fr"))` `.expect(1)`; `language: Some("fr")` | passes (mock verifies query sent) |
+
+- [ ] **Step 6: Run + fmt + commit**
+
+```bash
+source /tmp/rdrs-env.sh && cargo nextest run -p rdrs kagi
+cargo fmt
+git add src/services/summarize/kagi.rs
+git commit -S -m "test(kagi): inject base URL and cover summarize_url HTTP paths"
+```
+
+---
+
+## Task 5: `feed_sync.rs` — wiremock + DB-seeded `refresh_feed` tests
+
+**Files:**
+- Test: `src/services/feed_sync.rs` (extend existing `#[cfg(test)] mod tests`)
+
+`refresh_feed(db: DbPool, feed_id, ua)` reads the feed row and fetches `feed.url`. Seed a feed whose `url = mock_server.uri()`. Use a shared-memory pool so the test can read back persisted state. **Seed a feed body with no `<icon>`/`<logo>` and `site_url = None`** so the icon-refresh branch makes no real outbound call.
+
+**Public surface:**
+```rust
+pub async fn refresh_feed(db: DbPool, feed_id: i64, default_user_agent: &str) -> AppResult<SyncResult>
+// SyncResult { new_entries: i64, updated_entries: i64 }
+pub async fn refresh_bucket(db: DbPool, bucket: u8, user_agent: &str) -> Vec<(i64, Result<SyncResult, String>)>
+```
+
+- [ ] **Step 1: Add a DB-fixture helper to the test module**
+
+The exact `DbPool`/`open_shared_memory` construction must mirror `tests/handlers_test.rs:39-48` and `src/db/pool.rs`. Read those first, then add to the `mod tests` of `feed_sync.rs`:
+```rust
+use crate::db::{self, pool::DbPool};
+use crate::models::{category, feed, user};
+use wiremock::matchers::method;
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+// Build a pool over one shared in-memory DB (write+read see the same data).
+fn seeded_pool(name: &str) -> DbPool {
+    let write_conn = db::pool::open_shared_memory(name); // confirm exact path/name of helper
+    db::init_db(&write_conn).unwrap();
+    let read_conn = db::pool::open_shared_memory(name);
+    let (pool, _handle) = DbPool::new(write_conn, read_conn);
+    pool
+}
+
+async fn seed_feed(pool: &DbPool, url: &str) -> i64 {
+    pool.user({
+        let url = url.to_string();
+        move |conn| {
+            let u = user::create_user(conn, "syncuser", "hash", user::Role::User).unwrap();
+            let cat = category::create_category(conn, u.id, "Tech").unwrap();
+            feed::create_feed(conn, &feed::CreateFeedParams {
+                category_id: cat.id, url: &url, title: Some("F"),
+                description: None, site_url: None, custom_user_agent: None,
+                http2_disabled: None, custom_referrer: None,
+            }).unwrap().id
+        }
+    }).await.unwrap()
+}
+```
+(If `open_shared_memory` is not `pub` at that path, read `src/db/pool.rs` and use the exact visible constructor; the integration tests build the same thing in `tests/handlers_test.rs`.)
+
+- [ ] **Step 2: Add the happy-path test and run it**
+
+```rust
+const RSS_TWO: &str = r#"<?xml version="1.0"?><rss version="2.0"><channel>
+  <title>F</title>
+  <item><guid>g1</guid><title>One</title><link>https://e/1</link>
+        <description>c1</description><pubDate>Tue, 10 Jun 2025 10:00:00 GMT</pubDate></item>
+  <item><guid>g2</guid><title>Two</title><link>https://e/2</link>
+        <description>c2</description><pubDate>Tue, 10 Jun 2025 11:00:00 GMT</pubDate></item>
+</channel></rss>"#;
+
+#[tokio::test]
+async fn refresh_feed_inserts_new_entries() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200)
+            .insert_header("content-type", "application/rss+xml").set_body_string(RSS_TWO))
+        .mount(&server).await;
+
+    let pool = seeded_pool("feed_sync_happy");
+    let feed_id = seed_feed(&pool, &server.uri()).await;
+
+    let result = refresh_feed(pool.clone(), feed_id, "RDRS-Test/1.0").await.unwrap();
+    assert_eq!(result.new_entries, 2);
+    assert_eq!(result.updated_entries, 0);
+}
+```
+```bash
+source /tmp/rdrs-env.sh && cargo nextest run -p rdrs feed_sync::tests::refresh_feed_inserts_new
+```
+Expected: PASS.
+
+- [ ] **Step 3: Add the remaining `refresh_feed` cases:**
+
+| Test name | Setup | Assert |
+|---|---|---|
+| `feed_not_found` | call with `feed_id = 999999` on empty pool | `Err(AppError::FeedNotFound)` |
+| `updates_existing_entries` | run happy-path body twice (same guids, second mock has changed `<description>`) | second `SyncResult{new:0, updated:2}` |
+| `skips_tombstoned_guid` | before sync, `pool.user(|c| entry::insert_tombstone(c, feed_id, "g1"))`; then sync `RSS_TWO` | `new_entries == 1` (g1 skipped); assert no entry with guid g1 exists |
+| `not_modified_304` | mock → `ResponseTemplate::new(304)` | `SyncResult{0,0}` |
+| `http_error_persists_fetch_error` | mock → 404 | `Err(AppError::FetchError(_))`; read feed row, `fetch_error` is `Some` |
+| `malformed_xml_errors` | 200 `application/rss+xml` body `"<rss><broken"` | `Err(AppError::FeedParseError(_))` |
+| `sends_conditional_get_headers` | seed feed, set its `etag`/`last_modified` via `feed::update_fetch_result`; mock `.and(header("if-none-match", ...))` `.expect(1)`, returns 304 | passes (mock verifies headers sent) |
+| `uses_custom_user_agent` | seed feed with `custom_user_agent: Some("Custom/9")`; mock `.and(header("user-agent","Custom/9"))` `.expect(1)` | passes |
+| `content_falls_back_to_summary` | item with empty `<description>` but `<content:encoded>`/summary | inserted entry content is the fallback (read back via `entry::find_by_guid_and_feed`) |
+
+- [ ] **Step 4: Add two `refresh_bucket` cases**
+
+| Test name | Setup | Assert |
+|---|---|---|
+| `refresh_bucket_empty` | fresh pool, no feeds in bucket 0 | returns `vec![]` |
+| `refresh_bucket_runs_feeds` | seed a feed in a known bucket (read `feed::create_feed` bucket assignment / set via update), mock its url | result vec has one `(feed_id, Ok(SyncResult))` with `new_entries > 0` |
+
+(If determining a feed's bucket is awkward, read `src/models/feed.rs` for how `bucket` is assigned and either seed accordingly or assert on the feed that lands in the queried bucket.)
+
+- [ ] **Step 5: Run all feed_sync tests**
+
+```bash
+source /tmp/rdrs-env.sh && cargo nextest run -p rdrs feed_sync
+```
+Expected: all pass (existing 8 pure tests + ~13 new).
+
+- [ ] **Step 6: fmt + commit**
+
+```bash
+source /tmp/rdrs-env.sh && cargo fmt
+git add src/services/feed_sync.rs
+git commit -S -m "test(feed_sync): cover refresh_feed/refresh_bucket via wiremock + seeded DB"
+```
+
+---
+
+## Task 6: `handlers/feeds.rs` — handler tests (pure-DB + wiremock success arms)
+
+**Files:**
+- Test: `tests/handlers_test.rs` (add tests; reuse `create_test_app`, `setup_authenticated_user`, `insert_test_feed`)
+
+These are SSR form handlers returning 303 + flash. The pure-DB branches need no network; the create/refresh/fetch-metadata **success** arms call `feed_discovery`/`feed_sync`, so those point a seeded feed url at a `wiremock::MockServer` (introduce wiremock to this test binary — it is already a dev-dependency).
+
+- [ ] **Step 1: Add the pure-DB branch tests first (no wiremock)**
+
+Use the established skeleton (`create_test_app(default_test_config())` → `setup_authenticated_user(&app.server).await` → seed → `app.server.post(...).form(...).await` → assert status/Location + DB). Cases:
+
+| Test name | Action | Assert |
+|---|---|---|
+| `edit_feed_empty_url_flashes` | POST `/feeds/{id}/edit` with `url=""` | 303 → `/feeds`; feed unchanged |
+| `edit_feed_not_found` | POST `/feeds/999999/edit` valid form | 303; flash error (feed row count for 999999 stays 0) |
+| `edit_feed_other_users_feed` | seed feed under a *second* user, edit as testuser | 303; original feed unchanged |
+| `edit_feed_new_category_not_owned` | edit with `category_id` of another user's category | 303; feed's category unchanged |
+| `edit_feed_clear_user_agent` | seed feed with custom UA, POST edit with `_clear_user_agent=on` | feed `custom_user_agent` is NULL |
+| `delete_feed_not_found` | POST `/feeds/999999/delete` | 303 → `/feeds` |
+| `import_opml_invalid` | POST `/feeds/import` multipart `file` = `"<not valid opml"` | 303; no feeds created |
+| `import_opml_duplicate_skipped` | pre-seed feed with url X in cat C; import OPML containing X under C | 303; feed count for X stays 1 |
+
+- [ ] **Step 2: Run the pure-DB tests**
+
+```bash
+source /tmp/rdrs-env.sh && cargo nextest run --test handlers_test feed
+```
+Expected: all new pure-DB tests pass.
+
+- [ ] **Step 3: Add wiremock success-arm tests**
+
+Add `use wiremock::...` to the test file. Pattern: start a `MockServer`, mock its GET to return RSS, then POST the create/refresh form with the feed url = `server.uri()`.
+
+| Test name | Setup | Assert |
+|---|---|---|
+| `create_feed_success` | mock returns RSS (content-type `application/rss+xml`); POST `/feeds` form `url=<server.uri()>`, `category_id=<owned cat>` | 303 → `/feeds`; one feed row with that url exists |
+| `create_feed_duplicate` | pre-create the feed (Task-style seed) with url = server.uri(); mock RSS; POST create same url | 303; feed count stays 1; flash "already subscribed" (assert via following redirect or flash cookie) |
+| `refresh_feed_success` | seed feed url = server.uri(); mock RSS with 1 item; POST `/feeds/{id}/refresh` | 303 → `/feeds`; entry count for feed ≥ 1 |
+| `fetch_metadata_success` | seed feed url = server.uri(); mock RSS with `<title>/<description>`; POST `/feeds/{id}/fetch-metadata` | 303; feed title/description updated in DB |
+
+- [ ] **Step 4: Run the full feeds handler test set**
+
+```bash
+source /tmp/rdrs-env.sh && cargo nextest run --test handlers_test feed
+```
+Expected: all pass.
+
+- [ ] **Step 5: fmt + commit**
+
+```bash
+source /tmp/rdrs-env.sh && cargo fmt
+git add tests/handlers_test.rs
+git commit -S -m "test(handlers/feeds): cover edit/import/create/refresh form paths"
+```
+
+---
+
+## Task 7: `handlers/greader/subscription.rs` — GReader handler tests
+
+**Files:**
+- Test: `tests/greader_test.rs` (reuse its `create_test_app`/`TestApp`, `setup_authenticated_user -> user_id`, `create_test_feed`)
+
+Pure validation + edit branches need no network; subscribe/quickadd success arms need wiremock (feed discovery).
+
+- [ ] **Step 1: Add pure validation/edit tests**
+
+| Test name | Request | Assert |
+|---|---|---|
+| `subscribe_missing_stream_id` | POST `/reader/api/0/subscription/edit` form `ac=subscribe` (no `s`) | 400 |
+| `subscribe_bad_prefix` | `ac=subscribe&s=https://x` (no `feed/`) | 400 |
+| `subscribe_empty_url` | `ac=subscribe&s=feed/` | 400 |
+| `edit_feed_not_found` | `ac=edit&s=feed/<unknown>` | 404 |
+| `edit_add_label_moves_category` | seed feed; `ac=edit&s=feed/<url>&a=user/-/label/NewCat` | 200; feed's category is now "NewCat" (DB assert) |
+| `extract_label_name_numeric_user` (unit, in `subscription.rs`) | `extract_label_name("user/12345/label/Foo")` | returns `"Foo"` |
+
+(`extract_label_name` is private — add that one as an in-file `#[cfg(test)]` unit test in `src/handlers/greader/subscription.rs`, not in the integration file.)
+
+- [ ] **Step 2: Run them**
+
+```bash
+source /tmp/rdrs-env.sh && cargo nextest run --test greader_test subscription
+source /tmp/rdrs-env.sh && cargo nextest run -p rdrs subscription::tests::extract_label_name_numeric
+```
+Expected: pass.
+
+- [ ] **Step 3: Add wiremock success arms**
+
+| Test name | Setup | Assert |
+|---|---|---|
+| `subscribe_success_creates_feed` | mock RSS; POST `ac=subscribe&s=feed/<server.uri()>` | 200; feed row exists for that url under the user |
+| `subscribe_with_explicit_label` | mock RSS; `ac=subscribe&s=feed/<uri>&a=user/-/label/Tech` | 200; feed under category "Tech" |
+| `subscribe_duplicate_conflict` | pre-seed feed url=uri; mock RSS; subscribe same | 409 CONFLICT |
+| `quickadd_success` | mock RSS; POST `/reader/api/0/subscription/quickadd` form `quickadd=<uri>` | 200; JSON `num_results == 1`, `stream_id == "feed/<uri>"` |
+
+- [ ] **Step 4: Run the full subscription set**
+
+```bash
+source /tmp/rdrs-env.sh && cargo nextest run --test greader_test subscription
+```
+Expected: all pass.
+
+- [ ] **Step 5: fmt + commit**
+
+```bash
+source /tmp/rdrs-env.sh && cargo fmt
+git add tests/greader_test.rs src/handlers/greader/subscription.rs
+git commit -S -m "test(greader/subscription): cover subscribe/quickadd/edit paths"
+```
+
+---
+
+## Task 8: Exclude the binary entrypoint from coverage
+
+**Files:**
+- Create: `codecov.yml`
+
+`src/main.rs` is 0% (170 lines, 119 uncovered) — it only runs in a live process (binds a socket, spawns workers). Excluding it from the Codecov *project* denominator is conventional for a binary entrypoint and is the cleanest way to stop the unreachable bootstrap from dragging the percentage down. This does not touch what `cargo llvm-cov` reports locally.
+
+- [ ] **Step 1: Create `codecov.yml`**
+
+```yaml
+# Coverage configuration. The binary entrypoint only executes in a live
+# process (socket bind, worker spawn) and is not unit-testable; exclude it
+# from the project coverage denominator.
+ignore:
+  - "src/main.rs"
+
+coverage:
+  status:
+    project:
+      default:
+        target: 90%
+        threshold: 1%
+    patch:
+      default:
+        target: 80%
+```
+
+- [ ] **Step 2: Validate the YAML is well-formed**
+
+```bash
+python3 -c "import yaml,sys; yaml.safe_load(open('codecov.yml')); print('ok')"
+```
+Expected: `ok`.
+
+- [ ] **Step 3: commit**
+
+```bash
+git add codecov.yml
+git commit -S -m "ci(coverage): exclude binary entrypoint, set 90% project target"
+```
+
+(Note: the `target: 90%` status gate takes effect once this lands on the default branch and a subsequent PR is measured against it. Confirm the Codecov status turns green on the first PR after merge.)
+
+---
+
+## Task 9: Measure and confirm >90% (gate)
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run full coverage locally, mirroring the Codecov ignore**
+
+```bash
+source /tmp/rdrs-env.sh && cargo llvm-cov nextest --summary-only --ignore-filename-regex 'src/main\.rs'
+```
+Expected: TOTAL line coverage **> 90%**.
+
+- [ ] **Step 2: If below 90%, fill the nearest remaining gap**
+
+Re-run `cargo llvm-cov nextest --summary-only --ignore-filename-regex 'src/main\.rs'` and read the per-file table. The next-highest-leverage untested files (each adds ~0.2–0.4%) are, in order: `services/summary_worker.rs` (61), `handlers/user.rs` (44), `services/opml.rs` (46), `handlers/pages/time_format.rs` (38, pure formatting — cheap), `models/feed.rs` (45). Add tests to whichever closes the gap, following the same patterns (pure functions → in-file unit tests; handlers → `axum_test`). Re-measure.
+
+- [ ] **Step 3: Final full test run (no regressions)**
+
+```bash
+source /tmp/rdrs-env.sh && cargo nextest run && cargo clippy --all-targets
+```
+Expected: all tests pass; clippy clean.
+
+---
+
+## Self-Review notes
+
+- **Coverage math:** Tasks 1–5 (services) cover ~540 lines; Task 8 removes 119 uncovered from a 170-smaller denominator → tasks 1–5 + 8 reach ≈90.1%. Tasks 6–7 add ~165 covered lines → ≈91%. Task 9 is the hard gate; Step 2 lists fallbacks if estimates run optimistic.
+- **proxy.rs deliberately excluded from the main path:** its origin-fetch is gated by `url_validation::validate_url`, which hard-blocks loopback with no test seam — covering it would need an SSRF-validation bypass (a riskier production change) for little percentage gain. Its pre-fetch branches (bad base64, bad signature, SSRF-block, scheme) are cheap follow-ups via `axum_test` if extra margin is ever needed.
+- **passkey.rs (120 uncovered) excluded:** WebAuthn ceremonies need a credential authenticator; out of proportion to the coverage gained. Not required to clear 90%.
+- **Kagi is the only production change** (extract a base-URL parameter); it is behaviour-preserving and verified by Step 2 of Task 4 before any new test is added.
+- **No injected `RetryConfig`:** all service tests mock immediate (200/304/4xx) responses; no test forces a transient-retry sleep except where explicitly noted with `.up_to_n_times`.

--- a/src/handlers/greader/subscription.rs
+++ b/src/handlers/greader/subscription.rs
@@ -492,6 +492,37 @@ fn extract_label_name(s: Option<&str>) -> Option<String> {
     })
 }
 
+#[cfg(test)]
+mod tests {
+    use super::extract_label_name;
+
+    #[test]
+    fn extract_label_name_dash_user() {
+        assert_eq!(
+            extract_label_name(Some("user/-/label/Foo")),
+            Some("Foo".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_label_name_numeric_user() {
+        assert_eq!(
+            extract_label_name(Some("user/12345/label/Foo")),
+            Some("Foo".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_label_name_none_input() {
+        assert_eq!(extract_label_name(None), None);
+    }
+
+    #[test]
+    fn extract_label_name_invalid_prefix() {
+        assert_eq!(extract_label_name(Some("tag/something")), None);
+    }
+}
+
 /// Verify POST token if request is not via cookie auth.
 fn verify_post_token_if_needed(
     auth: &GReaderUser,

--- a/src/handlers/greader/subscription.rs
+++ b/src/handlers/greader/subscription.rs
@@ -492,6 +492,28 @@ fn extract_label_name(s: Option<&str>) -> Option<String> {
     })
 }
 
+/// Verify POST token if request is not via cookie auth.
+fn verify_post_token_if_needed(
+    auth: &GReaderUser,
+    state: &AppState,
+    token: Option<&str>,
+) -> AppResult<()> {
+    if auth.via_cookie {
+        // Cookie auth has SameSite protection, skip POST token
+        return Ok(());
+    }
+
+    if let Some(post_token) = token {
+        super::auth::verify_post_token(
+            &state.config.image_proxy_secret,
+            &auth.session.session_token,
+            post_token,
+        )?;
+    }
+    // Many clients don't send POST token, so we allow it for now
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::extract_label_name;
@@ -521,26 +543,4 @@ mod tests {
     fn extract_label_name_invalid_prefix() {
         assert_eq!(extract_label_name(Some("tag/something")), None);
     }
-}
-
-/// Verify POST token if request is not via cookie auth.
-fn verify_post_token_if_needed(
-    auth: &GReaderUser,
-    state: &AppState,
-    token: Option<&str>,
-) -> AppResult<()> {
-    if auth.via_cookie {
-        // Cookie auth has SameSite protection, skip POST token
-        return Ok(());
-    }
-
-    if let Some(post_token) = token {
-        super::auth::verify_post_token(
-            &state.config.image_proxy_secret,
-            &auth.session.session_token,
-            post_token,
-        )?;
-    }
-    // Many clients don't send POST token, so we allow it for now
-    Ok(())
 }

--- a/src/services/feed_discovery.rs
+++ b/src/services/feed_discovery.rs
@@ -136,3 +136,202 @@ fn parse_feed_content(feed_url: &str, content: &str) -> AppResult<DiscoveredFeed
         site_url,
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    const RSS: &str = r#"<?xml version="1.0"?><rss version="2.0"><channel>
+        <title>Example Feed</title><description>Desc</description>
+        <link>https://example.com</link></channel></rss>"#;
+
+    #[tokio::test]
+    async fn discover_direct_feed_by_content_type() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "application/rss+xml")
+                    .set_body_string(RSS),
+            )
+            .mount(&server)
+            .await;
+        let result = discover_feed(&server.uri(), "RDRS-Test/1.0").await.unwrap();
+        assert_eq!(result.title.as_deref(), Some("Example Feed"));
+        assert_eq!(result.description.as_deref(), Some("Desc"));
+    }
+
+    #[tokio::test]
+    async fn discover_via_html_link() {
+        let server = MockServer::start().await;
+        let html = r#"<html><head>
+            <link rel="alternate" type="application/rss+xml" href="/feed.xml">
+            </head><body>hi</body></html>"#;
+        Mock::given(method("GET"))
+            .and(path("/"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/html")
+                    .set_body_string(html),
+            )
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/feed.xml"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "application/rss+xml")
+                    .set_body_string(RSS),
+            )
+            .mount(&server)
+            .await;
+        let result = discover_feed(&format!("{}/", server.uri()), "RDRS-Test/1.0")
+            .await
+            .unwrap();
+        assert_eq!(result.feed_url, format!("{}/feed.xml", server.uri()));
+        assert_eq!(result.title.as_deref(), Some("Example Feed"));
+    }
+
+    #[tokio::test]
+    async fn rejects_invalid_url() {
+        let result = discover_feed("not a url", "ua").await;
+        assert!(matches!(result, Err(AppError::InvalidUrl)));
+    }
+
+    #[tokio::test]
+    async fn rejects_non_http_scheme() {
+        let result = discover_feed("ftp://example.com", "ua").await;
+        assert!(matches!(result, Err(AppError::InvalidUrl)));
+    }
+
+    #[tokio::test]
+    async fn discover_by_body_sniffing() {
+        // content-type is text/html but body looks like a feed — covers looks_like_feed
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/html")
+                    .set_body_string(RSS),
+            )
+            .mount(&server)
+            .await;
+        let result = discover_feed(&server.uri(), "RDRS-Test/1.0").await.unwrap();
+        assert_eq!(result.title.as_deref(), Some("Example Feed"));
+    }
+
+    #[tokio::test]
+    async fn html_without_feed_link_errors() {
+        let server = MockServer::start().await;
+        let html = "<html><head></head><body>no feed here</body></html>";
+        Mock::given(method("GET"))
+            .and(path("/"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/html")
+                    .set_body_string(html),
+            )
+            .mount(&server)
+            .await;
+        let result = discover_feed(&format!("{}/", server.uri()), "RDRS-Test/1.0").await;
+        assert!(matches!(result, Err(AppError::NoFeedFound)));
+    }
+
+    #[tokio::test]
+    async fn first_fetch_non_success_errors() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+        let result = discover_feed(&server.uri(), "RDRS-Test/1.0").await;
+        assert!(matches!(result, Err(AppError::FetchError(_))));
+    }
+
+    #[tokio::test]
+    async fn discovered_fetch_non_success_errors() {
+        let server = MockServer::start().await;
+        let html = r#"<html><head>
+            <link rel="alternate" type="application/rss+xml" href="/feed.xml">
+            </head><body>hi</body></html>"#;
+        Mock::given(method("GET"))
+            .and(path("/"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/html")
+                    .set_body_string(html),
+            )
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/feed.xml"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+        let result = discover_feed(&format!("{}/", server.uri()), "RDRS-Test/1.0").await;
+        assert!(matches!(result, Err(AppError::FetchError(_))));
+    }
+
+    #[tokio::test]
+    async fn malformed_feed_body_errors() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "application/rss+xml")
+                    .set_body_string("<rss><broken"),
+            )
+            .mount(&server)
+            .await;
+        let result = discover_feed(&server.uri(), "RDRS-Test/1.0").await;
+        assert!(matches!(result, Err(AppError::FeedParseError(_))));
+    }
+
+    #[tokio::test]
+    async fn sends_user_agent_header() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(header("user-agent", "RDRS-Test/1.0"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "application/rss+xml")
+                    .set_body_string(RSS),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        discover_feed(&server.uri(), "RDRS-Test/1.0").await.unwrap();
+        // MockServer verifies .expect(1) on drop
+    }
+
+    #[test]
+    fn is_feed_content_type_unit() {
+        assert!(is_feed_content_type("application/rss+xml"));
+        assert!(is_feed_content_type("application/atom+xml"));
+        assert!(is_feed_content_type("application/xml"));
+        assert!(is_feed_content_type("text/xml"));
+        assert!(!is_feed_content_type("text/html"));
+    }
+
+    #[test]
+    fn looks_like_feed_unit() {
+        assert!(looks_like_feed("<?xml version"));
+        assert!(looks_like_feed("<rss version="));
+        assert!(looks_like_feed("<feed xmlns="));
+        assert!(looks_like_feed("<RDF:RDF"));
+        assert!(!looks_like_feed("random text"));
+        assert!(!looks_like_feed("<html>"));
+    }
+
+    #[test]
+    fn find_feed_link_relative_resolution() {
+        let html = r#"<html><head>
+            <link rel="alternate" type="application/rss+xml" href="/f.xml">
+            </head></html>"#;
+        let base = Url::parse("https://x.com/a/b").unwrap();
+        let result = find_feed_link_in_html(html, &base).unwrap();
+        assert_eq!(result, "https://x.com/f.xml");
+    }
+}

--- a/src/services/feed_sync.rs
+++ b/src/services/feed_sync.rs
@@ -469,8 +469,451 @@ pub async fn refresh_bucket(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::db::{init_db, DbPool};
+    use crate::error::AppError;
+    use crate::models::entry;
+    use crate::models::user::Role;
+    use crate::models::{category, feed, user};
     use crate::utils::datetime::normalize_timezone_format;
     use chrono::{Datelike, Timelike};
+    use rusqlite::Connection;
+    use wiremock::matchers::{header, method};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    // ---------------------------------------------------------------------------
+    // Test infrastructure
+    // ---------------------------------------------------------------------------
+
+    /// Open a named shared-memory SQLite connection. Both write and read
+    /// connections must use the same name so the pool sees one database.
+    fn open_shared_memory(name: &str) -> Connection {
+        let uri = format!("file:{}?mode=memory&cache=shared", name);
+        Connection::open_with_flags(
+            uri,
+            rusqlite::OpenFlags::SQLITE_OPEN_READ_WRITE
+                | rusqlite::OpenFlags::SQLITE_OPEN_CREATE
+                | rusqlite::OpenFlags::SQLITE_OPEN_URI,
+        )
+        .unwrap()
+    }
+
+    /// Build a fully-initialized DbPool backed by a shared in-memory database.
+    /// Returns `(pool, handle)` — the caller **must** keep `handle` alive for
+    /// the duration of the test, otherwise the actor stops and every pool
+    /// operation returns `DbError::ActorStopped`.
+    fn seeded_pool(name: &str) -> (DbPool, tokio::task::JoinHandle<()>) {
+        let write_conn = open_shared_memory(name);
+        init_db(&write_conn).unwrap();
+        let read_conn = open_shared_memory(name);
+        DbPool::new(write_conn, read_conn)
+    }
+
+    /// Seed one user → category → feed whose URL points at `url`.
+    /// Returns the feed id.
+    async fn seed_feed(pool: &DbPool, url: &str) -> i64 {
+        let url = url.to_string();
+        pool.user(move |conn| {
+            let u = user::create_user(conn, "syncuser", "hash", Role::User).unwrap();
+            let cat = category::create_category(conn, u.id, "Tech").unwrap();
+            feed::create_feed(
+                conn,
+                &feed::CreateFeedParams {
+                    category_id: cat.id,
+                    url: &url,
+                    title: Some("F"),
+                    description: None,
+                    site_url: None,
+                    custom_user_agent: None,
+                    http2_disabled: None,
+                    custom_referrer: None,
+                },
+            )
+            .unwrap()
+            .id
+        })
+        .await
+        .unwrap()
+    }
+
+    /// Like `seed_feed` but allows a custom user agent override.
+    async fn seed_feed_with_ua(pool: &DbPool, url: &str, custom_user_agent: &str) -> i64 {
+        let url = url.to_string();
+        let ua = custom_user_agent.to_string();
+        pool.user(move |conn| {
+            let u = user::create_user(conn, "uauser", "hash", Role::User).unwrap();
+            let cat = category::create_category(conn, u.id, "Tech").unwrap();
+            feed::create_feed(
+                conn,
+                &feed::CreateFeedParams {
+                    category_id: cat.id,
+                    url: &url,
+                    title: Some("F"),
+                    description: None,
+                    site_url: None,
+                    custom_user_agent: Some(&ua),
+                    http2_disabled: None,
+                    custom_referrer: None,
+                },
+            )
+            .unwrap()
+            .id
+        })
+        .await
+        .unwrap()
+    }
+
+    /// Minimal two-item RSS fixture — no `<icon>` or `<logo>` elements so the
+    /// icon fetcher is never triggered. `site_url: None` on the feed achieves
+    /// the same for the favicon fallback.
+    const RSS_TWO: &str = r#"<?xml version="1.0"?><rss version="2.0"><channel><title>F</title>
+  <item><guid>g1</guid><title>One</title><link>https://e/1</link><description>c1</description>
+        <pubDate>Tue, 10 Jun 2025 10:00:00 GMT</pubDate></item>
+  <item><guid>g2</guid><title>Two</title><link>https://e/2</link><description>c2</description>
+        <pubDate>Tue, 10 Jun 2025 11:00:00 GMT</pubDate></item>
+</channel></rss>"#;
+
+    /// Same guids as RSS_TWO but with changed descriptions, to drive the
+    /// "updated entries" path.
+    const RSS_TWO_UPDATED: &str = r#"<?xml version="1.0"?><rss version="2.0"><channel><title>F</title>
+  <item><guid>g1</guid><title>One</title><link>https://e/1</link><description>c1-v2</description>
+        <pubDate>Tue, 10 Jun 2025 10:00:00 GMT</pubDate></item>
+  <item><guid>g2</guid><title>Two</title><link>https://e/2</link><description>c2-v2</description>
+        <pubDate>Tue, 10 Jun 2025 11:00:00 GMT</pubDate></item>
+</channel></rss>"#;
+
+    // ---------------------------------------------------------------------------
+    // Happy-path: new entries are inserted
+    // ---------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn refresh_feed_inserts_new_entries() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "application/rss+xml")
+                    .set_body_string(RSS_TWO),
+            )
+            .mount(&server)
+            .await;
+
+        let (pool, _handle) = seeded_pool("feed_sync_happy");
+        let feed_id = seed_feed(&pool, &server.uri()).await;
+
+        let result = refresh_feed(pool.clone(), feed_id, "RDRS-Test/1.0")
+            .await
+            .unwrap();
+        assert_eq!(result.new_entries, 2);
+        assert_eq!(result.updated_entries, 0);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Feed not found
+    // ---------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn feed_not_found() {
+        let (pool, _handle) = seeded_pool("feed_sync_not_found");
+        let err = refresh_feed(pool, 999_999, "RDRS-Test/1.0")
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, AppError::FeedNotFound),
+            "expected FeedNotFound, got {err:?}"
+        );
+    }
+
+    // ---------------------------------------------------------------------------
+    // Existing entries are updated on second sync
+    // ---------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn updates_existing_entries() {
+        let server = MockServer::start().await;
+
+        // First request: original RSS
+        Mock::given(method("GET"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "application/rss+xml")
+                    .set_body_string(RSS_TWO),
+            )
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+
+        // Second request: same guids, changed descriptions
+        Mock::given(method("GET"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "application/rss+xml")
+                    .set_body_string(RSS_TWO_UPDATED),
+            )
+            .mount(&server)
+            .await;
+
+        let (pool, _handle) = seeded_pool("feed_sync_update");
+        let feed_id = seed_feed(&pool, &server.uri()).await;
+
+        let first = refresh_feed(pool.clone(), feed_id, "RDRS-Test/1.0")
+            .await
+            .unwrap();
+        assert_eq!(first.new_entries, 2);
+
+        let second = refresh_feed(pool.clone(), feed_id, "RDRS-Test/1.0")
+            .await
+            .unwrap();
+        assert_eq!(second.new_entries, 0);
+        assert_eq!(second.updated_entries, 2);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Tombstoned guids are skipped
+    // ---------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn skips_tombstoned_guid() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "application/rss+xml")
+                    .set_body_string(RSS_TWO),
+            )
+            .mount(&server)
+            .await;
+
+        let (pool, _handle) = seeded_pool("feed_sync_tombstone");
+        let feed_id = seed_feed(&pool, &server.uri()).await;
+
+        // Tombstone g1 before the sync
+        pool.user(move |conn| entry::insert_tombstone(conn, feed_id, "g1").unwrap())
+            .await
+            .unwrap();
+
+        let result = refresh_feed(pool.clone(), feed_id, "RDRS-Test/1.0")
+            .await
+            .unwrap();
+        assert_eq!(result.new_entries, 1, "g1 should be skipped");
+
+        // Verify g1 was not inserted
+        let found = pool
+            .user(move |conn| entry::find_by_guid_and_feed(conn, "g1", feed_id).unwrap())
+            .await
+            .unwrap();
+        assert!(found.is_none(), "g1 must not exist (tombstoned)");
+    }
+
+    // ---------------------------------------------------------------------------
+    // 304 Not Modified returns zero counts
+    // ---------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn not_modified_304() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(304))
+            .mount(&server)
+            .await;
+
+        let (pool, _handle) = seeded_pool("feed_sync_304");
+        let feed_id = seed_feed(&pool, &server.uri()).await;
+
+        let result = refresh_feed(pool.clone(), feed_id, "RDRS-Test/1.0")
+            .await
+            .unwrap();
+        assert_eq!(result.new_entries, 0);
+        assert_eq!(result.updated_entries, 0);
+    }
+
+    // ---------------------------------------------------------------------------
+    // HTTP 4xx/5xx persists a fetch error on the feed row
+    // ---------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn http_error_persists_fetch_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let (pool, _handle) = seeded_pool("feed_sync_fetch_err");
+        let feed_id = seed_feed(&pool, &server.uri()).await;
+
+        let err = refresh_feed(pool.clone(), feed_id, "RDRS-Test/1.0")
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, AppError::FetchError(_)),
+            "expected FetchError, got {err:?}"
+        );
+
+        // Fetch error must have been written to the feed row
+        let fetch_error = pool
+            .user(move |conn| {
+                feed::find_by_id(conn, feed_id)
+                    .unwrap()
+                    .unwrap()
+                    .fetch_error
+            })
+            .await
+            .unwrap();
+        assert!(
+            fetch_error.is_some(),
+            "feed.fetch_error should be populated after HTTP error"
+        );
+    }
+
+    // ---------------------------------------------------------------------------
+    // Malformed XML returns a parse error
+    // ---------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn malformed_xml_errors() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "application/rss+xml")
+                    .set_body_string("<rss><broken"),
+            )
+            .mount(&server)
+            .await;
+
+        let (pool, _handle) = seeded_pool("feed_sync_parse_err");
+        let feed_id = seed_feed(&pool, &server.uri()).await;
+
+        let err = refresh_feed(pool.clone(), feed_id, "RDRS-Test/1.0")
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, AppError::FeedParseError(_)),
+            "expected FeedParseError, got {err:?}"
+        );
+    }
+
+    // ---------------------------------------------------------------------------
+    // Conditional-GET headers are sent when etag/last_modified are set
+    // ---------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn sends_conditional_get_headers() {
+        let server = MockServer::start().await;
+
+        // The mock verifies that If-None-Match is included; `.expect(1)` makes
+        // wiremock fail the test if the header is never seen.
+        Mock::given(method("GET"))
+            .and(header("if-none-match", "\"abc123\""))
+            .respond_with(ResponseTemplate::new(304))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let (pool, _handle) = seeded_pool("feed_sync_cond_get");
+        let feed_id = seed_feed(&pool, &server.uri()).await;
+
+        // Write etag + last_modified directly onto the feed row
+        pool.user(move |conn| {
+            feed::update_fetch_result(
+                conn,
+                feed_id,
+                chrono::Utc::now(),
+                None,
+                Some("\"abc123\""),
+                Some("Mon, 09 Jun 2025 00:00:00 GMT"),
+                None,
+            )
+            .unwrap()
+        })
+        .await
+        .unwrap();
+
+        let result = refresh_feed(pool.clone(), feed_id, "RDRS-Test/1.0")
+            .await
+            .unwrap();
+        assert_eq!(result.new_entries, 0);
+        // wiremock verifies the expectation on server drop
+    }
+
+    // ---------------------------------------------------------------------------
+    // Per-feed custom User-Agent is sent
+    // ---------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn uses_custom_user_agent() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(header("user-agent", "Custom/9"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "application/rss+xml")
+                    .set_body_string(RSS_TWO),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let (pool, _handle) = seeded_pool("feed_sync_custom_ua");
+        let feed_id = seed_feed_with_ua(&pool, &server.uri(), "Custom/9").await;
+
+        let result = refresh_feed(pool.clone(), feed_id, "RDRS-Default/1.0")
+            .await
+            .unwrap();
+        assert_eq!(result.new_entries, 2);
+        // wiremock verifies the User-Agent expectation on server drop
+    }
+
+    // ---------------------------------------------------------------------------
+    // refresh_bucket: empty bucket returns empty vec
+    // ---------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn refresh_bucket_empty() {
+        let (pool, _handle) = seeded_pool("feed_sync_bucket_empty");
+        // Use bucket 255 — no feeds hashed there in our empty DB
+        let results = refresh_bucket(pool, 255, "RDRS-Test/1.0").await;
+        assert!(results.is_empty());
+    }
+
+    // ---------------------------------------------------------------------------
+    // refresh_bucket: feeds in the bucket are synced
+    // ---------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn refresh_bucket_runs_feeds() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "application/rss+xml")
+                    .set_body_string(RSS_TWO),
+            )
+            .mount(&server)
+            .await;
+
+        let (pool, _handle) = seeded_pool("feed_sync_bucket_feeds");
+        let feed_id = seed_feed(&pool, &server.uri()).await;
+
+        // Discover which bucket the seeded feed was assigned
+        let bucket = pool
+            .user(move |conn| feed::find_by_id(conn, feed_id).unwrap().unwrap().bucket)
+            .await
+            .unwrap()
+            .expect("bucket should be set on create") as u8;
+
+        let results = refresh_bucket(pool, bucket, "RDRS-Test/1.0").await;
+
+        assert!(!results.is_empty(), "expected at least one result");
+        let matching = results.iter().find(|(id, _)| *id == feed_id);
+        assert!(matching.is_some(), "seeded feed should appear in results");
+        let (_, outcome) = matching.unwrap();
+        let sync = outcome.as_ref().expect("sync should succeed");
+        assert!(
+            sync.new_entries > 0,
+            "expected new entries from bucket sync"
+        );
+    }
 
     #[test]
     fn test_normalize_timezone_format() {

--- a/src/services/icon_fetcher.rs
+++ b/src/services/icon_fetcher.rs
@@ -210,6 +210,270 @@ fn resolve_url(href: &str, base_url: &Url) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    const PNG_BYTES: &[u8] = &[0x89, 0x50, 0x4E, 0x47]; // PNG magic; non-empty
+
+    #[tokio::test]
+    async fn fetch_image_success_returns_bytes_and_type() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "image/png")
+                    .set_body_bytes(PNG_BYTES.to_vec()),
+            )
+            .mount(&server)
+            .await;
+        let img = fetch_image(&server.uri(), "RDRS-Test/1.0")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(img.content_type, "image/png");
+        assert_eq!(img.data, PNG_BYTES);
+        assert_eq!(img.source_url, server.uri());
+    }
+
+    #[tokio::test]
+    async fn fetch_image_strips_content_type_params() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "image/svg+xml; charset=utf-8")
+                    .set_body_bytes(PNG_BYTES.to_vec()),
+            )
+            .mount(&server)
+            .await;
+        let img = fetch_image(&server.uri(), "RDRS-Test/1.0")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(img.content_type, "image/svg+xml");
+    }
+
+    #[tokio::test]
+    async fn fetch_image_non_success_is_none() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+        let result = fetch_image(&server.uri(), "RDRS-Test/1.0").await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn fetch_image_non_image_type_is_none() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/html")
+                    .set_body_bytes(b"hi".to_vec()),
+            )
+            .mount(&server)
+            .await;
+        let result = fetch_image(&server.uri(), "RDRS-Test/1.0").await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn fetch_image_missing_type_is_none() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(PNG_BYTES.to_vec()))
+            .mount(&server)
+            .await;
+        let result = fetch_image(&server.uri(), "RDRS-Test/1.0").await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn fetch_image_too_large_is_none() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "image/png")
+                    .set_body_bytes(vec![0u8; 300 * 1024]),
+            )
+            .mount(&server)
+            .await;
+        let result = fetch_image(&server.uri(), "RDRS-Test/1.0").await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn fetch_image_empty_body_is_none() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "image/png")
+                    .set_body_bytes(vec![]),
+            )
+            .mount(&server)
+            .await;
+        let result = fetch_image(&server.uri(), "RDRS-Test/1.0").await.unwrap();
+        assert!(result.is_none());
+    }
+
+    // NOTE: fetch_favicon_uses_favicon_ico is skipped because fetch_favicon constructs
+    // the favicon URL as "{scheme}://{host}/favicon.ico" using Url::host_str(), which
+    // drops the port number. This makes it impossible to point at a wiremock server
+    // running on a dynamic port without changing production code.
+
+    #[tokio::test]
+    async fn fetch_favicon_falls_back_to_html_link() {
+        let server = MockServer::start().await;
+
+        // /favicon.ico → 404 (the direct attempt will actually fail to connect on
+        // port 80 since host_str() drops the port, so this 404 is for the HTML
+        // fetch of / which goes to the site_url directly)
+        Mock::given(method("GET"))
+            .and(path("/favicon.ico"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let icon_html =
+            r#"<html><head><link rel="icon" href="/icon.png"></head></html>"#.to_string();
+        Mock::given(method("GET"))
+            .and(path("/"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/html")
+                    .set_body_string(icon_html),
+            )
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/icon.png"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "image/png")
+                    .set_body_bytes(PNG_BYTES.to_vec()),
+            )
+            .mount(&server)
+            .await;
+
+        let result = fetch_favicon(&server.uri(), "RDRS-Test/1.0").await.unwrap();
+        assert!(result.is_some());
+        let img = result.unwrap();
+        assert!(
+            img.source_url.ends_with("/icon.png"),
+            "source_url was: {}",
+            img.source_url
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_favicon_no_icon_is_none() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/favicon.ico"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let html_no_icon = r#"<html><head><title>No icon here</title></head></html>"#;
+        Mock::given(method("GET"))
+            .and(path("/"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/html")
+                    .set_body_string(html_no_icon),
+            )
+            .mount(&server)
+            .await;
+
+        let result = fetch_favicon(&server.uri(), "RDRS-Test/1.0").await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn fetch_feed_icon_prefers_icon_url() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/a"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "image/png")
+                    .set_body_bytes(PNG_BYTES.to_vec()),
+            )
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/b"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "image/png")
+                    .set_body_bytes(PNG_BYTES.to_vec()),
+            )
+            .mount(&server)
+            .await;
+
+        let icon_url = format!("{}/a", server.uri());
+        let logo_url = format!("{}/b", server.uri());
+        let result = fetch_feed_icon(Some(&icon_url), Some(&logo_url), None, "RDRS-Test/1.0")
+            .await
+            .unwrap();
+        assert!(result.is_some());
+        let img = result.unwrap();
+        assert!(
+            img.source_url.ends_with("/a"),
+            "source_url was: {}",
+            img.source_url
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_feed_icon_falls_back_to_logo() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/a"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/b"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "image/png")
+                    .set_body_bytes(PNG_BYTES.to_vec()),
+            )
+            .mount(&server)
+            .await;
+
+        let icon_url = format!("{}/a", server.uri());
+        let logo_url = format!("{}/b", server.uri());
+        let result = fetch_feed_icon(Some(&icon_url), Some(&logo_url), None, "RDRS-Test/1.0")
+            .await
+            .unwrap();
+        assert!(result.is_some());
+        let img = result.unwrap();
+        assert!(
+            img.source_url.ends_with("/b"),
+            "source_url was: {}",
+            img.source_url
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_feed_icon_all_none() {
+        let result = fetch_feed_icon(None, None, None, "RDRS-Test/1.0")
+            .await
+            .unwrap();
+        assert!(result.is_none());
+    }
 
     #[test]
     fn test_extract_href() {

--- a/src/services/icon_fetcher.rs
+++ b/src/services/icon_fetcher.rs
@@ -114,12 +114,11 @@ async fn fetch_favicon(site_url: &str, user_agent: &str) -> AppResult<Option<Fet
     };
 
     // Try /favicon.ico first
-    let favicon_url = format!(
-        "{}://{}/favicon.ico",
-        base_url.scheme(),
-        base_url.host_str().unwrap_or("")
-    );
-    if let Ok(Some(img)) = fetch_image(&favicon_url, user_agent).await {
+    let favicon_url = match base_url.join("/favicon.ico") {
+        Ok(u) => u,
+        Err(_) => return Ok(None),
+    };
+    if let Ok(Some(img)) = fetch_image(favicon_url.as_str(), user_agent).await {
         debug!("Fetched favicon from {}", favicon_url);
         return Ok(Some(img));
     }
@@ -320,18 +319,34 @@ mod tests {
         assert!(result.is_none());
     }
 
-    // NOTE: fetch_favicon_uses_favicon_ico is skipped because fetch_favicon constructs
-    // the favicon URL as "{scheme}://{host}/favicon.ico" using Url::host_str(), which
-    // drops the port number. This makes it impossible to point at a wiremock server
-    // running on a dynamic port without changing production code.
+    #[tokio::test]
+    async fn fetch_favicon_uses_favicon_ico() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/favicon.ico"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "image/x-icon")
+                    .set_body_bytes(PNG_BYTES.to_vec()),
+            )
+            .mount(&server)
+            .await;
+        let img = fetch_favicon(&server.uri(), "RDRS-Test/1.0")
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(
+            img.source_url.ends_with("/favicon.ico"),
+            "source_url was: {}",
+            img.source_url
+        );
+    }
 
     #[tokio::test]
     async fn fetch_favicon_falls_back_to_html_link() {
         let server = MockServer::start().await;
 
-        // /favicon.ico → 404 (the direct attempt will actually fail to connect on
-        // port 80 since host_str() drops the port, so this 404 is for the HTML
-        // fetch of / which goes to the site_url directly)
+        // /favicon.ico → 404 so the fallback HTML-link path is exercised
         Mock::given(method("GET"))
             .and(path("/favicon.ico"))
             .respond_with(ResponseTemplate::new(404))

--- a/src/services/save/linkding.rs
+++ b/src/services/save/linkding.rs
@@ -163,6 +163,228 @@ fn construct_bookmark_url(base_url: &str, bookmark_id: i64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use wiremock::matchers::{header, method};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[tokio::test]
+    async fn save_success_returns_bookmark_url() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(header("authorization", "Token tok123"))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({"id": 42})))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let config = LinkdingConfig {
+            api_url: server.uri(),
+            api_token: "tok123".into(),
+        };
+        let bookmark = BookmarkData {
+            url: "https://example.com/post".into(),
+            title: Some("Title".into()),
+            description: None,
+            tags: vec!["rust".into()],
+        };
+        let result = save_to_linkding(&config, &bookmark).await.unwrap();
+        assert!(result.success);
+        assert!(result.message.contains("Saved"));
+    }
+
+    #[tokio::test]
+    async fn not_configured_short_circuits() {
+        let config = LinkdingConfig {
+            api_url: "".into(),
+            api_token: "".into(),
+        };
+        let bookmark = BookmarkData {
+            url: "https://example.com".into(),
+            title: None,
+            description: None,
+            tags: vec![],
+        };
+        let result = save_to_linkding(&config, &bookmark).await.unwrap();
+        assert!(!result.success);
+        assert!(result.message.contains("not configured"));
+    }
+
+    #[tokio::test]
+    async fn duplicate_returns_friendly_message() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(
+                ResponseTemplate::new(400).set_body_string(r#"{"url":["already exists"]}"#),
+            )
+            .mount(&server)
+            .await;
+        let config = LinkdingConfig {
+            api_url: server.uri(),
+            api_token: "tok".into(),
+        };
+        let bookmark = BookmarkData {
+            url: "https://example.com".into(),
+            title: None,
+            description: None,
+            tags: vec![],
+        };
+        let result = save_to_linkding(&config, &bookmark).await.unwrap();
+        assert!(!result.success);
+        assert!(result.message.contains("already exists"));
+    }
+
+    #[tokio::test]
+    async fn bad_request_other() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(400).set_body_string("bad field"))
+            .mount(&server)
+            .await;
+        let config = LinkdingConfig {
+            api_url: server.uri(),
+            api_token: "tok".into(),
+        };
+        let bookmark = BookmarkData {
+            url: "https://example.com".into(),
+            title: None,
+            description: None,
+            tags: vec![],
+        };
+        let result = save_to_linkding(&config, &bookmark).await.unwrap();
+        assert!(!result.success);
+        assert!(result.message.contains("Bad request"));
+    }
+
+    #[tokio::test]
+    async fn invalid_token_401() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(401))
+            .mount(&server)
+            .await;
+        let config = LinkdingConfig {
+            api_url: server.uri(),
+            api_token: "bad-token".into(),
+        };
+        let bookmark = BookmarkData {
+            url: "https://example.com".into(),
+            title: None,
+            description: None,
+            tags: vec![],
+        };
+        let result = save_to_linkding(&config, &bookmark).await.unwrap();
+        assert!(!result.success);
+        assert!(result.message.contains("Invalid API token"));
+    }
+
+    #[tokio::test]
+    async fn forbidden_403() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(403))
+            .mount(&server)
+            .await;
+        let config = LinkdingConfig {
+            api_url: server.uri(),
+            api_token: "tok".into(),
+        };
+        let bookmark = BookmarkData {
+            url: "https://example.com".into(),
+            title: None,
+            description: None,
+            tags: vec![],
+        };
+        let result = save_to_linkding(&config, &bookmark).await.unwrap();
+        assert!(!result.success);
+        assert!(result.message.contains("forbidden"));
+    }
+
+    #[tokio::test]
+    async fn not_found_404() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+        let config = LinkdingConfig {
+            api_url: server.uri(),
+            api_token: "tok".into(),
+        };
+        let bookmark = BookmarkData {
+            url: "https://example.com".into(),
+            title: None,
+            description: None,
+            tags: vec![],
+        };
+        let result = save_to_linkding(&config, &bookmark).await.unwrap();
+        assert!(!result.success);
+        assert!(result.message.contains("endpoint not found"));
+    }
+
+    #[tokio::test]
+    async fn server_error_500() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(500).set_body_string("boom"))
+            .mount(&server)
+            .await;
+        let config = LinkdingConfig {
+            api_url: server.uri(),
+            api_token: "tok".into(),
+        };
+        let bookmark = BookmarkData {
+            url: "https://example.com".into(),
+            title: None,
+            description: None,
+            tags: vec![],
+        };
+        let result = save_to_linkding(&config, &bookmark).await.unwrap();
+        assert!(!result.success);
+        assert!(result.message.contains("Linkding error (500"));
+    }
+
+    #[tokio::test]
+    async fn malformed_json_errors() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(201).set_body_string("{not json"))
+            .mount(&server)
+            .await;
+        let config = LinkdingConfig {
+            api_url: server.uri(),
+            api_token: "tok".into(),
+        };
+        let bookmark = BookmarkData {
+            url: "https://example.com".into(),
+            title: None,
+            description: None,
+            tags: vec![],
+        };
+        let result = save_to_linkding(&config, &bookmark).await;
+        assert!(matches!(result, Err(AppError::Internal(_))));
+    }
+
+    #[tokio::test]
+    async fn omits_empty_optional_fields() {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(wiremock::matchers::body_json(
+                serde_json::json!({"url": "https://x/"}),
+            ))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({"id": 1})))
+            .mount(&server)
+            .await;
+        let config = LinkdingConfig {
+            api_url: server.uri(),
+            api_token: "tok".into(),
+        };
+        let bookmark = BookmarkData {
+            url: "https://x/".into(),
+            title: None,
+            description: None,
+            tags: vec![],
+        };
+        let result = save_to_linkding(&config, &bookmark).await.unwrap();
+        assert!(result.success);
+    }
 
     #[test]
     fn test_normalize_api_url() {

--- a/src/services/save/mod.rs
+++ b/src/services/save/mod.rs
@@ -67,3 +67,33 @@ impl SaveServicesConfig {
         !self.configured_services().is_empty()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn save_services_config_json_roundtrip() {
+        let json = r#"{"linkding":{"api_url":"https://l","api_token":"t"}}"#;
+        let cfg = SaveServicesConfig::from_json(json).unwrap();
+        assert!(cfg.has_any_service());
+        let back = cfg.to_json().unwrap();
+        assert!(back.contains("https://l"));
+    }
+
+    #[test]
+    fn empty_config_has_no_service() {
+        let cfg = SaveServicesConfig::from_json("{}").unwrap();
+        assert!(!cfg.has_any_service());
+        assert!(cfg.configured_services().is_empty());
+    }
+
+    #[test]
+    fn configured_services_lists_linkding() {
+        let cfg = SaveServicesConfig::from_json(
+            r#"{"linkding":{"api_url":"https://l","api_token":"t"}}"#,
+        )
+        .unwrap();
+        assert_eq!(cfg.configured_services(), vec!["linkding"]);
+    }
+}

--- a/src/services/summarize/kagi.rs
+++ b/src/services/summarize/kagi.rs
@@ -42,8 +42,18 @@ pub struct SummarizeResult {
     pub error: Option<String>,
 }
 
+const KAGI_API_BASE: &str = "https://kagi.com";
+
 /// Summarize a URL using Kagi Universal Summarizer
 pub async fn summarize_url(config: &KagiConfig, url: &str) -> AppResult<SummarizeResult> {
+    summarize_url_with_base(KAGI_API_BASE, config, url).await
+}
+
+async fn summarize_url_with_base(
+    base: &str,
+    config: &KagiConfig,
+    url: &str,
+) -> AppResult<SummarizeResult> {
     if !config.is_configured() {
         return Ok(SummarizeResult {
             success: false,
@@ -58,7 +68,7 @@ pub async fn summarize_url(config: &KagiConfig, url: &str) -> AppResult<Summariz
         .map_err(|e| AppError::Internal(format!("Failed to build HTTP client: {}", e)))?;
 
     // Build the API URL with query parameters
-    let mut api_url = url::Url::parse("https://kagi.com/mother/summary_labs")
+    let mut api_url = url::Url::parse(&format!("{}/mother/summary_labs", base))
         .map_err(|e| AppError::Internal(format!("Failed to parse Kagi API URL: {}", e)))?;
 
     {
@@ -144,6 +154,8 @@ pub async fn summarize_url(config: &KagiConfig, url: &str) -> AppResult<Summariz
 #[cfg(test)]
 mod tests {
     use super::*;
+    use wiremock::matchers::{header, method, query_param};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     #[test]
     fn test_kagi_config_is_configured() {
@@ -181,5 +193,223 @@ mod tests {
 
         assert_eq!(config.session_token, "test");
         assert!(config.language.is_none());
+    }
+
+    #[tokio::test]
+    async fn summarize_success_strips_title_prefix() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(header("authorization", "session-tok"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "output_data": {"markdown": "Title: Foo\n\nThe body."}
+            })))
+            .mount(&server)
+            .await;
+        let config = KagiConfig {
+            session_token: "session-tok".into(),
+            language: None,
+        };
+        let result = summarize_url_with_base(&server.uri(), &config, "https://x.com/a")
+            .await
+            .unwrap();
+        assert!(result.success);
+        assert_eq!(result.output_text.as_deref(), Some("The body."));
+    }
+
+    #[tokio::test]
+    async fn not_configured() {
+        let config = KagiConfig {
+            session_token: "".into(),
+            language: None,
+        };
+        // No mock server needed — the not-configured early return fires before any HTTP call
+        let result = summarize_url_with_base("http://unused.invalid", &config, "https://x.com/a")
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result
+            .error
+            .as_deref()
+            .unwrap_or("")
+            .contains("not configured"));
+    }
+
+    #[tokio::test]
+    async fn markdown_without_title_prefix() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "output_data": {"markdown": "Plain body"}
+            })))
+            .mount(&server)
+            .await;
+        let config = KagiConfig {
+            session_token: "tok".into(),
+            language: None,
+        };
+        let result = summarize_url_with_base(&server.uri(), &config, "https://x.com/a")
+            .await
+            .unwrap();
+        assert!(result.success);
+        assert_eq!(result.output_text.as_deref(), Some("Plain body"));
+    }
+
+    #[tokio::test]
+    async fn error_field_in_body() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "error": "nope"
+            })))
+            .mount(&server)
+            .await;
+        let config = KagiConfig {
+            session_token: "tok".into(),
+            language: None,
+        };
+        let result = summarize_url_with_base(&server.uri(), &config, "https://x.com/a")
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert_eq!(result.error.as_deref(), Some("nope"));
+    }
+
+    #[tokio::test]
+    async fn no_output_data() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+            .mount(&server)
+            .await;
+        let config = KagiConfig {
+            session_token: "tok".into(),
+            language: None,
+        };
+        let result = summarize_url_with_base(&server.uri(), &config, "https://x.com/a")
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result.error.as_deref().unwrap_or("").contains("No summary"));
+    }
+
+    #[tokio::test]
+    async fn invalid_token_401() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(401))
+            .mount(&server)
+            .await;
+        let config = KagiConfig {
+            session_token: "tok".into(),
+            language: None,
+        };
+        let result = summarize_url_with_base(&server.uri(), &config, "https://x.com/a")
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result
+            .error
+            .as_deref()
+            .unwrap_or("")
+            .contains("Invalid session token"));
+    }
+
+    #[tokio::test]
+    async fn forbidden_403() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(403))
+            .mount(&server)
+            .await;
+        let config = KagiConfig {
+            session_token: "tok".into(),
+            language: None,
+        };
+        let result = summarize_url_with_base(&server.uri(), &config, "https://x.com/a")
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result
+            .error
+            .as_deref()
+            .unwrap_or("")
+            .contains("Access forbidden"));
+    }
+
+    #[tokio::test]
+    async fn rate_limited_429() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(429))
+            .mount(&server)
+            .await;
+        let config = KagiConfig {
+            session_token: "tok".into(),
+            language: None,
+        };
+        let result = summarize_url_with_base(&server.uri(), &config, "https://x.com/a")
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result.error.as_deref().unwrap_or("").contains("Rate limit"));
+    }
+
+    #[tokio::test]
+    async fn server_error_500() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(500).set_body_string("x"))
+            .mount(&server)
+            .await;
+        let config = KagiConfig {
+            session_token: "tok".into(),
+            language: None,
+        };
+        let result = summarize_url_with_base(&server.uri(), &config, "https://x.com/a")
+            .await
+            .unwrap();
+        assert!(!result.success);
+        assert!(result
+            .error
+            .as_deref()
+            .unwrap_or("")
+            .contains("Kagi error (500"));
+    }
+
+    #[tokio::test]
+    async fn malformed_json() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("{bad"))
+            .mount(&server)
+            .await;
+        let config = KagiConfig {
+            session_token: "tok".into(),
+            language: None,
+        };
+        let result = summarize_url_with_base(&server.uri(), &config, "https://x.com/a").await;
+        assert!(matches!(result, Err(AppError::Internal(_))));
+    }
+
+    #[tokio::test]
+    async fn language_adds_query_param() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(query_param("target_language", "fr"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "output_data": {"markdown": "Résumé"}
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        let config = KagiConfig {
+            session_token: "tok".into(),
+            language: Some("fr".into()),
+        };
+        let result = summarize_url_with_base(&server.uri(), &config, "https://x.com/a")
+            .await
+            .unwrap();
+        assert!(result.success);
+        // MockServer verifies the query param expectation on drop
     }
 }

--- a/tests/greader_test.rs
+++ b/tests/greader_test.rs
@@ -21,6 +21,8 @@ use rdrs::models::{category, entry, feed};
 use rdrs::{auth, create_router, db, services, AppState, Config, DbPool};
 use rusqlite::Connection;
 use serde_json::json;
+use wiremock::matchers::{method, path_regex};
+use wiremock::{Mock, MockServer, ResponseTemplate};
 
 struct TestApp {
     server: TestServer,
@@ -788,4 +790,289 @@ async fn test_unauthenticated_access_denied() {
         .get("/reader/api/0/stream/contents/user/-/state/com.google/reading-list")
         .await;
     assert_eq!(response.status_code(), StatusCode::UNAUTHORIZED);
+}
+
+// ============================================================================
+// RSS fixture used by wiremock-based subscribe/quickadd tests
+// ============================================================================
+
+const RSS_FIXTURE: &str = r#"<?xml version="1.0"?><rss version="2.0"><channel>
+  <title>Mock Feed</title><description>D</description><link>https://e</link>
+  <item><guid>m1</guid><title>One</title><link>https://e/1</link><description>c1</description></item>
+</channel></rss>"#;
+
+// ============================================================================
+// Part A — pure validation / edit tests (no network required)
+// ============================================================================
+
+#[tokio::test]
+async fn test_subscription_subscribe_missing_stream_id() {
+    let app = create_test_app(default_test_config());
+    setup_authenticated_user(&app).await;
+
+    // POST ac=subscribe without `s` → 400 Bad Request
+    let form = vec![("ac", "subscribe".to_string())];
+    let response = app
+        .server
+        .post("/reader/api/0/subscription/edit")
+        .form(&form)
+        .await;
+    response.assert_status(StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_subscription_subscribe_bad_prefix() {
+    let app = create_test_app(default_test_config());
+    setup_authenticated_user(&app).await;
+
+    // Stream ID must start with "feed/"; bare URL should be rejected with 400
+    let form = vec![
+        ("ac", "subscribe".to_string()),
+        ("s", "https://example.com/feed.xml".to_string()),
+    ];
+    let response = app
+        .server
+        .post("/reader/api/0/subscription/edit")
+        .form(&form)
+        .await;
+    response.assert_status(StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_subscription_subscribe_empty_url() {
+    let app = create_test_app(default_test_config());
+    setup_authenticated_user(&app).await;
+
+    // "feed/" with nothing after the slash → empty URL → 400
+    let form = vec![("ac", "subscribe".to_string()), ("s", "feed/".to_string())];
+    let response = app
+        .server
+        .post("/reader/api/0/subscription/edit")
+        .form(&form)
+        .await;
+    response.assert_status(StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_subscription_edit_feed_not_found() {
+    let app = create_test_app(default_test_config());
+    setup_authenticated_user(&app).await;
+
+    // ac=edit with a URL that doesn't exist in the DB → 404
+    let form = vec![
+        ("ac", "edit".to_string()),
+        (
+            "s",
+            "feed/https://does-not-exist.example.com/rss".to_string(),
+        ),
+    ];
+    let response = app
+        .server
+        .post("/reader/api/0/subscription/edit")
+        .form(&form)
+        .await;
+    response.assert_status(StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_subscription_edit_add_label_moves_category() {
+    let app = create_test_app(default_test_config());
+    let user_id = setup_authenticated_user(&app).await;
+
+    let feed_url = "https://example.com/feed-to-move.xml";
+    create_test_feed(&app.db, user_id, "OldCat", feed_url).await;
+
+    // Move to a new category via ac=edit + a=user/-/label/NewCat
+    let form = vec![
+        ("ac", "edit".to_string()),
+        ("s", format!("feed/{}", feed_url)),
+        ("a", "user/-/label/NewCat".to_string()),
+    ];
+    let response = app
+        .server
+        .post("/reader/api/0/subscription/edit")
+        .form(&form)
+        .await;
+    response.assert_status_ok();
+
+    // DB: feed's category should now be "NewCat"
+    let found_url = feed_url.to_string();
+    let (cat_name, _feed_title) = app
+        .db
+        .user(move |conn| {
+            let f = feed::find_by_url_for_user(conn, &found_url, user_id)?
+                .ok_or(rdrs::error::AppError::FeedNotFound)?;
+            let cats = category::list_by_user(conn, user_id)?;
+            let cat = cats
+                .into_iter()
+                .find(|c| c.id == f.category_id)
+                .ok_or(rdrs::error::AppError::CategoryNotFound)?;
+            Ok::<_, rdrs::error::AppError>((cat.name, f.title))
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(cat_name, "NewCat");
+}
+
+// ============================================================================
+// Part B — wiremock subscribe / quickadd success tests
+// ============================================================================
+
+#[tokio::test]
+async fn test_subscription_subscribe_success() {
+    let mock_server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path_regex(".*"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string(RSS_FIXTURE)
+                .insert_header("content-type", "application/rss+xml"),
+        )
+        .mount(&mock_server)
+        .await;
+
+    let app = create_test_app(default_test_config());
+    let user_id = setup_authenticated_user(&app).await;
+
+    let feed_url = mock_server.uri();
+    let form = vec![
+        ("ac", "subscribe".to_string()),
+        ("s", format!("feed/{}", feed_url)),
+    ];
+    let response = app
+        .server
+        .post("/reader/api/0/subscription/edit")
+        .form(&form)
+        .await;
+    response.assert_status_ok();
+
+    // Verify feed row exists in the DB for this user
+    let url_clone = feed_url.clone();
+    let feed_exists = app
+        .db
+        .user(move |conn| {
+            Ok::<_, rdrs::error::AppError>(
+                feed::find_by_url_for_user(conn, &url_clone, user_id)?.is_some(),
+            )
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(feed_exists, "feed row should exist after subscribe");
+}
+
+#[tokio::test]
+async fn test_subscription_subscribe_with_label() {
+    let mock_server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path_regex(".*"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string(RSS_FIXTURE)
+                .insert_header("content-type", "application/rss+xml"),
+        )
+        .mount(&mock_server)
+        .await;
+
+    let app = create_test_app(default_test_config());
+    let user_id = setup_authenticated_user(&app).await;
+
+    let feed_url = mock_server.uri();
+    let form = vec![
+        ("ac", "subscribe".to_string()),
+        ("s", format!("feed/{}", feed_url)),
+        ("a", "user/-/label/Tech".to_string()),
+    ];
+    let response = app
+        .server
+        .post("/reader/api/0/subscription/edit")
+        .form(&form)
+        .await;
+    response.assert_status_ok();
+
+    // Verify feed is under the "Tech" category
+    let url_clone = feed_url.clone();
+    let cat_name = app
+        .db
+        .user(move |conn| {
+            let f = feed::find_by_url_for_user(conn, &url_clone, user_id)?
+                .ok_or(rdrs::error::AppError::FeedNotFound)?;
+            let cats = category::list_by_user(conn, user_id)?;
+            let cat = cats
+                .into_iter()
+                .find(|c| c.id == f.category_id)
+                .ok_or(rdrs::error::AppError::CategoryNotFound)?;
+            Ok::<_, rdrs::error::AppError>(cat.name)
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(cat_name, "Tech");
+}
+
+#[tokio::test]
+async fn test_subscription_subscribe_duplicate() {
+    let mock_server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path_regex(".*"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string(RSS_FIXTURE)
+                .insert_header("content-type", "application/rss+xml"),
+        )
+        .mount(&mock_server)
+        .await;
+
+    let app = create_test_app(default_test_config());
+    let user_id = setup_authenticated_user(&app).await;
+
+    // Pre-create the feed in the DB (same URL the mock server serves)
+    let feed_url = mock_server.uri();
+    create_test_feed(&app.db, user_id, "Existing", &feed_url).await;
+
+    // Attempt to subscribe again → 409 CONFLICT (AppError::FeedExists)
+    let form = vec![
+        ("ac", "subscribe".to_string()),
+        ("s", format!("feed/{}", feed_url)),
+    ];
+    let response = app
+        .server
+        .post("/reader/api/0/subscription/edit")
+        .form(&form)
+        .await;
+    response.assert_status(StatusCode::CONFLICT);
+}
+
+#[tokio::test]
+async fn test_quickadd_success() {
+    let mock_server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path_regex(".*"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string(RSS_FIXTURE)
+                .insert_header("content-type", "application/rss+xml"),
+        )
+        .mount(&mock_server)
+        .await;
+
+    let app = create_test_app(default_test_config());
+    setup_authenticated_user(&app).await;
+
+    let feed_url = mock_server.uri();
+    let form = vec![("quickadd", feed_url.clone())];
+    let response = app
+        .server
+        .post("/reader/api/0/subscription/quickadd")
+        .form(&form)
+        .await;
+    response.assert_status_ok();
+
+    let body: serde_json::Value = response.json();
+    assert_eq!(body["numResults"].as_i64().unwrap(), 1);
+    assert_eq!(
+        body["streamId"].as_str().unwrap(),
+        format!("feed/{}", feed_url)
+    );
 }

--- a/tests/handlers_test.rs
+++ b/tests/handlers_test.rs
@@ -4670,3 +4670,585 @@ async fn test_sidebar_unread_returns_payload() {
         "payload must contain unread:2 in: {html}"
     );
 }
+
+// ============================================================================
+// handlers/feeds.rs — additional branch coverage (Part A: pure-DB tests)
+// ============================================================================
+
+#[tokio::test]
+async fn test_edit_feed_form_empty_url() {
+    let app = create_test_app_named(default_test_config(), "test_edit_feed_empty_url");
+    setup_authenticated_user(&app.server).await;
+    let (cat_id, feed_id) =
+        insert_test_feed(&app, "Tech", "https://empty-url-test.example.com/feed.xml").await;
+
+    let response = app
+        .server
+        .post(&format!("/feeds/{}/edit", feed_id))
+        .form(&json!({
+            "url": "",
+            "title": "Test Feed",
+            "description": "",
+            "site_url": "",
+            "category_id": cat_id,
+            "custom_user_agent": "",
+            "custom_referrer": "",
+        }))
+        .await;
+
+    // Empty url → error flash redirect back to the edit page.
+    response.assert_status(StatusCode::SEE_OTHER);
+    assert_eq!(
+        response.header(header::LOCATION),
+        format!("/feeds/{}/edit", feed_id)
+    );
+
+    // Verify url unchanged in DB.
+    let url: String = app
+        .db
+        .user(move |conn| {
+            conn.query_row(
+                "SELECT url FROM feed WHERE id = ?1",
+                rusqlite::params![feed_id],
+                |row| row.get(0),
+            )
+            .unwrap()
+        })
+        .await
+        .unwrap();
+    assert_eq!(url, "https://empty-url-test.example.com/feed.xml");
+}
+
+#[tokio::test]
+async fn test_edit_feed_form_not_found() {
+    let app = create_test_app_named(default_test_config(), "test_edit_feed_not_found");
+    setup_authenticated_user(&app.server).await;
+    let (cat_id, _) =
+        insert_test_feed(&app, "Tech", "https://notfound-test.example.com/feed.xml").await;
+
+    let response = app
+        .server
+        .post("/feeds/999999/edit")
+        .form(&json!({
+            "url": "https://notfound-test.example.com/feed.xml",
+            "title": "Test",
+            "description": "",
+            "site_url": "",
+            "category_id": cat_id,
+            "custom_user_agent": "",
+            "custom_referrer": "",
+        }))
+        .await;
+
+    // Not found → error flash redirect (no crash).
+    response.assert_status(StatusCode::SEE_OTHER);
+    assert_eq!(response.header(header::LOCATION), "/feeds/999999/edit");
+}
+
+#[tokio::test]
+async fn test_edit_feed_form_other_users_feed() {
+    let app = create_test_app_named(default_test_config(), "test_edit_other_user_feed");
+    setup_authenticated_user(&app.server).await;
+
+    // Seed a feed under a different user (not testuser).
+    let other_feed_id: i64 = app
+        .db
+        .user(|conn| {
+            let other_uid: i64 = conn
+                .execute(
+                    "INSERT INTO user (username, password_hash, role) VALUES ('other_editfeed', 'x', 'user')",
+                    [],
+                )
+                .map(|_| conn.last_insert_rowid())
+                .unwrap();
+            let cat =
+                rdrs::models::category::create_category(conn, other_uid, "OtherCat").unwrap();
+            rdrs::models::feed::create_feed(
+                conn,
+                &rdrs::models::feed::CreateFeedParams {
+                    category_id: cat.id,
+                    url: "https://other-edit.example.com/feed.xml",
+                    title: Some("Other Feed"),
+                    description: None,
+                    site_url: None,
+                    custom_user_agent: None,
+                    http2_disabled: None,
+                    custom_referrer: None,
+                },
+            )
+            .unwrap()
+            .id
+        })
+        .await
+        .unwrap();
+
+    // testuser tries to edit the other user's feed — the handler checks
+    // category ownership (find_by_id_and_user on the feed's category)
+    // which fails because the category belongs to other_editfeed.
+    let response = app
+        .server
+        .post(&format!("/feeds/{}/edit", other_feed_id))
+        .form(&json!({
+            "url": "https://other-edit.example.com/feed.xml",
+            "title": "Hacked",
+            "description": "",
+            "site_url": "",
+            "category_id": 1,
+            "custom_user_agent": "",
+            "custom_referrer": "",
+        }))
+        .await;
+
+    response.assert_status(StatusCode::SEE_OTHER);
+
+    // The other user's feed must be unchanged.
+    let title: String = app
+        .db
+        .user(move |conn| {
+            conn.query_row(
+                "SELECT title FROM feed WHERE id = ?1",
+                rusqlite::params![other_feed_id],
+                |row| row.get(0),
+            )
+            .unwrap()
+        })
+        .await
+        .unwrap();
+    assert_eq!(title, "Other Feed");
+}
+
+#[tokio::test]
+async fn test_edit_feed_form_category_not_owned() {
+    let app = create_test_app_named(default_test_config(), "test_edit_feed_cat_not_owned");
+    setup_authenticated_user(&app.server).await;
+    let (cat_id, feed_id) = insert_test_feed(
+        &app,
+        "OwnedCat",
+        "https://cat-not-owned.example.com/feed.xml",
+    )
+    .await;
+
+    // Create a category that belongs to a different user.
+    let other_cat_id: i64 = app
+        .db
+        .user(|conn| {
+            let other_uid: i64 = conn
+                .execute(
+                    "INSERT INTO user (username, password_hash, role) VALUES ('other_catowner', 'x', 'user')",
+                    [],
+                )
+                .map(|_| conn.last_insert_rowid())
+                .unwrap();
+            rdrs::models::category::create_category(conn, other_uid, "NotMyCategory")
+                .unwrap()
+                .id
+        })
+        .await
+        .unwrap();
+
+    // testuser tries to move their feed into the other user's category.
+    let response = app
+        .server
+        .post(&format!("/feeds/{}/edit", feed_id))
+        .form(&json!({
+            "url": "https://cat-not-owned.example.com/feed.xml",
+            "title": "Test Feed",
+            "description": "",
+            "site_url": "",
+            "category_id": other_cat_id,
+            "custom_user_agent": "",
+            "custom_referrer": "",
+        }))
+        .await;
+
+    response.assert_status(StatusCode::SEE_OTHER);
+
+    // The feed's category must remain unchanged.
+    let actual_cat: i64 = app
+        .db
+        .user(move |conn| {
+            conn.query_row(
+                "SELECT category_id FROM feed WHERE id = ?1",
+                rusqlite::params![feed_id],
+                |row| row.get(0),
+            )
+            .unwrap()
+        })
+        .await
+        .unwrap();
+    assert_eq!(actual_cat, cat_id);
+}
+
+#[tokio::test]
+async fn test_edit_feed_form_clear_user_agent() {
+    let app = create_test_app_named(default_test_config(), "test_edit_feed_clear_ua");
+    setup_authenticated_user(&app.server).await;
+
+    // Seed a feed and set a custom_user_agent on it directly.
+    let (cat_id, feed_id) =
+        insert_test_feed(&app, "Tech", "https://clear-ua.example.com/feed.xml").await;
+    app.db
+        .user(move |conn| {
+            conn.execute(
+                "UPDATE feed SET custom_user_agent = 'MyBot/1.0' WHERE id = ?1",
+                rusqlite::params![feed_id],
+            )
+            .unwrap();
+        })
+        .await
+        .unwrap();
+
+    // POST edit with _clear_user_agent=on
+    let response = app
+        .server
+        .post(&format!("/feeds/{}/edit", feed_id))
+        .form(&json!({
+            "url": "https://clear-ua.example.com/feed.xml",
+            "title": "Test Feed",
+            "description": "",
+            "site_url": "",
+            "category_id": cat_id,
+            "custom_user_agent": "",
+            "custom_referrer": "",
+            "_clear_user_agent": "on",
+        }))
+        .await;
+
+    response.assert_status(StatusCode::SEE_OTHER);
+    assert_eq!(
+        response.header(header::LOCATION),
+        format!("/feeds/{}/edit", feed_id)
+    );
+
+    // custom_user_agent must now be NULL.
+    let ua: Option<String> = app
+        .db
+        .user(move |conn| {
+            conn.query_row(
+                "SELECT custom_user_agent FROM feed WHERE id = ?1",
+                rusqlite::params![feed_id],
+                |row| row.get(0),
+            )
+            .unwrap()
+        })
+        .await
+        .unwrap();
+    assert!(
+        ua.is_none(),
+        "custom_user_agent should be NULL after _clear_user_agent=on, got: {:?}",
+        ua
+    );
+}
+
+#[tokio::test]
+async fn test_delete_feed_form_not_found() {
+    let app = create_test_app_named(default_test_config(), "test_delete_feed_not_found");
+    setup_authenticated_user(&app.server).await;
+
+    let response = app.server.post("/feeds/999999/delete").await;
+
+    response.assert_status(StatusCode::SEE_OTHER);
+    assert_eq!(response.header(header::LOCATION), "/feeds");
+}
+
+#[tokio::test]
+async fn test_import_opml_form_invalid() {
+    let app = create_test_app_named(default_test_config(), "test_import_opml_invalid_form");
+    setup_authenticated_user(&app.server).await;
+
+    let invalid_xml = b"<not valid opml";
+    let part = Part::bytes(invalid_xml.as_ref())
+        .file_name("bad.opml")
+        .mime_type("application/xml");
+    let form = MultipartForm::new().add_part("file", part);
+    let response = app.server.post("/feeds/import").multipart(form).await;
+
+    // Parse error → error flash redirect to /feeds/import.
+    response.assert_status(StatusCode::SEE_OTHER);
+    assert_eq!(response.header(header::LOCATION), "/feeds/import");
+
+    // No feeds created.
+    let count: i64 = app
+        .db
+        .user(|conn| {
+            conn.query_row("SELECT COUNT(*) FROM feed", [], |row| row.get(0))
+                .unwrap()
+        })
+        .await
+        .unwrap();
+    assert_eq!(count, 0);
+}
+
+#[tokio::test]
+async fn test_import_opml_form_duplicate_skipped() {
+    let app = create_test_app_named(default_test_config(), "test_import_opml_dup_skipped");
+    setup_authenticated_user(&app.server).await;
+
+    // Pre-seed a feed with a specific URL in a specific category.
+    let feed_url = "https://dup-import.example.com/feed.xml";
+    insert_test_feed(&app, "DupCat", feed_url).await;
+
+    // Import OPML containing the same URL under the same category name.
+    let opml = format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<opml version="2.0">
+  <head><title>Dup Test</title></head>
+  <body>
+    <outline text="DupCat" title="DupCat">
+      <outline type="rss" text="Dup Feed" xmlUrl="{feed_url}"/>
+    </outline>
+  </body>
+</opml>"#
+    );
+    let part = Part::bytes(opml.into_bytes())
+        .file_name("subs.opml")
+        .mime_type("application/xml");
+    let form = MultipartForm::new().add_part("file", part);
+    let response = app.server.post("/feeds/import").multipart(form).await;
+
+    response.assert_status(StatusCode::SEE_OTHER);
+    assert_eq!(response.header(header::LOCATION), "/feeds");
+
+    // Feed count for that URL must still be 1 (duplicate skipped).
+    let count: i64 = app
+        .db
+        .user(move |conn| {
+            conn.query_row(
+                "SELECT COUNT(*) FROM feed WHERE url = ?1",
+                rusqlite::params![feed_url],
+                |row| row.get(0),
+            )
+            .unwrap()
+        })
+        .await
+        .unwrap();
+    assert_eq!(
+        count, 1,
+        "duplicate import must not create a second feed row"
+    );
+}
+
+// ============================================================================
+// handlers/feeds.rs — Part B: wiremock success-arm tests
+// ============================================================================
+
+const RSS_FIXTURE: &str = r#"<?xml version="1.0"?><rss version="2.0"><channel>
+  <title>Mock Feed</title><description>Mock Desc</description><link>https://e</link>
+  <item><guid>m1</guid><title>One</title><link>https://e/1</link><description>c1</description></item>
+</channel></rss>"#;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_create_feed_form_success() {
+    use wiremock::matchers::{any, method};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let app = create_test_app_named(default_test_config(), "test_create_feed_success");
+    setup_authenticated_user(&app.server).await;
+
+    // Get the owned category id (the seeded "Uncategorized").
+    let cat_id: i64 = app
+        .db
+        .user(|conn| {
+            conn.query_row("SELECT id FROM category LIMIT 1", [], |row| row.get(0))
+                .unwrap()
+        })
+        .await
+        .unwrap();
+
+    let mock_server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(any())
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string(RSS_FIXTURE)
+                .insert_header("content-type", "application/rss+xml"),
+        )
+        .mount(&mock_server)
+        .await;
+
+    let feed_url = mock_server.uri();
+
+    let response = app
+        .server
+        .post("/feeds")
+        .form(&json!({ "url": feed_url, "category_id": cat_id }))
+        .await;
+
+    response.assert_status(StatusCode::SEE_OTHER);
+    assert_eq!(response.header(header::LOCATION), "/feeds");
+
+    // One feed row with that URL must exist.
+    let count: i64 = app
+        .db
+        .user(move |conn| {
+            conn.query_row(
+                "SELECT COUNT(*) FROM feed WHERE url = ?1",
+                rusqlite::params![feed_url],
+                |row| row.get(0),
+            )
+            .unwrap()
+        })
+        .await
+        .unwrap();
+    assert_eq!(count, 1, "feed should have been created in the DB");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_create_feed_form_duplicate() {
+    use wiremock::matchers::{any, method};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let app = create_test_app_named(default_test_config(), "test_create_feed_dup");
+    setup_authenticated_user(&app.server).await;
+
+    let mock_server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(any())
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string(RSS_FIXTURE)
+                .insert_header("content-type", "application/rss+xml"),
+        )
+        .mount(&mock_server)
+        .await;
+
+    let feed_url = mock_server.uri();
+
+    // Pre-create the feed.
+    insert_test_feed(&app, "Tech", &feed_url).await;
+
+    let cat_id: i64 = app
+        .db
+        .user(|conn| {
+            conn.query_row("SELECT id FROM category LIMIT 1", [], |row| row.get(0))
+                .unwrap()
+        })
+        .await
+        .unwrap();
+
+    // POST create with the same URL.
+    let response = app
+        .server
+        .post("/feeds")
+        .form(&json!({ "url": feed_url, "category_id": cat_id }))
+        .await;
+
+    response.assert_status(StatusCode::SEE_OTHER);
+    assert_eq!(response.header(header::LOCATION), "/feeds");
+
+    // Feed count must still be 1.
+    let count: i64 = app
+        .db
+        .user(move |conn| {
+            conn.query_row(
+                "SELECT COUNT(*) FROM feed WHERE url = ?1",
+                rusqlite::params![feed_url],
+                |row| row.get(0),
+            )
+            .unwrap()
+        })
+        .await
+        .unwrap();
+    assert_eq!(count, 1, "duplicate create must not add a second feed row");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_refresh_feed_form_success() {
+    use wiremock::matchers::{any, method};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let app = create_test_app_named(default_test_config(), "test_refresh_feed_success");
+    setup_authenticated_user(&app.server).await;
+
+    let mock_server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(any())
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string(RSS_FIXTURE)
+                .insert_header("content-type", "application/rss+xml"),
+        )
+        .mount(&mock_server)
+        .await;
+
+    let feed_url = mock_server.uri();
+    let (_, feed_id) = insert_test_feed(&app, "Tech", &feed_url).await;
+
+    let response = app
+        .server
+        .post(&format!("/feeds/{}/refresh", feed_id))
+        .await;
+
+    response.assert_status(StatusCode::SEE_OTHER);
+    assert_eq!(response.header(header::LOCATION), "/feeds");
+
+    // At least 1 entry should have been synced.
+    let entry_count: i64 = app
+        .db
+        .user(move |conn| {
+            conn.query_row(
+                "SELECT COUNT(*) FROM entry WHERE feed_id = ?1",
+                rusqlite::params![feed_id],
+                |row| row.get(0),
+            )
+            .unwrap()
+        })
+        .await
+        .unwrap();
+    assert!(
+        entry_count >= 1,
+        "refresh should have synced at least 1 entry, got {}",
+        entry_count
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_fetch_metadata_form_success() {
+    use wiremock::matchers::{any, method};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let app = create_test_app_named(default_test_config(), "test_fetch_metadata_success");
+    setup_authenticated_user(&app.server).await;
+
+    let mock_server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(any())
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string(RSS_FIXTURE)
+                .insert_header("content-type", "application/rss+xml"),
+        )
+        .mount(&mock_server)
+        .await;
+
+    let feed_url = mock_server.uri();
+    let (_, feed_id) = insert_test_feed(&app, "Tech", &feed_url).await;
+
+    let response = app
+        .server
+        .post(&format!("/feeds/{}/fetch-metadata", feed_id))
+        .await;
+
+    response.assert_status(StatusCode::SEE_OTHER);
+    assert_eq!(
+        response.header(header::LOCATION),
+        format!("/feeds/{}/edit", feed_id)
+    );
+
+    // The RSS fixture has title "Mock Feed" and description "Mock Desc"; these
+    // must now be reflected in the DB.
+    let (title, description): (String, String) = app
+        .db
+        .user(move |conn| {
+            conn.query_row(
+                "SELECT title, description FROM feed WHERE id = ?1",
+                rusqlite::params![feed_id],
+                |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+            )
+            .unwrap()
+        })
+        .await
+        .unwrap();
+    assert_eq!(title, "Mock Feed");
+    assert_eq!(description, "Mock Desc");
+}


### PR DESCRIPTION
## Summary

Raises Codecov **project (line) coverage from ~86% to ~91.8%** by testing the previously-untested HTTP service layer with `wiremock`, filling pure-DB handler gaps with the existing `axum_test` harness, and excluding the binary entrypoint from the coverage denominator.

Plan: `docs/superpowers/plans/2026-06-12-coverage-to-90.md`.

### Tests added (~80)
- `services/feed_discovery.rs` — `discover_feed` via wiremock + helper units (was 14%)
- `services/icon_fetcher.rs` — image/favicon fetch paths via wiremock (was 40%)
- `services/save/linkding.rs` + `save/mod.rs` — `save_to_linkding` HTTP paths + `SaveServicesConfig`
- `services/summarize/kagi.rs` — `summarize_url` HTTP paths
- `services/feed_sync.rs` — `refresh_feed`/`refresh_bucket` via wiremock + seeded in-memory DB (was 22%)
- `handlers/feeds.rs` — edit/import/create/refresh/fetch-metadata form paths
- `handlers/greader/subscription.rs` — subscribe/quickadd/edit paths + `extract_label_name` units

### Production changes (2, both genuine improvements)
- **`fix(icon_fetcher)`**: build the favicon URL with `base_url.join("/favicon.ico")` instead of `format!("{}://{}/favicon.ico", scheme, host_str())`, which silently dropped non-default ports. Also removes ~3s of dead connection-retry latency in tests.
- **`test(kagi)`**: extract `summarize_url_with_base(base, config, url)` so the API host is injectable; public `summarize_url` signature is unchanged and delegates with the real host const.

### Coverage config
- `codecov.yml`: ignore `src/main.rs` (binary entrypoint — only runs in a live process); project target 90%, threshold 1%.

## Test Plan
- [x] `cargo nextest run` — 887/887 pass
- [x] `cargo clippy --all-targets` — clean
- [x] `cargo llvm-cov nextest --ignore-filename-regex 'src/main\.rs'` — TOTAL line **91.84%** (region 89.83%, function 90.70%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)