### PR TITLE
perf(ci): minimal Argon2 params in test/CI to speed up the coverage and e2e jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,12 @@ jobs:
       - uses: taiki-e/install-action@8c6986fc38d22c217606a7ad4f1d438eced263e0 # nextest
 
       - name: Generate coverage
+        # RDRS_FAST_HASH swaps Argon2 to minimal cost params for this run only.
+        # The integration tests register/log in hundreds of times; with the
+        # production (memory-hard) params each hash costs ~hundreds of ms in a
+        # debug build, dominating the suite. Never set in production.
+        env:
+          RDRS_FAST_HASH: "1"
         run: cargo llvm-cov nextest --lcov --output-path lcov.info
 
       - name: Upload coverage reports to Codecov

--- a/e2e/support/server.js
+++ b/e2e/support/server.js
@@ -67,6 +67,10 @@ export async function spawnRdrs() {
       SIGNUP_ENABLED: "true",
       MULTI_USER_ENABLED: "true",
       RUST_LOG: "warn",
+      // This is always a throwaway test server. Use minimal Argon2 cost so the
+      // register/login each scenario performs costs microseconds instead of
+      // hundreds of ms — roughly halves the suite. Never set in production.
+      RDRS_FAST_HASH: "1",
     },
     stdio: "pipe",
   });

--- a/src/auth/password.rs
+++ b/src/auth/password.rs
@@ -1,15 +1,40 @@
+use std::sync::LazyLock;
+
 use argon2::{
     password_hash::{rand_core::OsRng, PasswordHash, PasswordHasher, PasswordVerifier, SaltString},
-    Argon2,
+    Algorithm, Argon2, Params, Version,
 };
 
 use crate::error::{AppError, AppResult};
 
+/// Argon2 hasher used to derive *new* password hashes.
+///
+/// Production uses [`Argon2::default`] (OWASP-recommended, deliberately
+/// memory-hard, ~hundreds of ms per hash in a debug build). When the
+/// `RDRS_FAST_HASH` environment variable is set — only ever in test/CI runs —
+/// minimal cost parameters are used instead, cutting each hash to microseconds.
+/// This is safe: production never sets the flag, and [`verify_password`] reads
+/// the cost parameters out of each stored hash, so hashes produced under either
+/// setting verify interchangeably.
+static HASHER: LazyLock<Argon2<'static>> = LazyLock::new(|| {
+    if std::env::var_os("RDRS_FAST_HASH").is_some() {
+        let params = Params::new(
+            Params::MIN_M_COST,
+            Params::MIN_T_COST,
+            Params::MIN_P_COST,
+            None,
+        )
+        .expect("minimal argon2 params are valid");
+        Argon2::new(Algorithm::Argon2id, Version::V0x13, params)
+    } else {
+        Argon2::default()
+    }
+});
+
 pub fn hash_password(password: &str) -> AppResult<String> {
     let salt = SaltString::generate(&mut OsRng);
-    let argon2 = Argon2::default();
 
-    argon2
+    HASHER
         .hash_password(password.as_bytes(), &salt)
         .map(|hash| hash.to_string())
         .map_err(|e| AppError::Internal(format!("Password hashing failed: {}", e)))
@@ -53,5 +78,33 @@ mod tests {
     #[test]
     fn test_invalid_hash() {
         assert!(!verify_password("password", "invalid_hash"));
+    }
+
+    #[test]
+    fn test_verify_is_independent_of_configured_params() {
+        // Guards the RDRS_FAST_HASH optimisation: verification reads the cost
+        // parameters from the stored hash, so a hash produced with strong
+        // (default) params and one produced with minimal params must both
+        // verify. This is what makes weakening hash params in test/CI safe.
+        let strong = Argon2::default()
+            .hash_password(b"pw", &SaltString::generate(&mut OsRng))
+            .unwrap()
+            .to_string();
+        let weak_params = Params::new(
+            Params::MIN_M_COST,
+            Params::MIN_T_COST,
+            Params::MIN_P_COST,
+            None,
+        )
+        .unwrap();
+        let weak = Argon2::new(Algorithm::Argon2id, Version::V0x13, weak_params)
+            .hash_password(b"pw", &SaltString::generate(&mut OsRng))
+            .unwrap()
+            .to_string();
+
+        assert!(verify_password("pw", &strong));
+        assert!(verify_password("pw", &weak));
+        assert!(!verify_password("nope", &strong));
+        assert!(!verify_password("nope", &weak));
     }
 }


### PR DESCRIPTION
## Summary

The `coverage` job is the slowest in CI (~4m20s) and is the only job that runs the Rust test suite. Profiling showed the bottleneck is **not** coverage instrumentation (measured negligible) but **Argon2**: the integration tests register/log in 137+ times and each hash uses the production memory-hard parameters, costing ~hundreds of ms per hash in a debug build. The e2e suite pays the same cost (each scenario registers + logs in).

Gate password hashing on a new `RDRS_FAST_HASH` env var. When set — only ever in test/CI — `hash_password` uses `Params::MIN_*` cost, cutting each hash to microseconds. **Production never sets the flag and is unchanged.** `verify_password` reads the cost parameters out of each stored hash, so hashes produced under either setting verify interchangeably (covered by a new test).

## Changes
- `src/auth/password.rs`: `RDRS_FAST_HASH`-gated minimal Argon2 params via a `LazyLock` hasher; new `test_verify_is_independent_of_configured_params` proving strong/weak hashes cross-verify.
- `.github/workflows/ci.yml`: set `RDRS_FAST_HASH: "1"` on the coverage step.
- `e2e/support/server.js`: bake `RDRS_FAST_HASH: "1"` into the spawned (always-throwaway) test server's env — self-contained, no workflow change, speeds local e2e too.

## Local benchmark (warm)
| Suite | Before | After | Speedup |
|---|---|---|---|
| Coverage (instrumented full suite, 888 tests) | ~49.3s | ~8.5s | ~5.8x |
| E2E (107 scenarios) | 23.3s | 10.2s | ~2.1x |

Extrapolated CI: coverage job ~4m20s → ~1m30s; each e2e shard ~1m13s → ~40-50s.

## Test Plan
- [x] `cargo nextest run` passes with the flag set (888) and unset (default path, 887)
- [x] `cargo clippy -p rdrs --all-targets` clean
- [x] e2e suite green both with and without the env (107 scenarios), confirming the baked-in `server.js` value works
- [x] New unit test asserts default-param and minimal-param hashes both verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)