### PR TITLE
fix(icon): make apple-touch-icon opaque full-bleed for iOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ ico = "0.5"
 [dev-dependencies]
 axum-test = "20"
 cookie = "0.18"
+image = "0.25"
 tempfile = "3.26.0"
 http-body-util = "0.1"
 wiremock = "0.6"

--- a/build.rs
+++ b/build.rs
@@ -51,15 +51,23 @@ fn generate_favicons() {
     let options = resvg::usvg::Options::default();
     let tree = resvg::usvg::Tree::from_data(&svg_data, &options).expect("Failed to parse SVG");
 
-    // Generate PNGs in various sizes
+    // Opaque background for the Apple touch icon. iOS does not support
+    // transparency on home-screen icons (transparent pixels render as black) and
+    // applies its own rounded-corner mask. We therefore flatten the icon onto a
+    // solid background matching the SVG's outer frame color (#1A0E08) so the
+    // corners stay full-bleed instead of transparent/self-rounded.
+    let apple_bg = resvg::tiny_skia::Color::from_rgba8(0x1A, 0x0E, 0x08, 0xFF);
+
+    // Generate PNGs in various sizes. Favicons keep a transparent background;
+    // the Apple touch icon is rendered opaque and full-bleed.
     let sizes = [
-        (16, "favicon-16x16.png"),
-        (32, "favicon-32x32.png"),
-        (180, "apple-touch-icon.png"),
+        (16, "favicon-16x16.png", None),
+        (32, "favicon-32x32.png", None),
+        (180, "apple-touch-icon.png", Some(apple_bg)),
     ];
 
-    for (size, filename) in sizes {
-        let png_data = render_svg_to_png(&tree, size);
+    for (size, filename, background) in sizes {
+        let png_data = render_svg_to_png(&tree, size, background);
         let path = out_path.join(filename);
         std::fs::write(&path, &png_data).unwrap_or_else(|_| panic!("Failed to write {}", filename));
     }
@@ -71,11 +79,21 @@ fn generate_favicons() {
     std::fs::copy("favicon.svg", out_path.join("favicon.svg")).expect("Failed to copy favicon.svg");
 }
 
-fn render_svg_to_png(tree: &resvg::usvg::Tree, size: u32) -> Vec<u8> {
+fn render_svg_to_png(
+    tree: &resvg::usvg::Tree,
+    size: u32,
+    background: Option<resvg::tiny_skia::Color>,
+) -> Vec<u8> {
     let tree_size = tree.size();
     let scale = size as f32 / tree_size.width().max(tree_size.height());
 
     let mut pixmap = resvg::tiny_skia::Pixmap::new(size, size).unwrap();
+
+    // Fill with an opaque background before rendering so transparent areas of
+    // the SVG (e.g. its rounded corners) become solid instead of transparent.
+    if let Some(color) = background {
+        pixmap.fill(color);
+    }
 
     // Calculate centering offset
     let scaled_w = tree_size.width() * scale;
@@ -99,7 +117,7 @@ fn generate_ico(tree: &resvg::usvg::Tree, out_path: &Path) {
 
     // Add 16x16 and 32x32 images
     for size in [16u32, 32u32] {
-        let png_data = render_svg_to_png(tree, size);
+        let png_data = render_svg_to_png(tree, size, None);
         let img = image::load_from_memory(&png_data).expect("Failed to load PNG");
         let rgba = img.to_rgba8();
         let ico_image = ico::IconImage::from_rgba_data(size, size, rgba.into_raw());

--- a/tests/handlers_test.rs
+++ b/tests/handlers_test.rs
@@ -2096,6 +2096,23 @@ async fn test_apple_touch_icon() {
         .to_str()
         .unwrap();
     assert_eq!(content_type, "image/png");
+
+    // iOS home-screen icons do not support transparency (transparent pixels
+    // render as black) and iOS applies its own rounded-corner mask. The Apple
+    // touch icon must therefore be a fully-opaque, full-bleed square: every
+    // corner pixel must have alpha == 255.
+    let img = image::load_from_memory(&response.into_bytes())
+        .expect("apple-touch-icon must be a decodable image")
+        .to_rgba8();
+    let (w, h) = img.dimensions();
+    assert_eq!((w, h), (180, 180));
+    for (x, y) in [(0, 0), (w - 1, 0), (0, h - 1), (w - 1, h - 1)] {
+        assert_eq!(
+            img.get_pixel(x, y).0[3],
+            255,
+            "corner pixel ({x},{y}) must be fully opaque, not transparent"
+        );
+    }
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

The Apple touch icon was rendered from `favicon.svg`, which draws its own rounded corners (`rx=\"55\"`) and leaves the four corners **fully transparent**. iOS home-screen icons:

- do **not** support transparency — transparent pixels are composited as **black**, and
- get iOS's **own** rounded-corner mask applied on top.

So the previous icon risked a black fringe at the corners and a double-rounded look. (In practice it was barely visible because the SVG frame color `#1A0E08` is near-black, but it's still a deviation from Apple's guidance to ship a fully-opaque, full-bleed square.)

## Change

- `build.rs`: render the 180×180 `apple-touch-icon.png` onto a solid `#1A0E08` background (matching the SVG's outer frame) so it is fully opaque and full-bleed. Favicons (16/32/ICO/SVG) keep their transparent background — `render_svg_to_png` now takes an optional background color.
- `tests/handlers_test.rs`: decode the served icon and assert it is 180×180 with all four corners fully opaque (alpha == 255).
- `Cargo.toml`: add `image` to dev-dependencies (already a build-dependency) for the test's PNG decode.

## Verification

- New/regenerated icon corners: `srgba(26,14,8,1)`, whole-image mean alpha = 255.
- `cargo nextest run` favicon + apple-touch-icon tests pass; `cargo fmt --check` and `cargo clippy --all-targets` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)