### PR TITLE
Mobile layout enhancement: 44px touch targets + editorial entry-row redesign

### DIFF
--- a/docs/superpowers/plans/2026-06-13-entry-item-redesign.md
+++ b/docs/superpowers/plans/2026-06-13-entry-item-redesign.md
@@ -1,0 +1,491 @@
+# Entry Item Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rebuild the entry-list row as one editorial CSS-grid layout (Option C v5) that works on desktop and mobile, with an always-present feed favicon, darker secondary text, and touch-sized actions.
+
+**Architecture:** A single row template (`_entry_row.html`) renders a CSS grid (`"fav head" / "fav meta" / "foot foot"`). The favicon falls back to a deterministic letter chip via two new `EntryRowView` methods. All styling lives in `static/css/app.css`: the desktop `.entry-item*` block is replaced and the mobile `@media (max-width:1024px)` block gets a dedicated entry-row section, while the entry-row selectors are stripped from the generic touch baseline. Existing `data-testid`s and POST endpoints are preserved so triage/responsive e2e keep passing.
+
+**Tech Stack:** Rust (Askama view-model), Askama HTML template, CSS, Playwright-BDD e2e.
+
+---
+
+## Notes for the implementer
+
+- **Environment (NixOS):** `source /tmp/rdrs-env.sh` in the SAME compound command before any `cargo`/e2e command (OpenSSL env).
+- **CSS is embedded in the binary via `include_str!`** — after editing CSS or Rust you MUST `cargo build` before running e2e, or stale CSS is served. The e2e harness does not rebuild on its own.
+- **e2e runs from `e2e/`.** After adding/removing `.feature` scenarios run `npx bddgen` (or just `npx playwright test`, which triggers it). `pwd` first.
+- **Rust:** run tests with `cargo nextest run`; run `cargo fmt` before committing.
+- **Commits:** GPG-sign (`git commit -S`); end the message with the `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>` trailer. Stage files explicitly — never `git add -A`/`.`.
+- The breakpoint convention: **>1024px = desktop** (base rules), **≤1024px = mobile** (the existing `@media (max-width: 1024px)` block).
+- `_entry_row.html` is included from `_entries_fragment.html`, `_entries_layout.html`, `_entry_actions_multi.html`, `_open_entry_multi.html` — one template change covers them all.
+
+---
+
+## Task 1: Favicon fallback view-model methods
+
+**Files:**
+- Modify: `src/handlers/pages/mod.rs` (impl `EntryRowView`, after `summary_status_str` ~line 54; tests in `mod tests` ~line 2688)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the `#[cfg(test)] mod tests` block in `src/handlers/pages/mod.rs` (after the existing tests). Note `row_view_from(&ewf, None)` builds an `EntryRowView`; `ewf_with_title` sets `feed_id = 1`, `feed_title = "Feed"`.
+
+```rust
+    #[test]
+    fn feed_initial_uppercases_first_char() {
+        let ewf = ewf_with_title("anything");
+        let row = row_view_from(&ewf, None); // feed_title = "Feed"
+        assert_eq!(row.feed_initial(), "F");
+    }
+
+    #[test]
+    fn feed_initial_handles_empty_title() {
+        let mut ewf = ewf_with_title("anything");
+        ewf.feed_title = Some(String::new());
+        let row = row_view_from(&ewf, None);
+        assert_eq!(row.feed_initial(), "?");
+    }
+
+    #[test]
+    fn feed_color_index_is_stable_and_bounded() {
+        let mut ewf = ewf_with_title("anything");
+        ewf.entry.feed_id = 13;
+        let row = row_view_from(&ewf, None);
+        assert_eq!(row.feed_color_index(), 1); // 13 % 6 == 1
+        assert!(row.feed_color_index() < 6);
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd /home/nixos/Develop/claude/rdrs && source /tmp/rdrs-env.sh && cargo nextest run -E 'test(feed_initial) + test(feed_color_index)' 2>&1 | tail -20
+```
+Expected: FAIL — `no method named feed_initial`/`feed_color_index`.
+
+- [ ] **Step 3: Implement the methods**
+
+In `src/handlers/pages/mod.rs`, inside `impl EntryRowView`, after `summary_status_str`:
+
+```rust
+    /// Uppercased first character of the feed title, for the favicon
+    /// letter-chip fallback shown when a feed has no icon. Returns "?" for
+    /// an empty title.
+    pub fn feed_initial(&self) -> String {
+        self.feed_title
+            .chars()
+            .next()
+            .map(|c| c.to_uppercase().to_string())
+            .unwrap_or_else(|| "?".to_string())
+    }
+
+    /// Stable index 0..6 into the favicon fallback colour palette, derived
+    /// from the feed id so the same feed always gets the same colour.
+    pub fn feed_color_index(&self) -> u8 {
+        self.feed_id.rem_euclid(6) as u8
+    }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+cd /home/nixos/Develop/claude/rdrs && source /tmp/rdrs-env.sh && cargo nextest run -E 'test(feed_initial) + test(feed_color_index)' 2>&1 | tail -20
+```
+Expected: 3 passed.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+cd /home/nixos/Develop/claude/rdrs && source /tmp/rdrs-env.sh && cargo fmt
+git add src/handlers/pages/mod.rs
+git commit -S -m "feat(entries): favicon fallback helpers on EntryRowView
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: e2e assertions for the redesigned row (failing)
+
+TDD red: assert the new structure (always-present favicon, full-width mobile action buttons, 24px feed/category) that the current DOM lacks.
+
+**Files:**
+- Modify: `e2e/steps/responsive.steps.js` (one new step)
+- Modify: `e2e/features/responsive.feature` (one new `@mobile` scenario)
+
+- [ ] **Step 1: Add a step that checks an element spans (nearly) the full row width**
+
+Append to `e2e/steps/responsive.steps.js`:
+
+```javascript
+Then("the {string} controls each span at least {int}% of the row", async ({ page }, selector, pct) => {
+  const row = await page.getByTestId("entry-item").first().boundingBox();
+  const btns = await page.locator(selector).all();
+  expect(btns.length).toBeGreaterThanOrEqual(2);
+  for (const b of btns) {
+    const box = await b.boundingBox();
+    expect(box).not.toBeNull();
+    expect(box.width).toBeGreaterThanOrEqual((row.width * pct) / 100);
+  }
+});
+```
+
+- [ ] **Step 2: Add the failing scenario**
+
+Append to `e2e/features/responsive.feature`:
+
+```gherkin
+  @mobile
+  Scenario: Entry row redesign — favicon, full-width actions, sized meta on mobile
+    Given I am viewing on a mobile screen
+    And I have a feed with 5 test entries
+    When I open the inbox
+    Then the ".entry-favicon" control is at least 24px wide
+    And the ".entry-favicon" control is at least 24px tall
+    And the ".entry-item-meta a" control is at least 24px tall
+    And the ".entry-item-actions .entry-action-btn" controls each span at least 25% of the row
+    And the ".entry-action-btn" control is at least 44px tall
+```
+
+- [ ] **Step 3: Run to verify it FAILS**
+
+```bash
+cd /home/nixos/Develop/claude/rdrs && source /tmp/rdrs-env.sh && cargo build 2>&1 | tail -1 && cd e2e && npx bddgen && npx playwright test --grep "Entry row redesign" 2>&1 | tail -15
+```
+Expected: FAIL — current rows have no `.entry-favicon` (seeded feed has no icon) and the action buttons are not full-width thirds.
+
+- [ ] **Step 4: Commit the failing test**
+
+```bash
+cd /home/nixos/Develop/claude/rdrs
+git add e2e/steps/responsive.steps.js e2e/features/responsive.feature
+git commit -S -m "test(e2e): assert entry-row redesign layout (failing)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Redesign the row template + CSS
+
+Makes Task 2 green and preserves all existing triage/responsive selectors.
+
+**Files:**
+- Modify: `templates/_entry_row.html` (full rewrite)
+- Modify: `static/css/app.css` (replace `.entry-item*` desktop block; edit the `@media (max-width:1024px)` block)
+
+- [ ] **Step 1: Rewrite `templates/_entry_row.html`**
+
+Replace the entire file with:
+
+```html
+{# Single entry row — editorial CSS-grid layout (see
+   docs/superpowers/specs/2026-06-13-entry-item-redesign-design.md).
+   Grid areas: "fav head" / "fav meta" / "foot foot". The form-wrapped
+   action buttons keep their data-testids and POST targets so triage and
+   responsive e2e keep working; on mobile the .action-label spans are
+   hidden (CSS) leaving icon-only 44px buttons. #}
+<div id="entry-row-{{ r.id }}" class="entry-item{% if r.is_read %} entry-read{% endif %}" data-entry-row data-entry-id="{{ r.id }}" data-testid="entry-item">
+    {% if r.feed_has_icon %}
+    <img class="entry-favicon" src="/api/feeds/{{ r.feed_id }}/icon" alt="" loading="lazy" width="24" height="24">
+    {% else %}
+    <span class="entry-favicon entry-favicon-chip fav-c{{ r.feed_color_index() }}" aria-hidden="true">{{ r.feed_initial() }}</span>
+    {% endif %}
+
+    <div class="entry-head">
+        <a href="/entries/{{ r.id }}/fragment" data-swap="#reading-pane" class="entry-item-title {% if r.is_read %}entry-title-normal{% else %}entry-title-bold{% endif %}" data-testid="entry-title-link">{{ r.title }}</a>
+        <span class="entry-item-badges">{% match r.summary_status_str() %}
+            {% when Some("completed") %}<span title="Has Summary" class="summary-badge">✅</span>
+            {% when Some("pending") %}<span title="Pending" class="summary-badge-pending">⏳</span>
+            {% when Some("processing") %}<span title="Processing" class="summary-badge-processing">🔄</span>
+            {% when Some("failed") %}<span title="Failed" class="summary-badge-failed">❌</span>
+            {% when _ %}
+        {% endmatch %}</span>
+        <time class="entry-time" datetime="{{ r.published_at_iso }}">{{ r.published_relative }}</time>
+    </div>
+
+    <div class="muted entry-item-meta">
+        <a href="/feeds/{{ r.feed_id }}/entries">{{ r.feed_title }}</a>
+        <span class="meta-sep">·</span>
+        <a href="/categories/{{ r.category_id }}/entries">{{ r.category_name }}</a>
+    </div>
+
+    <div class="entry-item-actions">
+        <form method="post" action="/entries/{{ r.id }}/{% if r.is_read %}unread{% else %}read{% endif %}" data-swap="#entry-row-{{ r.id }}">
+            <button type="submit" class="entry-action-btn" data-testid="entry-read-action" aria-label="{% if r.is_read %}Mark unread{% else %}Mark read{% endif %}"><span class="action-icon" aria-hidden="true">{% if r.is_read %}↺{% else %}✓{% endif %}</span><span class="action-label">{% if r.is_read %}unread{% else %}read{% endif %}</span></button>
+        </form>
+        <form method="post" action="/entries/{{ r.id }}/{% if r.is_starred %}unstar{% else %}star{% endif %}" data-swap="#entry-row-{{ r.id }}">
+            <button type="submit" class="entry-action-btn" data-testid="entry-star-action" aria-label="{% if r.is_starred %}Unstar{% else %}Star{% endif %}"><span class="action-icon" aria-hidden="true">{% if r.is_starred %}★{% else %}☆{% endif %}</span><span class="action-label">{% if r.is_starred %}starred{% else %}star{% endif %}</span></button>
+        </form>
+        {% if let Some(link) = r.link.as_ref() %}<a href="{{ link }}" target="_blank" rel="noopener noreferrer" data-testid="entry-original-link" aria-label="Open original"><span class="action-icon" aria-hidden="true">↗</span><span class="action-label">original</span></a>{% endif %}
+    </div>
+</div>
+```
+
+- [ ] **Step 2: Replace the desktop `.entry-item*` block in `static/css/app.css`**
+
+Find the block starting at `/* ===== Entry Items (List) ===== */` (the `.entry-item { padding: var(--space-4) var(--space-5); ... }` rule) and ending after `.entry-item-meta { ... }` and the `.entry-item-actions` + `.entry-item-meta a/.entry-item-actions a/.breadcrumb a` colour rules (the contiguous `.entry-item*` section, roughly the rule for `.entry-item` through the `.entry-item-meta a:hover, .entry-item-actions a:hover, .breadcrumb a:hover` rule). Replace that whole section with:
+
+```css
+/* ===== Entry Items (List) — editorial grid ===== */
+.entry-item {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    grid-template-areas:
+        "fav  head"
+        "fav  meta"
+        "foot foot";
+    column-gap: var(--space-3);
+    padding: var(--space-4) var(--space-5);
+    border-bottom: 1px solid var(--color-border-light);
+    cursor: pointer;
+    transition: background 0.1s;
+}
+
+.entry-item:hover { background: var(--color-bg-secondary); }
+
+.entry-item.selected {
+    background: var(--color-accent-subtle);
+    box-shadow: inset var(--border-accent-width) 0 0 var(--color-accent);
+}
+
+.entry-item.entry-read { opacity: 0.62; }
+.entry-item.entry-read:hover,
+.entry-item.entry-read.selected { opacity: 1; }
+
+/* Favicon spans the title+meta rows only (no tall empty column). */
+.entry-favicon {
+    grid-area: fav;
+    width: 24px;
+    height: 24px;
+    margin-top: 2px;
+    border-radius: var(--radius-control);
+    flex: none;
+    object-fit: cover;
+}
+.entry-favicon-chip {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #fff;
+    font-family: var(--font-ui);
+    font-size: var(--font-xs);
+    font-weight: 700;
+}
+.fav-c0 { background: #7C6F9B; }
+.fav-c1 { background: #B05B3B; }
+.fav-c2 { background: #3B7A6B; }
+.fav-c3 { background: #4A6FA5; }
+.fav-c4 { background: #A6563E; }
+.fav-c5 { background: #6E8B3D; }
+
+/* Head: serif title + summary badges + right-aligned time. */
+.entry-head {
+    grid-area: head;
+    display: flex;
+    align-items: baseline;
+    gap: var(--space-2);
+}
+.entry-item-title {
+    font-family: var(--font-display);
+    font-size: var(--font-base);
+    font-weight: 600;
+    line-height: 1.32;
+    color: var(--color-text);
+    cursor: pointer;
+    overflow-wrap: break-word;
+    word-break: break-word;
+}
+.entry-item-title:hover { color: var(--color-accent); }
+.entry-title-bold { font-weight: 600; }
+.entry-title-normal { font-weight: 400; }
+.entry-item-badges { flex: none; }
+.entry-time {
+    margin-left: auto;
+    flex: none;
+    font-family: var(--font-ui);
+    font-size: var(--font-xs);
+    color: var(--color-text-muted);
+    white-space: nowrap;
+}
+
+/* Meta: feed · category, flush-left with the title. */
+.entry-item-meta {
+    grid-area: meta;
+    display: flex;
+    align-items: center;
+    gap: var(--space-1);
+    margin-top: var(--space-1);
+    font-family: var(--font-ui);
+    font-size: var(--font-sm);
+    color: var(--color-text-secondary);
+}
+.entry-item-meta a { color: var(--color-text-secondary); font-weight: 500; }
+.entry-item-meta a:hover { color: var(--color-accent); }
+.entry-item-meta .meta-sep { color: var(--color-text-muted); }
+
+/* Actions: full-width strip. Desktop = quiet text links that brighten on
+   row hover; mobile (below) = full-width icon buttons. */
+.entry-item-actions {
+    grid-area: foot;
+    display: flex;
+    gap: var(--space-5);
+    margin-top: var(--space-2);
+    font-family: var(--font-ui);
+    font-size: var(--font-xs);
+    opacity: 0.72;
+    transition: opacity 0.1s;
+}
+.entry-item:hover .entry-item-actions,
+.entry-item.selected .entry-item-actions { opacity: 1; }
+.entry-action-btn,
+.entry-item-actions a {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35em;
+    padding: 0;
+    border: none;
+    background: none;
+    color: var(--color-text-secondary);
+    font: inherit;
+    cursor: pointer;
+}
+.entry-action-btn:hover,
+.entry-item-actions a:hover { color: var(--color-accent); }
+```
+
+- [ ] **Step 3: Strip entry-row selectors from the generic mobile baseline**
+
+In the `@media (max-width: 1024px)` block of `static/css/app.css`, make these edits (the entry row now styles these itself):
+
+1. In the inline-flex touch group (the rule whose selectors include `.action-link, .actions a, .tab-bar a, …`), **delete** these three selector lines: `.entry-action-btn,`, `.entry-item-actions a,`, and `.entry-item-meta a,`.
+
+2. **Delete** the entire rule:
+```css
+    .entry-item .entry-item-actions .entry-action-btn,
+    .entry-item .entry-item-actions a {
+        padding: var(--space-1) var(--space-2);
+    }
+```
+(including its preceding comment block about padding:0 / specificity).
+
+3. In the font-size rule `.entry-item-meta, .entry-item-actions, .action-link { font-size: var(--font-sm); }`, **delete** `.entry-item-meta,` and `.entry-item-actions,` so only `.action-link { font-size: var(--font-sm); }` remains.
+
+4. **Delete** the entire rule (comment + selector):
+```css
+    /* Anti-mis-tap: widen gaps ... */
+    .entry-item-actions {
+        gap: var(--space-4);
+        align-items: center;
+    }
+```
+
+- [ ] **Step 4: Add the mobile entry-row section**
+
+Still inside the `@media (max-width: 1024px)` block, locate the existing rule `.entry-item { padding: var(--space-4); }` and replace it with the consolidated mobile entry-row rules:
+
+```css
+    /* ===== Entry row (redesign) — mobile ===== */
+    .entry-item { padding: var(--space-4); }
+
+    /* Feed/category: 24px tap area (AA floor; inline links are exempt from
+       the 44px rule), no horizontal padding so they stay flush with title. */
+    .entry-item-meta { margin-top: var(--space-2); }
+    .entry-item-meta a {
+        display: inline-flex;
+        align-items: center;
+        min-height: 24px;
+    }
+
+    /* Actions: full-width equal thirds, 44px tall, big icon, small padding,
+       always visible, icon-only (labels hidden). */
+    .entry-item-actions {
+        gap: var(--space-2);
+        margin-top: var(--space-3);
+        opacity: 1;
+    }
+    .entry-item-actions .action-label { display: none; }
+    .entry-action-btn,
+    .entry-item-actions a {
+        flex: 1;
+        justify-content: center;
+        gap: 0;
+        min-height: var(--touch-min);
+        padding: var(--space-2);
+        border: 1px solid var(--color-border-light);
+        border-radius: var(--radius-md);
+        font-size: var(--font-xl);
+    }
+```
+
+- [ ] **Step 5: Rebuild and run the redesign + regression e2e**
+
+```bash
+cd /home/nixos/Develop/claude/rdrs && source /tmp/rdrs-env.sh && cargo build 2>&1 | tail -1 && cd e2e && npx bddgen && npx playwright test --grep @mobile 2>&1 | tail -6
+```
+Expected: all `@mobile` scenarios PASS, including "Entry row redesign…".
+
+- [ ] **Step 6: Run triage + entries scenarios (depend on row testids)**
+
+```bash
+cd /home/nixos/Develop/claude/rdrs/e2e && source /tmp/rdrs-env.sh && npx playwright test triage entries 2>&1 | tail -6
+```
+Expected: PASS (read/star/original actions and title-link still work via preserved testids).
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /home/nixos/Develop/claude/rdrs
+git add templates/_entry_row.html static/css/app.css
+git commit -S -m "feat(ui): editorial entry-row redesign (desktop + mobile)
+
+Grid layout (fav/head/meta/foot) with always-present favicon (letter-chip
+fallback), serif title, darker meta, and a full-width action strip:
+quiet hover text links on desktop, 44px icon buttons on mobile. Keeps all
+entry-row data-testids and POST targets.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Full regression sweep
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Rust tests**
+
+```bash
+cd /home/nixos/Develop/claude/rdrs && source /tmp/rdrs-env.sh && cargo nextest run 2>&1 | tail -8
+```
+Expected: all pass.
+
+- [ ] **Step 2: Full e2e suite**
+
+```bash
+cd /home/nixos/Develop/claude/rdrs && source /tmp/rdrs-env.sh && cargo build 2>&1 | tail -1 && cd e2e && npx bddgen && npx playwright test 2>&1 | tail -4
+```
+Expected: all pass (responsive + triage + entries + keyboard + search + the rest).
+
+- [ ] **Step 3: If anything failed, fix and re-run.** Do not leave the suite red.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Grid layout `"fav head"/"fav meta"/"foot foot"` → Task 3 Step 2. ✅
+- Favicon always present + letter-chip fallback (6 colors, `feed_id % 6`) → Task 1 (methods) + Task 3 Steps 1-2. ✅
+- Serif title + right time; meta = feed·category darker, flush-left → Task 3 Step 2/4. ✅
+- Actions: desktop hover text links (icon+label), mobile full-width 44px icon-only with aria-label → Task 3 Steps 1-2-4. ✅
+- Feed/category 24px no h-padding → Task 3 Step 4. ✅
+- Read opacity 0.62, selected gold bar, unread bold → Task 3 Step 2. ✅
+- Color darkening (meta → text-secondary) → Task 3 Step 2. ✅
+- Preserve data-testids / POST endpoints → Task 3 Step 1 (verified Task 2 Step? triage in Task 3 Step 6). ✅
+- Supersede entry-row baseline rules, keep the rest → Task 3 Step 3. ✅
+- e2e for new layout → Task 2; regression → Task 4. ✅
+
+**Placeholder scan:** none — all template/CSS/Rust/test code is concrete.
+
+**Consistency:** class names match between template (Task 3 Step 1) and CSS (Steps 2/4): `.entry-favicon`, `.entry-favicon-chip`, `.fav-c{0..5}`, `.entry-head`, `.entry-item-title`, `.entry-item-badges`, `.entry-time`, `.entry-item-meta`, `.meta-sep`, `.entry-item-actions`, `.entry-action-btn`, `.action-icon`, `.action-label`. Method names `feed_initial()` / `feed_color_index()` match Task 1 and the template. e2e selectors in Task 2 (`.entry-favicon`, `.entry-item-meta a`, `.entry-item-actions .entry-action-btn`) exist in the new DOM.

--- a/docs/superpowers/plans/2026-06-13-mobile-touch-targets.md
+++ b/docs/superpowers/plans/2026-06-13-mobile-touch-targets.md
@@ -1,0 +1,318 @@
+# Mobile Touch-Target Enhancement Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every interactive control reach a ≥44×44px tap target on mobile (≤1024px), CSS-only, verified by e2e.
+
+**Architecture:** Add a single new design token (`--touch-min: 44px`) and a "mobile touch baseline" sub-section inside the existing `@media (max-width: 1024px)` block in `static/css/app.css`. Broad selectors raise the floor for all interactive elements; a few rules handle icon-only and text-only controls. A new generic e2e step asserts control sizes, exercised by new `@mobile` scenarios. No HTML/Rust/JS-behavior changes.
+
+**Tech Stack:** CSS (`static/css/app.css`), Playwright-BDD e2e (`e2e/features/*.feature`, `e2e/steps/*.steps.js`).
+
+---
+
+## Notes for the implementer
+
+- **Environment:** Before any e2e command, re-source the OpenSSL env on this box:
+  `source /tmp/rdrs-env.sh`. The e2e global-setup builds and launches the `rdrs`
+  binary, which needs it.
+- **Run e2e from the `e2e/` dir.** `pwd` first (multi-project workspace rule).
+- **Commits are GPG-signed** (`git commit -S`). End each commit message with the
+  `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>` trailer.
+- **Stage files explicitly by name** — never `git add -A`/`.`.
+- All new CSS rules MUST live **inside** the `@media (max-width: 1024px)` block
+  (it ends at the lone `}` on line 1770) so desktop is untouched.
+
+---
+
+## Task 1: Add the e2e tap-target assertion step and failing scenarios
+
+This is the failing test (TDD red). The two new scenarios assert ≥44px on
+controls that are currently 22–38px, so they fail before the CSS change.
+
+**Files:**
+- Modify: `e2e/steps/responsive.steps.js` (append two step defs)
+- Modify: `e2e/features/responsive.feature` (append two `@mobile` scenarios)
+
+- [ ] **Step 1: Add the generic size-assertion steps**
+
+Append to `e2e/steps/responsive.steps.js` (after the last step, line 125):
+
+```javascript
+Then("the {string} control is at least {int}px tall", async ({ page }, selector, min) => {
+  const box = await page.locator(selector).first().boundingBox();
+  expect(box).not.toBeNull();
+  expect(box.height).toBeGreaterThanOrEqual(min);
+});
+
+Then("the {string} control is at least {int}px wide", async ({ page }, selector, min) => {
+  const box = await page.locator(selector).first().boundingBox();
+  expect(box).not.toBeNull();
+  expect(box.width).toBeGreaterThanOrEqual(min);
+});
+```
+
+- [ ] **Step 2: Add the failing scenarios**
+
+Append to `e2e/features/responsive.feature` (after the last desktop scenario,
+line 107):
+
+```gherkin
+  @mobile
+  Scenario: Inbox and drawer controls meet the 44px touch minimum on mobile
+    Given I am viewing on a mobile screen
+    And I have a feed with 5 test entries
+    When I open the inbox
+    Then the ".sidebar-toggle" control is at least 44px wide
+    And the ".sidebar-toggle" control is at least 44px tall
+    And the ".entry-action-btn" control is at least 44px tall
+    When I tap the hamburger
+    Then the ".sidebar-close" control is at least 44px wide
+    And the ".sidebar-close" control is at least 44px tall
+    And the ".sidebar-item" control is at least 44px tall
+    When I tap the sidebar close button
+    And I click the entry titled "Test Entry 1"
+    Then the reading pane is visible on mobile
+    And the ".reading-pane-back-link" control is at least 44px tall
+
+  @mobile
+  Scenario: Table action links meet the 44px touch minimum on mobile
+    Given I am viewing on a mobile screen
+    And I have a category named "Test Category"
+    When I open the categories page
+    Then the ".action-link" control is at least 44px tall
+```
+
+- [ ] **Step 3: Run the new scenarios to verify they FAIL**
+
+```bash
+pwd   # expect /home/nixos/Develop/claude/rdrs
+source /tmp/rdrs-env.sh
+cd e2e && npx playwright test --grep @mobile
+```
+
+Expected: the two new scenarios FAIL on the size assertions (e.g.
+`.sidebar-toggle` height ~38 < 44, `.entry-action-btn` height < 44,
+`.action-link` height < 44). The 8 pre-existing `@mobile` scenarios still PASS.
+
+- [ ] **Step 4: Commit the failing tests**
+
+```bash
+cd /home/nixos/Develop/claude/rdrs
+git add e2e/steps/responsive.steps.js e2e/features/responsive.feature
+git commit -S -m "test(e2e): assert 44px mobile tap targets (failing)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Add the `--touch-min` token and the mobile touch baseline CSS
+
+This is the implementation (TDD green).
+
+**Files:**
+- Modify: `static/css/app.css` (`:root` token at line ~49; new rules inside the
+  `@media (max-width: 1024px)` block; `.entry-item` padding at line 1737)
+
+- [ ] **Step 1: Add the `--touch-min` token**
+
+In `static/css/app.css`, in the `/* Borders */` area of `:root` (lines 48-49),
+add the token after `--border-accent-width: 3px;`:
+
+```css
+    /* Borders */
+    --border-accent-width: 3px;
+
+    /* Touch */
+    --touch-min: 2.75rem;   /* 44px — WCAG 2.5.5 / iOS minimum tap target */
+```
+
+- [ ] **Step 2: Fix the entry-row padding regression**
+
+In `static/css/app.css`, the `@media (max-width: 1024px)` rule currently shrinks
+the row padding (lines 1736-1738):
+
+```css
+    .entry-item {
+        padding: var(--space-3) var(--space-4);
+    }
+```
+
+Change it to keep the comfortable 16px vertical padding:
+
+```css
+    .entry-item {
+        padding: var(--space-4);
+    }
+```
+
+- [ ] **Step 3: Append the mobile touch baseline block**
+
+In `static/css/app.css`, insert the following **inside** the
+`@media (max-width: 1024px)` block, immediately before its closing `}` on
+line 1770 (i.e. after the `...padding-top: var(--space-6); } }` rule that ends on
+line 1769):
+
+```css
+    /* ===== Mobile touch baseline — 44px minimum tap targets ===== */
+
+    /* Buttons are already inline-flex & centered (base styles); just raise
+       them to the touch minimum. */
+    button,
+    .btn {
+        min-height: var(--touch-min);
+    }
+
+    /* Link- and text-styled controls have little or no padding by default —
+       turn them into real flex boxes so min-height centers the label and the
+       whole box is tappable, not just the glyph run. */
+    .action-link,
+    .actions a,
+    .tab-bar a,
+    .reading-pane-nav-btn,
+    .stats-period-btn,
+    .feed-filter-link,
+    .entry-action-btn,
+    .reading-pane-back-link,
+    .entry-item-meta a,
+    .breadcrumb a,
+    .search-result-title,
+    .link a {
+        display: inline-flex;
+        align-items: center;
+        min-height: var(--touch-min);
+    }
+
+    /* The entry-row toggles ship with padding:0 — give them horizontal room. */
+    .entry-action-btn {
+        padding: var(--space-1) var(--space-2);
+    }
+
+    /* Square icon-only controls: width AND height must reach the minimum. */
+    .sidebar-toggle,
+    .sidebar-close,
+    .banner-dismiss {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-width: var(--touch-min);
+        min-height: var(--touch-min);
+    }
+
+    /* Drawer rows. */
+    .sidebar-item {
+        min-height: var(--touch-min);
+    }
+
+    /* Form controls: touch height + 16px font to suppress iOS focus-zoom. */
+    input[type="text"],
+    input[type="password"],
+    input[type="url"],
+    input[type="email"],
+    input[type="number"],
+    input[type="search"],
+    input[type="date"],
+    select,
+    textarea {
+        min-height: var(--touch-min);
+        font-size: var(--font-base);
+    }
+
+    /* Legibility: lift the smallest interactive/secondary text to 14px. */
+    .entry-item-meta,
+    .entry-item-actions,
+    .action-link {
+        font-size: var(--font-sm);
+    }
+
+    /* Anti-mis-tap: widen gaps between adjacent tappable controls. */
+    .entry-item-actions {
+        gap: var(--space-4);
+    }
+
+    .tab-bar {
+        gap: var(--space-2);
+    }
+```
+
+- [ ] **Step 4: Run the new scenarios to verify they PASS**
+
+```bash
+pwd
+source /tmp/rdrs-env.sh
+cd e2e && npx playwright test --grep @mobile
+```
+
+Expected: all `@mobile` scenarios PASS (the 8 pre-existing + the 2 new).
+
+- [ ] **Step 5: Commit the CSS**
+
+```bash
+cd /home/nixos/Develop/claude/rdrs
+git add static/css/app.css
+git commit -S -m "feat(ui): enforce 44px touch targets on mobile
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Full responsive regression sweep
+
+Confirm tablet/desktop scenarios still pass (the change is media-scoped, but
+verify no leakage).
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full responsive feature**
+
+```bash
+pwd
+source /tmp/rdrs-env.sh
+cd e2e && npx playwright test responsive
+```
+
+Expected: all `@mobile`, `@tablet`, `@desktop` scenarios PASS.
+
+- [ ] **Step 2: Run the mobile keyboard-shortcuts feature (shares the overlay)**
+
+```bash
+cd /home/nixos/Develop/claude/rdrs
+source /tmp/rdrs-env.sh
+cd e2e && npx playwright test keyboard_shortcuts_mobile
+```
+
+Expected: PASS (reading-pane overlay still opens/closes correctly).
+
+- [ ] **Step 3: If anything failed, fix and re-run**
+
+If a tablet/desktop scenario regressed, confirm every new rule is inside the
+`@media (max-width: 1024px)` block (desktop is 1280px wide, tablet 768px). The
+tablet viewport (768px) IS within the ≤1024px range, so tablet now also gets the
+larger targets — that is intended and the tablet scenarios assert layout, not
+sizes, so they should still pass.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- 44px min on all controls (Task 2 Step 3 baseline block). ✅
+- New `--touch-min` token (Task 2 Step 1). ✅
+- Text-only controls get real hit area (inline-flex group). ✅
+- Icon-only specials `.banner-dismiss`, `.sidebar-close` (square-icon group). ✅
+- `.sidebar-item` drawer rows. ✅
+- Fix `.entry-item` padding regression (Task 2 Step 2). ✅
+- Anti-mis-tap spacing (`.entry-item-actions`, `.tab-bar` gaps). ✅
+- Font: 12.8px→14px for meta/actions; inputs→16px iOS anti-zoom. ✅
+- e2e tap-target assertions + new scenarios (Task 1). ✅
+- All pages covered via shared classes (buttons, action-link, inputs, tabs). ✅
+- CSS-only, no HTML/Rust/JS changes. ✅
+
+**Placeholder scan:** No TBD/TODO; all CSS and step code is concrete. ✅
+
+**Consistency:** Step phrasing `the {string} control is at least {int}px tall/wide`
+is identical in the step defs (Task 1 Step 1) and the scenarios (Task 1 Step 2).
+Selectors used in scenarios (`.sidebar-toggle`, `.entry-action-btn`,
+`.sidebar-close`, `.sidebar-item`, `.reading-pane-back-link`, `.action-link`) all
+have matching rules in Task 2 Step 3. ✅

--- a/docs/superpowers/specs/2026-06-13-entry-item-redesign-design.md
+++ b/docs/superpowers/specs/2026-06-13-entry-item-redesign-design.md
@@ -92,10 +92,13 @@ label is hidden) MUST carry an `aria-label` / `title` ("Star", "Mark read",
 ### Touch sizing
 
 - Action buttons (primary controls): **44px** min-height on mobile.
-- Feed / category (inline links): **24px** min-height on mobile, **no horizontal
-  padding** so the first link is flush-left with the title. 24px is the WCAG
-  2.5.8 (AA) floor; inline text links are formally exempt from 2.5.5's 44px, so
-  24px is a deliberate, compliant choice.
+- Feed / category: kept as plain **inline** links so "feed · category" wraps
+  naturally as one text run (not two side-by-side flex blocks). Vertical padding
+  gives each link a ~28px hit box (≥ the WCAG 2.5.8 AA 24px floor) without
+  breaking the wrap; **no horizontal padding** so the first link is flush-left
+  with the title. Inline text links are formally exempt from 2.5.5's 44px, so
+  this is a deliberate, compliant choice. (min-height/inline-flex is avoided
+  here because it would make each link an atomic box and break wrapping.)
 
 ### States (unchanged semantics, restyled)
 

--- a/docs/superpowers/specs/2026-06-13-entry-item-redesign-design.md
+++ b/docs/superpowers/specs/2026-06-13-entry-item-redesign-design.md
@@ -46,9 +46,11 @@ column-gap: var(--space-3);   /* 12px */
 - **`fav`** — leading feed favicon (24px, `--radius-control`). Spans only the
   `head`+`meta` rows so there is no tall empty column beside the action strip.
 - **`head`** — title + relative time. Title `var(--font-ui)` (DM Sans, the UI
-  sans — a serif here read as out of place), `var(--font-base)`, weight 600 when
-  unread / 400 when read, `color: var(--color-text)`. Time is `margin-left:auto`,
-  muted, `white-space:nowrap`.
+  sans — a serif here read as out of place). Size `var(--font-sm)` (14px) on
+  desktop so it matches the visible 14px sidebar/chrome scale, bumped to
+  `var(--font-base)` (16px) on mobile where no sidebar is shown for comparison.
+  Weight 600 when unread / 400 when read, `color: var(--color-text)`. Time is
+  `margin-left:auto`, muted, `white-space:nowrap`.
 - **`meta`** — feed link `·` category link. `var(--font-ui)`, ~12.5px desktop /
   13px mobile, `color: var(--color-text-secondary)` (darker than today's muted),
   normal weight, separator muted. Left edge is flush with the title.

--- a/docs/superpowers/specs/2026-06-13-entry-item-redesign-design.md
+++ b/docs/superpowers/specs/2026-06-13-entry-item-redesign-design.md
@@ -1,0 +1,154 @@
+# Entry Item Redesign (Option C — Editorial) — Design
+
+**Date:** 2026-06-13
+**Branch:** `feat/mobile-touch-targets` (continues the mobile-layout effort; builds on the `--touch-min` token and mobile touch baseline already on this branch)
+**Status:** Approved design (v5 mockup), pending implementation plan
+
+## Problem
+
+After the 44px touch-target pass, the entry-item row reads awkwardly on mobile:
+the meta links and action controls were inflated piecemeal on top of a layout
+that was designed for desktop density, so spacing and alignment look off. The
+row needs a coherent redesign that works for **both** desktop and mobile rather
+than mobile patches over a desktop layout.
+
+This was validated visually through a browser mockup session (Option C, iterated
+v1→v5). The chosen direction is the "editorial" treatment.
+
+## Goals
+
+- One coherent entry-row layout that scales from desktop to a 375px phone.
+- Touch-friendly on mobile without looking bulky; tidy and scannable on desktop.
+- Darker, more legible secondary text (current muted grey is too pale).
+- Keep the existing interaction model: tap the row/title to open; per-row
+  star / read-toggle / open-original actions; unread/read/selected states.
+
+## Non-Goals
+
+- No change to the reading pane, sidebar, tables, or other pages (those keep the
+  touch-baseline work already on this branch).
+- No change to backend endpoints or the swap/data-flow model.
+- No new JS behavior beyond what the existing action forms already do.
+
+## Chosen Design (v5)
+
+### Layout — CSS grid, identical structure desktop & mobile
+
+```
+grid-template-columns: auto 1fr;
+grid-template-areas:
+  "fav  head"
+  "fav  meta"
+  "foot foot";
+column-gap: var(--space-3);   /* 12px */
+```
+
+- **`fav`** — leading feed favicon (24px, `--radius-control`). Spans only the
+  `head`+`meta` rows so there is no tall empty column beside the action strip.
+- **`head`** — serif title + relative time. Title `var(--font-display)`
+  (Source Serif 4), 16px desktop / 16.5px mobile, weight 600 when unread / 400
+  when read, `color: var(--color-text)`. Time is `margin-left:auto`, muted,
+  `white-space:nowrap`.
+- **`meta`** — feed link `·` category link. `var(--font-ui)`, ~12.5px desktop /
+  13px mobile, `color: var(--color-text-secondary)` (darker than today's muted),
+  links weight 500, separator muted. Left edge is flush with the title.
+- **`foot`** — action strip spanning the full width from the row's left content
+  edge (both grid columns).
+
+### Favicon (new: always present, with fallback)
+
+Today the feed icon renders only when `feed_has_icon`. The redesign always shows
+a 24px leading favicon:
+
+- If the feed has an icon: `<img src="/api/feeds/{feed_id}/icon" width="24" height="24">`.
+- Otherwise: a deterministic colored chip showing the feed title's first letter.
+  Color is chosen from a fixed 6-color palette indexed by `feed_id % 6`
+  (computed in the template/handler), so the same feed is always the same color.
+  No new network/storage — pure render.
+
+### Actions (`foot`)
+
+Same three controls as today, re-presented:
+
+- **Star** — `★` (starred) / `☆` (not). Posts to `…/star` | `…/unstar`.
+- **Read toggle** — `✓` (mark read, when unread) / `↺` (mark unread, when read).
+  Posts to `…/read` | `…/unread`.
+- **Original** — `↗` link to `r.link` (external), only when a link exists.
+
+Presentation differs by breakpoint:
+
+- **Desktop:** quiet inline text links with icon + label
+  (`★ starred`, `✓ read`, `↗ original`), `opacity: ~0.72`, raised to full
+  opacity on row hover (a "hover footer"). Left-aligned, `gap: var(--space-5)`.
+- **Mobile (≤1024px):** three equal full-width icon **buttons**
+  (`display:flex; gap:var(--space-2)`, each `flex:1`), `min-height:var(--touch-min)`
+  (44px), icon ~22px, small padding (~6px), thin `--color-border-light` border,
+  `--radius-md`. Icon-only.
+
+Accessibility: each mobile icon button (and the icon-only desktop link where the
+label is hidden) MUST carry an `aria-label` / `title` ("Star", "Mark read",
+"Open original"). Desktop keeps the visible text label.
+
+### Touch sizing
+
+- Action buttons (primary controls): **44px** min-height on mobile.
+- Feed / category (inline links): **24px** min-height on mobile, **no horizontal
+  padding** so the first link is flush-left with the title. 24px is the WCAG
+  2.5.8 (AA) floor; inline text links are formally exempt from 2.5.5's 44px, so
+  24px is a deliberate, compliant choice.
+
+### States (unchanged semantics, restyled)
+
+- **Unread:** bold title. (Optional later: leading dot — NOT in this scope.)
+- **Read:** `opacity: 0.62` (was 0.55 — slightly less faded for legibility);
+  full opacity on hover/selected.
+- **Selected:** `--color-accent-subtle` background + inset gold left bar
+  (`box-shadow: inset var(--border-accent-width) 0 0 var(--color-accent)`) — kept
+  from current.
+- Row hover: `--color-bg-secondary` background — kept.
+
+### Color/legibility changes
+
+- Meta text: `--color-text-muted` → `--color-text-secondary` (darker).
+- Read opacity: 0.55 → 0.62.
+
+## Affected Units
+
+- **`templates/_entry_row.html`** — restructured to the grid areas; favicon
+  always rendered (with letter-chip fallback); actions grouped in `.foot` with
+  `aria-label`s. This is the single source of the row DOM.
+- **`static/css/app.css`** — replace the `.entry-item*` rule block (desktop) and
+  the entry-row parts of the `@media (max-width:1024px)` baseline with the v5
+  grid layout + states. Remove now-superseded entry-row touch tweaks added
+  earlier on this branch (the `.entry-item-actions` flex/gap/align rules and the
+  `.entry-action-btn` padding rule) since the redesign defines the action strip
+  wholesale.
+- Possibly a tiny helper in the page handler/template for the favicon fallback
+  color/letter if it can't be expressed in Askama alone.
+
+## Testing
+
+Extend the existing Playwright-BDD e2e (which already asserts 44px targets):
+
+- Update/keep the entry-row selectors used by existing scenarios. The action
+  controls move from text links to icon buttons — the existing
+  `.entry-action-btn` test hooks (`data-testid="entry-read-action"`,
+  `entry-star-action`, `entry-original-link`) MUST be preserved so triage and
+  responsive scenarios keep working.
+- Add a `@mobile` assertion that the action buttons span full width (each ≈ a
+  third of the row) and are ≥44px tall, and that feed/category links are ≥24px.
+- Verify desktop still shows text labels and the hover footer.
+- Full responsive + triage + keyboard sweeps stay green.
+
+## Risks & Mitigations
+
+- **Breaking triage/responsive e2e** by changing the action DOM. Mitigation:
+  keep all existing `data-testid`s and POST actions identical; only restyle and
+  re-wrap.
+- **Favicon fallback** adds template logic. Mitigation: keep it a pure
+  deterministic render (palette indexed by `feed_id`), no DB/network.
+- **Overlap with the touch-baseline already on this branch.** Mitigation: the
+  redesign explicitly supersedes the entry-row-specific baseline rules; the
+  broader baseline (buttons, inputs, sidebar, tabs, banner, hamburger) stays.
+- **Icon-only mobile a11y.** Mitigation: required `aria-label`/`title` on every
+  icon control.

--- a/docs/superpowers/specs/2026-06-13-entry-item-redesign-design.md
+++ b/docs/superpowers/specs/2026-06-13-entry-item-redesign-design.md
@@ -45,13 +45,13 @@ column-gap: var(--space-3);   /* 12px */
 
 - **`fav`** — leading feed favicon (24px, `--radius-control`). Spans only the
   `head`+`meta` rows so there is no tall empty column beside the action strip.
-- **`head`** — serif title + relative time. Title `var(--font-display)`
-  (Source Serif 4), 16px desktop / 16.5px mobile, weight 600 when unread / 400
-  when read, `color: var(--color-text)`. Time is `margin-left:auto`, muted,
-  `white-space:nowrap`.
+- **`head`** — title + relative time. Title `var(--font-ui)` (DM Sans, the UI
+  sans — a serif here read as out of place), `var(--font-base)`, weight 600 when
+  unread / 400 when read, `color: var(--color-text)`. Time is `margin-left:auto`,
+  muted, `white-space:nowrap`.
 - **`meta`** — feed link `·` category link. `var(--font-ui)`, ~12.5px desktop /
   13px mobile, `color: var(--color-text-secondary)` (darker than today's muted),
-  links weight 500, separator muted. Left edge is flush with the title.
+  normal weight, separator muted. Left edge is flush with the title.
 - **`foot`** — action strip spanning the full width from the row's left content
   edge (both grid columns).
 

--- a/docs/superpowers/specs/2026-06-13-mobile-touch-targets-design.md
+++ b/docs/superpowers/specs/2026-06-13-mobile-touch-targets-design.md
@@ -1,0 +1,170 @@
+# Mobile Touch-Target Enhancement — Design
+
+**Date:** 2026-06-13
+**Branch:** `feat/mobile-touch-targets`
+**Status:** Approved design, pending implementation plan
+
+## Problem
+
+On mobile, most interactive elements are too small — hard to tap and easy to
+mis-tap. An audit of `static/css/app.css`, the Askama templates, and the
+responsive infrastructure confirmed the root cause:
+
+- The design tokens (`--space-1`=4px, `--space-2`=8px, `--font-xs`=12.8px) are
+  tuned for a compact **desktop** layout.
+- The `@media (max-width: 1024px)` block does **not** enlarge any touch target.
+  It actively *shrinks* `.entry-item` vertical padding from 16px → 12px
+  (`app.css:1736`).
+- No media query raises button/link/select sizes or interactive font sizes for
+  touch.
+
+Confirmed-good baseline (no change needed):
+- Viewport meta is correct: `width=device-width, initial-scale=1.0`
+  (`templates/base.html:5`).
+- The sidebar drawer JS (`toggleSidebar`/`closeSidebar`, tap-outside-to-close)
+  and the reading-pane overlay JS already work.
+- The e2e harness (`e2e/features/responsive.feature`, `responsive.steps.js`,
+  `VIEWPORTS.mobile = 375×667`) is in place — but has **no** tap-target size
+  assertions.
+
+### Worst offenders (from audit)
+
+Text-only, `padding: 0` (effective target ≈ text box only):
+- `.entry-action-btn` (entry row read/star toggles) — repeated on every row
+- `.reading-pane-back-link` (mobile-only escape route)
+- `.entry-item-meta a`, `.breadcrumb a`, `.search-result-title`, `.link a`
+
+Fixed-tiny / compact:
+- `.banner-dismiss` — fixed 22×22px
+- `.sidebar-close` — `padding: var(--space-1)` (4px)
+- `.action-link` / `.btn-sm` / `.actions a` — 4×8px padding + 12.8px font
+  (table actions in feeds/categories/admin, reading-pane action buttons,
+  "Mark Above as Read")
+- `.tab-bar a` — 8×12px, tabs only 4px apart
+- `.stats-period-btn`, `.feed-filter-link`, `.stats-date-input` — 4px vertical
+  padding
+
+All fall below the **44×44px** WCAG 2.5.5 / iOS touch minimum.
+
+## Goals
+
+- Every interactive control reaches a **≥44×44px** effective tap target on
+  mobile (≤1024px viewport).
+- Reduce mis-tap risk by widening gaps between adjacent tappable controls.
+- Raise the smallest interactive font sizes for legibility and to prevent iOS
+  focus-zoom.
+- Cover **all** pages (entry list, reading pane, sidebar, tables, statistics,
+  auth) — most share the same classes, so one pass covers them.
+
+## Non-Goals
+
+- No HTML/template changes — this is a **CSS-only** change so it stays
+  centralized and low-regression.
+- No new font-size tokens; reuse existing `--font-sm`/`--font-base`.
+- No change to desktop layout or to the existing drawer/overlay behavior.
+- Main body text scale is unchanged (`body` is already 18px).
+
+## Approach
+
+**Global touch baseline + minimal token tuning**, applied inside the existing
+`@media (max-width: 1024px)` block in `static/css/app.css`. A small set of
+broad selectors raises the floor for all interactive elements; a few special
+cases handle icon-only controls.
+
+### 1. New token (`:root`)
+
+```css
+--touch-min: 2.75rem;   /* 44px — WCAG 2.5.5 / iOS touch minimum */
+```
+
+This is the only new token. Define it near the existing spacing tokens.
+
+### 2. Global touch baseline (inside `@media (max-width: 1024px)`)
+
+A new sub-section that:
+
+- **Padded controls** — `button, .btn, .action-link, .actions a, .tab-bar a,
+  .reading-pane-nav-btn, .stats-period-btn, .feed-filter-link, select, input,
+  textarea` → `min-height: var(--touch-min)`. Where the element is not already
+  flex, set `display: inline-flex; align-items: center` so the increased height
+  vertically centers the label. (Block/full-width buttons keep their width.)
+- **Text-only controls** — `.entry-action-btn, .reading-pane-back-link,
+  .entry-item-meta a, .breadcrumb a, .search-result-title, .link a` → add
+  `min-height: var(--touch-min)`, vertical padding, and
+  `display: inline-flex; align-items: center` so the hit area is a real block,
+  not just the glyph run.
+- **Icon-only specials**:
+  - `.banner-dismiss` → `min-width/min-height: var(--touch-min)` (from 22×22).
+  - `.sidebar-close` → padding raised to reach 44×44 (from `--space-1`).
+- **Sidebar items** — `.sidebar-item` → `min-height: var(--touch-min)` for the
+  drawer.
+
+### 3. Fix the reverse setting
+
+`.entry-item` mobile padding (`app.css:1736`) currently shrinks to
+`var(--space-3)` (12px) vertical. Restore to `var(--space-4)` (16px) vertical so
+the most-used list rows stay comfortable.
+
+### 4. Anti-mis-tap spacing
+
+Widen gaps between adjacent tappable controls on mobile:
+- `.entry-item-actions` gap (currently `--space-3`) → larger.
+- `.actions` / `.tab-bar` gaps → larger.
+
+### 5. Interactive font sizes (minimal)
+
+- Raise mobile `--font-xs` contexts that are interactive/secondary —
+  `.entry-item-meta`, `.entry-item-actions`, `.action-link` — to
+  `var(--font-sm)` (14px).
+- Ensure `input, select, textarea` render at `var(--font-base)` (16px) on
+  mobile to suppress iOS focus-zoom (some are currently 14px).
+
+Main text (entry title, sidebar item label) is **not** scaled up — per the
+"only fix the too-small" decision.
+
+## Testing
+
+Add e2e tap-target assertions (matching existing conventions) so the change is
+verified and protected from regression:
+
+- New step in `e2e/steps/responsive.steps.js`:
+  `Then("the {string} control is at least {int}px tall")` (and `…wide`) using
+  `boundingBox()`.
+- New `@mobile` scenario in `e2e/features/responsive.feature` asserting key
+  controls are ≥44px on the mobile viewport: hamburger (`.sidebar-toggle`),
+  sidebar close (`.sidebar-close`), entry row action (`.entry-action-btn`),
+  reading-pane back (`.reading-pane-back-link`), and a table action link
+  (`.action-link`).
+
+The step is generic (takes a selector + size) so future controls are easy to
+add. Existing responsive scenarios must continue to pass.
+
+### Verification commands
+
+Run from the repo root (re-source `/tmp/rdrs-env.sh` first per project setup):
+
+- `cd e2e && npx playwright test --grep @mobile` — new + existing mobile
+  scenarios green.
+- Full e2e responsive sweep green.
+
+## Files Touched
+
+- `static/css/app.css` — add `--touch-min`; new touch-baseline rules and
+  spacing/font tweaks inside `@media (max-width: 1024px)`; fix `.entry-item`
+  mobile padding.
+- `e2e/steps/responsive.steps.js` — new generic size-assertion step(s).
+- `e2e/features/responsive.feature` — new `@mobile` tap-target scenario.
+
+No template, Rust, or JS-behavior changes.
+
+## Risks & Mitigations
+
+- **Layout shift on desktop** — all rules live inside `@media (max-width:
+  1024px)`; desktop is untouched. Mitigation: keep every new rule inside the
+  media block.
+- **`inline-flex` breaking full-width/block buttons** — apply `inline-flex`
+  only to inline controls; leave `.btn-block` and form-submit buttons as-is
+  (they already fill width and just need `min-height`).
+- **`min-height` not enlarging text-only links without padding** — pair
+  `min-height` with `inline-flex; align-items: center` so height takes effect.
+- **iOS focus-zoom** — guaranteed by forcing 16px font on inputs.

--- a/e2e/features/responsive.feature
+++ b/e2e/features/responsive.feature
@@ -140,3 +140,14 @@ Feature: Responsive layout
     And I have a feed with 5 test entries
     When I open the all-entries page
     Then the ".tab-bar a" control is at least 44px tall
+
+  @mobile
+  Scenario: Entry row redesign — favicon, full-width actions, sized meta on mobile
+    Given I am viewing on a mobile screen
+    And I have a feed with 5 test entries
+    When I open the inbox
+    Then the ".entry-favicon" control is at least 24px wide
+    And the ".entry-favicon" control is at least 24px tall
+    And the ".entry-item-meta a" control is at least 24px tall
+    And the ".entry-item-actions .entry-action-btn" controls each span at least 25% of the row
+    And the ".entry-action-btn" control is at least 44px tall

--- a/e2e/features/responsive.feature
+++ b/e2e/features/responsive.feature
@@ -105,3 +105,27 @@ Feature: Responsive layout
     And I have a feed with 5 test entries
     When I open the inbox
     Then the entry list pane is narrower than the viewport
+
+  @mobile
+  Scenario: Inbox and drawer controls meet the 44px touch minimum on mobile
+    Given I am viewing on a mobile screen
+    And I have a feed with 5 test entries
+    When I open the inbox
+    Then the ".sidebar-toggle" control is at least 44px wide
+    And the ".sidebar-toggle" control is at least 44px tall
+    And the ".entry-action-btn" control is at least 44px tall
+    When I tap the hamburger
+    Then the ".sidebar-close" control is at least 44px wide
+    And the ".sidebar-close" control is at least 44px tall
+    And the ".sidebar-item" control is at least 44px tall
+    When I tap the sidebar close button
+    And I click the entry titled "Test Entry 1"
+    Then the reading pane is visible on mobile
+    And the ".reading-pane-back-link" control is at least 44px tall
+
+  @mobile
+  Scenario: Table action links meet the 44px touch minimum on mobile
+    Given I am viewing on a mobile screen
+    And I have a category named "Test Category"
+    When I open the categories page
+    Then the ".action-link" control is at least 44px tall

--- a/e2e/features/responsive.feature
+++ b/e2e/features/responsive.feature
@@ -68,6 +68,8 @@ Feature: Responsive layout
     When I open the inbox
     And a flash banner is shown
     Then the flash banner sits below the hamburger
+    And the ".banner-dismiss" control is at least 44px wide
+    And the ".banner-dismiss" control is at least 44px tall
 
   @tablet
   Scenario: Sidebar is a drawer on tablet
@@ -114,6 +116,7 @@ Feature: Responsive layout
     Then the ".sidebar-toggle" control is at least 44px wide
     And the ".sidebar-toggle" control is at least 44px tall
     And the ".entry-action-btn" control is at least 44px tall
+    And the ".filter-bar select" control is at least 44px tall
     When I tap the hamburger
     Then the ".sidebar-close" control is at least 44px wide
     And the ".sidebar-close" control is at least 44px tall
@@ -129,3 +132,11 @@ Feature: Responsive layout
     And I have a category named "Test Category"
     When I open the categories page
     Then the ".action-link" control is at least 44px tall
+    And the "#name" control is at least 44px tall
+
+  @mobile
+  Scenario: Tab bar links meet the 44px touch minimum on mobile
+    Given I am viewing on a mobile screen
+    And I have a feed with 5 test entries
+    When I open the all-entries page
+    Then the ".tab-bar a" control is at least 44px tall

--- a/e2e/steps/entries.steps.js
+++ b/e2e/steps/entries.steps.js
@@ -375,9 +375,13 @@ Then("I see a flash message", async ({ page }) => {
 });
 
 Then("the entry row for {string} shows as starred", async ({ page }, title) => {
-  // _entry_row.html renders a `.star-icon` span only when is_starred is true.
+  // Editorial redesign: the starred state lives on the star-action toggle —
+  // when starred it shows ★ and flips to aria-label "Unstar" + POST /unstar.
   const row = page.getByTestId("entry-item").filter({ hasText: title }).first();
-  await expect(row.locator(".star-icon")).toBeVisible();
+  await expect(row.getByTestId("entry-star-action")).toHaveAttribute(
+    "aria-label",
+    "Unstar",
+  );
 });
 
 Then("the entry row for {string} shows as unread", async ({ page }, title) => {

--- a/e2e/steps/responsive.steps.js
+++ b/e2e/steps/responsive.steps.js
@@ -123,3 +123,15 @@ Then("the reading pane overlay is dismissed", async ({ page }) => {
   await expect(pane).not.toHaveClass(/reading-pane-active/);
   await expect(pane).toBeHidden();
 });
+
+Then("the {string} control is at least {int}px tall", async ({ page }, selector, min) => {
+  const box = await page.locator(selector).first().boundingBox();
+  expect(box).not.toBeNull();
+  expect(box.height).toBeGreaterThanOrEqual(min);
+});
+
+Then("the {string} control is at least {int}px wide", async ({ page }, selector, min) => {
+  const box = await page.locator(selector).first().boundingBox();
+  expect(box).not.toBeNull();
+  expect(box.width).toBeGreaterThanOrEqual(min);
+});

--- a/e2e/steps/responsive.steps.js
+++ b/e2e/steps/responsive.steps.js
@@ -141,8 +141,12 @@ Then("the {string} control is at least {int}px wide", async ({ page }, selector,
 });
 
 Then("the {string} controls each span at least {int}% of the row", async ({ page }, selector, pct) => {
-  const row = await page.getByTestId("entry-item").first().boundingBox();
-  const btns = await page.locator(selector).all();
+  // "row" = the first entry-item; scope the controls to that same row so the
+  // width comparison is against the row they live in (rows are uniform width).
+  const firstRow = page.getByTestId("entry-item").first();
+  const row = await firstRow.boundingBox();
+  expect(row).not.toBeNull();
+  const btns = await firstRow.locator(selector).all();
   expect(btns.length).toBeGreaterThanOrEqual(2);
   for (const b of btns) {
     const box = await b.boundingBox();

--- a/e2e/steps/responsive.steps.js
+++ b/e2e/steps/responsive.steps.js
@@ -139,3 +139,14 @@ Then("the {string} control is at least {int}px wide", async ({ page }, selector,
   expect(box).not.toBeNull();
   expect(box.width).toBeGreaterThanOrEqual(min);
 });
+
+Then("the {string} controls each span at least {int}% of the row", async ({ page }, selector, pct) => {
+  const row = await page.getByTestId("entry-item").first().boundingBox();
+  const btns = await page.locator(selector).all();
+  expect(btns.length).toBeGreaterThanOrEqual(2);
+  for (const b of btns) {
+    const box = await b.boundingBox();
+    expect(box).not.toBeNull();
+    expect(box.width).toBeGreaterThanOrEqual((row.width * pct) / 100);
+  }
+});

--- a/e2e/steps/responsive.steps.js
+++ b/e2e/steps/responsive.steps.js
@@ -30,6 +30,10 @@ When("I open the categories page", async ({ page, serverUrl }) => {
   await page.goto(`${serverUrl}/categories`);
 });
 
+When("I open the all-entries page", async ({ page, serverUrl }) => {
+  await page.goto(`${serverUrl}/entries`);
+});
+
 When("I tap the hamburger", async ({ page }) => {
   await page.locator(".sidebar-toggle").click();
 });

--- a/e2e/steps/triage.steps.js
+++ b/e2e/steps/triage.steps.js
@@ -40,9 +40,13 @@ When("I mark the entry titled {string} read", async ({ page }, title) => {
 });
 
 Then("the entry titled {string} is marked starred", async ({ page }, title) => {
-  // After starring, _entry_row.html renders a <span class="star-icon">⭐</span> inside the row.
+  // Editorial redesign: the starred state lives on the star-action toggle —
+  // when starred it shows ★ and flips to aria-label "Unstar" + POST /unstar.
   const row = page.getByTestId("entry-item").filter({ hasText: title }).first();
-  await expect(row.locator(".star-icon")).toBeVisible();
+  await expect(row.getByTestId("entry-star-action")).toHaveAttribute(
+    "aria-label",
+    "Unstar",
+  );
 });
 
 Then("the sidebar starred count is at least {int}", async ({ page }, n) => {

--- a/src/handlers/pages/mod.rs
+++ b/src/handlers/pages/mod.rs
@@ -52,6 +52,23 @@ impl EntryRowView {
     pub fn summary_status_str(&self) -> Option<&'static str> {
         self.summary_status.map(|s| s.as_str())
     }
+
+    /// Uppercased first character of the feed title, for the favicon
+    /// letter-chip fallback shown when a feed has no icon. Returns "?" for
+    /// an empty title.
+    pub fn feed_initial(&self) -> String {
+        self.feed_title
+            .chars()
+            .next()
+            .map(|c| c.to_uppercase().to_string())
+            .unwrap_or_else(|| "?".to_string())
+    }
+
+    /// Stable index 0..6 into the favicon fallback colour palette, derived
+    /// from the feed id so the same feed always gets the same colour.
+    pub fn feed_color_index(&self) -> u8 {
+        self.feed_id.rem_euclid(6) as u8
+    }
 }
 
 /// View-model for the reading pane (`_reading_pane.html`).
@@ -2804,5 +2821,29 @@ mod tests {
     fn build_snippet_strips_html_comments() {
         let out = build_snippet(Some("hello <!-- secret note --> world"), "", 200);
         assert_eq!(out, "hello world");
+    }
+
+    #[test]
+    fn feed_initial_uppercases_first_char() {
+        let ewf = ewf_with_title("anything");
+        let row = row_view_from(&ewf, None); // feed_title = "Feed"
+        assert_eq!(row.feed_initial(), "F");
+    }
+
+    #[test]
+    fn feed_initial_handles_empty_title() {
+        let mut ewf = ewf_with_title("anything");
+        ewf.feed_title = Some(String::new());
+        let row = row_view_from(&ewf, None);
+        assert_eq!(row.feed_initial(), "?");
+    }
+
+    #[test]
+    fn feed_color_index_is_stable_and_bounded() {
+        let mut ewf = ewf_with_title("anything");
+        ewf.entry.feed_id = 13;
+        let row = row_view_from(&ewf, None);
+        assert_eq!(row.feed_color_index(), 1); // 13 % 6 == 1
+        assert!(row.feed_color_index() < 6);
     }
 }

--- a/src/handlers/pages/mod.rs
+++ b/src/handlers/pages/mod.rs
@@ -2825,9 +2825,10 @@ mod tests {
 
     #[test]
     fn feed_initial_uppercases_first_char() {
-        let ewf = ewf_with_title("anything");
-        let row = row_view_from(&ewf, None); // feed_title = "Feed"
-        assert_eq!(row.feed_initial(), "F");
+        let mut ewf = ewf_with_title("anything");
+        ewf.feed_title = Some("delta".to_string());
+        let row = row_view_from(&ewf, None);
+        assert_eq!(row.feed_initial(), "D");
     }
 
     #[test]
@@ -2839,11 +2840,24 @@ mod tests {
     }
 
     #[test]
+    fn feed_initial_uppercases_unicode() {
+        let mut ewf = ewf_with_title("anything");
+        ewf.feed_title = Some("über".to_string());
+        let row = row_view_from(&ewf, None);
+        assert_eq!(row.feed_initial(), "Ü");
+    }
+
+    #[test]
     fn feed_color_index_is_stable_and_bounded() {
         let mut ewf = ewf_with_title("anything");
         ewf.entry.feed_id = 13;
         let row = row_view_from(&ewf, None);
         assert_eq!(row.feed_color_index(), 1); // 13 % 6 == 1
+
+        // rem_euclid (not %) keeps the index non-negative for any id.
+        ewf.entry.feed_id = -1;
+        let row = row_view_from(&ewf, None);
+        assert_eq!(row.feed_color_index(), 5); // (-1).rem_euclid(6) == 5
         assert!(row.feed_color_index() < 6);
     }
 }

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -1704,12 +1704,14 @@ summary {
         height: auto;
     }
 
+    /* Clear the fixed hamburger that floats at top:--space-4 with a
+       --touch-min (44px) box: --space-4 gap + button + --space-4 gap. */
     .page-content {
-        padding: var(--space-16) var(--space-4) var(--space-4);
+        padding: calc(2 * var(--space-4) + var(--touch-min)) var(--space-4) var(--space-4);
     }
 
     .list-pane-header {
-        padding: var(--space-16) var(--space-4) var(--space-3);
+        padding: calc(2 * var(--space-4) + var(--touch-min)) var(--space-4) var(--space-3);
     }
 
     /* Allow tab-bar to scroll edge-to-edge */
@@ -1740,10 +1742,18 @@ summary {
         padding: var(--space-4);
     }
 
-    /* Banner stack: tighter padding on narrow viewports. */
+    /* Banner stack: tighter padding on narrow viewports. The 44px dismiss
+       button makes the grid row taller than the text, so center every cell
+       (overriding the base align-items:start) and drop the icon's first-line
+       offset so the dot centers too. */
     .banner {
         padding: var(--space-2);
         column-gap: var(--space-2);
+        align-items: center;
+    }
+
+    .banner-icon {
+        margin-top: 0;
     }
 
     /* On narrow viewports the fixed hamburger floats over the top-left
@@ -1751,12 +1761,10 @@ summary {
        --space-4 gap under the button as above/left of it — so banners
        stay full-width instead of indenting their content to dodge the
        button (which read as the button punching a hole in the banner).
-       Clearance = button top offset + button height + gap:
-       --space-4 + (--font-xl + 2 × --space-2 + 2px border) + --space-4
-       = 16 + 38 + 16 = 70px. `line-height: 1` on .sidebar-toggle makes
-       --font-xl the content height. */
+       Clearance = --space-4 gap + --touch-min button + --space-4 gap
+       = 16 + 44 + 16 = 76px, matching the no-flash header clearance above. */
     .main-content > .banner-stack:not(:empty) {
-        padding-top: calc(2 * var(--space-4) + var(--font-xl) + 2 * var(--space-2) + 2px);
+        padding-top: calc(2 * var(--space-4) + var(--touch-min));
     }
 
     /* While a banner is visible, the banner-stack's own padding-top
@@ -1790,6 +1798,7 @@ summary {
     .stats-period-btn,
     .feed-filter-link,
     .entry-action-btn,
+    .entry-item-actions a,
     .reading-pane-back-link,
     .entry-item-meta a,
     .breadcrumb a,
@@ -1855,9 +1864,12 @@ summary {
         font-size: var(--font-sm);
     }
 
-    /* Anti-mis-tap: widen gaps between adjacent tappable controls. */
+    /* Anti-mis-tap: widen gaps between adjacent tappable controls, and
+       vertically center the now-44px action items (read/star buttons vs the
+       plain "original" link) so they share a baseline instead of top-aligning. */
     .entry-item-actions {
         gap: var(--space-4);
+        align-items: center;
     }
 
     .tab-bar {

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -1806,9 +1806,10 @@ summary {
     }
 
     /* The entry-row toggles ship with padding:0 (.entry-item-actions
-       .entry-action-btn) — match that specificity here so the horizontal
-       room actually applies on mobile. */
-    .entry-item-actions .entry-action-btn {
+       .entry-action-btn). That rule sits later in source at equal 0-2-0,
+       so add the .entry-item ancestor here (0-3-0) to win regardless of
+       source order and apply the horizontal touch room on mobile. */
+    .entry-item .entry-item-actions .entry-action-btn {
         padding: var(--space-1) var(--space-2);
     }
 

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -1046,7 +1046,7 @@ td input[type="text"] {
     gap: var(--space-2);
 }
 .entry-item-title {
-    font-family: var(--font-display);
+    font-family: var(--font-ui);
     font-size: var(--font-base);
     font-weight: 600;
     line-height: 1.32;
@@ -1079,7 +1079,7 @@ td input[type="text"] {
     font-size: var(--font-sm);
     color: var(--color-text-secondary);
 }
-.entry-item-meta a { color: var(--color-text-secondary); font-weight: 500; }
+.entry-item-meta a { color: var(--color-text-secondary); }
 .entry-item-meta a:hover { color: var(--color-accent); }
 .entry-item-meta .meta-sep { color: var(--color-text-muted); }
 

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -1489,11 +1489,6 @@ mark {
     width: 100%;
 }
 
-.star-icon {
-    color: var(--color-accent);
-    font-size: var(--font-xs);
-}
-
 .auth-divider {
     text-align: center;
     margin-bottom: var(--space-4);

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -1814,11 +1814,14 @@ summary {
         display: flex;
     }
 
-    /* The entry-row toggles ship with padding:0 (.entry-item-actions
-       .entry-action-btn). That rule sits later in source at equal 0-2-0,
-       so add the .entry-item ancestor here (0-3-0) to win regardless of
-       source order and apply the horizontal touch room on mobile. */
-    .entry-item .entry-item-actions .entry-action-btn {
+    /* Give the read/star toggles AND the "original" link the same horizontal
+       padding so the spacing between all three action items is uniform (the
+       buttons would otherwise carry padding the bare link lacks). The toggles
+       ship with padding:0 (.entry-item-actions .entry-action-btn, later in
+       source at equal 0-2-0), so the .entry-item ancestor (0-3-0) is needed to
+       win regardless of source order. */
+    .entry-item .entry-item-actions .entry-action-btn,
+    .entry-item .entry-item-actions a {
         padding: var(--space-1) var(--space-2);
     }
 

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -48,6 +48,9 @@
     /* Borders */
     --border-accent-width: 3px;
 
+    /* Touch */
+    --touch-min: 2.75rem;   /* 44px — WCAG 2.5.5 / iOS minimum tap target */
+
     /* Icon sizes */
     --icon-sm: 14px;
     --icon-md: 18px;
@@ -1734,7 +1737,7 @@ summary {
     }
 
     .entry-item {
-        padding: var(--space-3) var(--space-4);
+        padding: var(--space-4);
     }
 
     /* Banner stack: tighter padding on narrow viewports. */
@@ -1766,6 +1769,86 @@ summary {
     body:has(.main-content > .banner-stack:not(:empty)) .list-pane-header,
     body:has(.main-content > .banner-stack:not(:empty)) .page-content {
         padding-top: var(--space-6);
+    }
+
+    /* ===== Mobile touch baseline — 44px minimum tap targets ===== */
+
+    /* Buttons are already inline-flex & centered (base styles); just raise
+       them to the touch minimum. */
+    button,
+    .btn {
+        min-height: var(--touch-min);
+    }
+
+    /* Link- and text-styled controls have little or no padding by default —
+       turn them into real flex boxes so min-height centers the label and the
+       whole box is tappable, not just the glyph run. */
+    .action-link,
+    .actions a,
+    .tab-bar a,
+    .reading-pane-nav-btn,
+    .stats-period-btn,
+    .feed-filter-link,
+    .entry-action-btn,
+    .reading-pane-back-link,
+    .entry-item-meta a,
+    .breadcrumb a,
+    .search-result-title,
+    .link a {
+        display: inline-flex;
+        align-items: center;
+        min-height: var(--touch-min);
+    }
+
+    /* The entry-row toggles ship with padding:0 — give them horizontal room. */
+    .entry-action-btn {
+        padding: var(--space-1) var(--space-2);
+    }
+
+    /* Square icon-only controls: width AND height must reach the minimum. */
+    .sidebar-toggle,
+    .sidebar-close,
+    .banner-dismiss {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-width: var(--touch-min);
+        min-height: var(--touch-min);
+    }
+
+    /* Drawer rows. */
+    .sidebar-item {
+        min-height: var(--touch-min);
+    }
+
+    /* Form controls: touch height + 16px font to suppress iOS focus-zoom. */
+    input[type="text"],
+    input[type="password"],
+    input[type="url"],
+    input[type="email"],
+    input[type="number"],
+    input[type="search"],
+    input[type="date"],
+    select,
+    textarea {
+        min-height: var(--touch-min);
+        font-size: var(--font-base);
+    }
+
+    /* Legibility: lift the smallest interactive/secondary text to 14px. */
+    .entry-item-meta,
+    .entry-item-actions,
+    .action-link {
+        font-size: var(--font-sm);
+    }
+
+    /* Anti-mis-tap: widen gaps between adjacent tappable controls. */
+    .entry-item-actions {
+        gap: var(--space-4);
+    }
+
+    .tab-bar {
+        gap: var(--space-2);
     }
 }
 

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -1047,7 +1047,9 @@ td input[type="text"] {
 }
 .entry-item-title {
     font-family: var(--font-ui);
-    font-size: var(--font-base);
+    /* Desktop sits next to the 14px sidebar, so the title matches that UI
+       scale; mobile bumps it to --font-base (see the media block). */
+    font-size: var(--font-sm);
     font-weight: 600;
     line-height: 1.32;
     color: var(--color-text);
@@ -1788,6 +1790,9 @@ summary {
 
     /* ===== Entry row (redesign) — mobile ===== */
     .entry-item { padding: var(--space-4); }
+
+    /* No sidebar visible on mobile, so the larger title reads fine here. */
+    .entry-item-title { font-size: var(--font-base); }
 
     /* Feed/category stay inline so "feed · category" wraps naturally. Vertical
        padding (not min-height/inline-flex, which would break the wrap) gives

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -986,81 +986,134 @@ td input[type="text"] {
     border: 0;
 }
 
-/* ===== Entry Items (List) ===== */
+/* ===== Entry Items (List) — editorial grid ===== */
 .entry-item {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    grid-template-areas:
+        "fav  head"
+        "fav  meta"
+        "foot foot";
+    column-gap: var(--space-3);
     padding: var(--space-4) var(--space-5);
     border-bottom: 1px solid var(--color-border-light);
     cursor: pointer;
     transition: background 0.1s;
 }
 
-.entry-item:hover {
-    background: var(--color-bg-secondary);
-}
+.entry-item:hover { background: var(--color-bg-secondary); }
 
 .entry-item.selected {
     background: var(--color-accent-subtle);
     box-shadow: inset var(--border-accent-width) 0 0 var(--color-accent);
 }
 
-.entry-item.entry-read {
-    opacity: 0.55;
-}
-
+.entry-item.entry-read { opacity: 0.62; }
 .entry-item.entry-read:hover,
-.entry-item.entry-read.selected {
-    opacity: 1;
-}
+.entry-item.entry-read.selected { opacity: 1; }
 
-.entry-item-title {
+/* Favicon spans the title+meta rows only (no tall empty column). */
+.entry-favicon {
+    grid-area: fav;
+    width: 24px;
+    height: 24px;
+    margin-top: 2px;
+    border-radius: var(--radius-control);
+    flex: none;
+    object-fit: cover;
+}
+.entry-favicon-chip {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #fff;
     font-family: var(--font-ui);
-    font-size: var(--font-sm);
-    line-height: 1.4;
+    font-size: var(--font-xs);
+    font-weight: 700;
+}
+.fav-c0 { background: #7C6F9B; }
+.fav-c1 { background: #B05B3B; }
+.fav-c2 { background: #3B7A6B; }
+.fav-c3 { background: #4A6FA5; }
+.fav-c4 { background: #A6563E; }
+.fav-c5 { background: #6E8B3D; }
+
+/* Head: serif title + summary badges + right-aligned time. */
+.entry-head {
+    grid-area: head;
+    display: flex;
+    align-items: baseline;
+    gap: var(--space-2);
+}
+.entry-item-title {
+    font-family: var(--font-display);
+    font-size: var(--font-base);
+    font-weight: 600;
+    line-height: 1.32;
     color: var(--color-text);
-    display: inline;
     cursor: pointer;
     overflow-wrap: break-word;
     word-break: break-word;
 }
-
-.entry-item-title:hover {
-    color: var(--color-accent);
+.entry-item-title:hover { color: var(--color-accent); }
+.entry-title-bold { font-weight: 600; }
+.entry-title-normal { font-weight: 400; }
+.entry-item-badges { flex: none; }
+.entry-time {
+    margin-left: auto;
+    flex: none;
+    font-family: var(--font-ui);
+    font-size: var(--font-xs);
+    color: var(--color-text-muted);
+    white-space: nowrap;
 }
 
-.entry-title-bold {
-    font-weight: 600;
-}
-
-.entry-title-normal {
-    font-weight: 400;
-}
-
+/* Meta: feed · category, flush-left with the title. */
 .entry-item-meta {
-    font-size: var(--font-xs);
-    margin-top: var(--space-2);
-    color: var(--color-text-muted);
-}
-
-.entry-item-actions {
-    margin-top: var(--space-2);
-    font-size: var(--font-xs);
+    grid-area: meta;
     display: flex;
-    gap: var(--space-3);
+    align-items: center;
+    gap: var(--space-1);
+    margin-top: var(--space-1);
+    font-family: var(--font-ui);
+    font-size: var(--font-sm);
+    color: var(--color-text-secondary);
 }
+.entry-item-meta a { color: var(--color-text-secondary); font-weight: 500; }
+.entry-item-meta a:hover { color: var(--color-accent); }
+.entry-item-meta .meta-sep { color: var(--color-text-muted); }
 
-/* Quiet secondary links (entry meta/actions, breadcrumb): muted until
-   hovered, then accent. */
-.entry-item-meta a,
-.entry-item-actions a,
-.breadcrumb a {
-    color: var(--color-text-muted);
+/* Actions: full-width strip. Desktop = quiet text links that brighten on
+   row hover; mobile (below) = full-width icon buttons. */
+.entry-item-actions {
+    grid-area: foot;
+    display: flex;
+    gap: var(--space-5);
+    margin-top: var(--space-2);
+    font-family: var(--font-ui);
+    font-size: var(--font-xs);
+    opacity: 0.72;
+    transition: opacity 0.1s;
 }
+.entry-item:hover .entry-item-actions,
+.entry-item.selected .entry-item-actions { opacity: 1; }
+.entry-action-btn,
+.entry-item-actions a {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35em;
+    padding: 0;
+    border: none;
+    background: none;
+    color: var(--color-text-secondary);
+    font: inherit;
+    cursor: pointer;
+}
+.entry-action-btn:hover,
+.entry-item-actions a:hover { color: var(--color-accent); }
 
-.entry-item-meta a:hover,
-.entry-item-actions a:hover,
-.breadcrumb a:hover {
-    color: var(--color-accent);
-}
+.breadcrumb a { color: var(--color-text-muted); }
+.breadcrumb a:hover { color: var(--color-accent); }
 
 /* ===== Actions (Table cell actions) ===== */
 .actions {
@@ -1738,8 +1791,39 @@ summary {
         align-items: center;
     }
 
-    .entry-item {
-        padding: var(--space-4);
+    /* ===== Entry row (redesign) — mobile ===== */
+    .entry-item { padding: var(--space-4); }
+
+    /* Feed/category: 24px tap area (AA floor; inline links are exempt from
+       the 44px rule), no horizontal padding so they stay flush with title. */
+    .entry-item-meta { margin-top: var(--space-2); }
+    .entry-item-meta a {
+        display: inline-flex;
+        align-items: center;
+        min-height: 24px;
+    }
+
+    /* Actions: full-width equal thirds, 44px tall, big icon, small padding,
+       always visible, icon-only (labels hidden). */
+    .entry-item-actions {
+        gap: var(--space-2);
+        margin-top: var(--space-3);
+        opacity: 1;
+    }
+    .entry-item-actions .action-label { display: none; }
+    /* The read/star buttons are form-wrapped; the form is the flex child, so
+       it carries the equal-thirds sizing and its button stretches to fill. */
+    .entry-item-actions form { flex: 1; }
+    .entry-action-btn,
+    .entry-item-actions a {
+        flex: 1;
+        justify-content: center;
+        gap: 0;
+        min-height: var(--touch-min);
+        padding: var(--space-2);
+        border: 1px solid var(--color-border-light);
+        border-radius: var(--radius-md);
+        font-size: var(--font-xl);
     }
 
     /* Banner stack: tighter padding on narrow viewports. The 44px dismiss
@@ -1797,10 +1881,7 @@ summary {
     .reading-pane-nav-btn,
     .stats-period-btn,
     .feed-filter-link,
-    .entry-action-btn,
-    .entry-item-actions a,
     .reading-pane-back-link,
-    .entry-item-meta a,
     .breadcrumb a,
     .search-result-title,
     .link a {
@@ -1812,17 +1893,6 @@ summary {
     /* Keep the full-row tap target for block-level title links. */
     .search-result-title {
         display: flex;
-    }
-
-    /* Give the read/star toggles AND the "original" link the same horizontal
-       padding so the spacing between all three action items is uniform (the
-       buttons would otherwise carry padding the bare link lacks). The toggles
-       ship with padding:0 (.entry-item-actions .entry-action-btn, later in
-       source at equal 0-2-0), so the .entry-item ancestor (0-3-0) is needed to
-       win regardless of source order. */
-    .entry-item .entry-item-actions .entry-action-btn,
-    .entry-item .entry-item-actions a {
-        padding: var(--space-1) var(--space-2);
     }
 
     /* Square icon-only controls: width AND height must reach the minimum. */
@@ -1861,18 +1931,8 @@ summary {
     }
 
     /* Legibility: lift the smallest interactive/secondary text to 14px. */
-    .entry-item-meta,
-    .entry-item-actions,
     .action-link {
         font-size: var(--font-sm);
-    }
-
-    /* Anti-mis-tap: widen gaps between adjacent tappable controls, and
-       vertically center the now-44px action items (read/star buttons vs the
-       plain "original" link) so they share a baseline instead of top-aligning. */
-    .entry-item-actions {
-        gap: var(--space-4);
-        align-items: center;
     }
 
     .tab-bar {
@@ -2245,26 +2305,16 @@ summary {
     padding: 0 var(--space-5);
 }
 
-/* SSR form-button actions inside `.entry-item-actions`. Mirrors the
-   muted-text + accent-on-hover styling of `.entry-item-actions a` so
-   form-wrapped read/star buttons read as inline action links. */
+/* SSR form-button actions inside `.entry-item-actions`. The read/star
+   buttons are form-wrapped (to carry their POST target), so the form is the
+   flex child of `.entry-item-actions`; it must `display: contents`-style
+   forward layout to its button. We instead make the form a transparent flex
+   box that stretches its button, matching `.entry-action-btn`/`a` styling
+   from the editorial-grid block above. */
 .entry-item-actions form {
-    display: inline;
+    display: flex;
     margin: 0;
     padding: 0;
-}
-
-.entry-item-actions .entry-action-btn {
-    background: transparent;
-    border: none;
-    padding: 0;
-    color: var(--color-text-muted);
-    font: inherit;
-    cursor: pointer;
-}
-
-.entry-item-actions .entry-action-btn:hover {
-    color: var(--color-accent);
 }
 
 /* Mobile: align load-more / mark-above wrappers with .entry-item (which drops

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -1071,12 +1071,12 @@ td input[type="text"] {
 /* Meta: feed · category, flush-left with the title. */
 .entry-item-meta {
     grid-area: meta;
-    display: flex;
-    align-items: center;
-    gap: var(--space-1);
+    /* Inline text flow (not flex) so "feed · category" wraps naturally as one
+       run of text instead of two side-by-side blocks. */
     margin-top: var(--space-1);
     font-family: var(--font-ui);
     font-size: var(--font-sm);
+    line-height: 1.5;
     color: var(--color-text-secondary);
 }
 .entry-item-meta a { color: var(--color-text-secondary); }
@@ -1789,13 +1789,16 @@ summary {
     /* ===== Entry row (redesign) — mobile ===== */
     .entry-item { padding: var(--space-4); }
 
-    /* Feed/category: 24px tap area (AA floor; inline links are exempt from
-       the 44px rule), no horizontal padding so they stay flush with title. */
-    .entry-item-meta { margin-top: var(--space-2); }
+    /* Feed/category stay inline so "feed · category" wraps naturally. Vertical
+       padding (not min-height/inline-flex, which would break the wrap) gives
+       each inline link a ~28px hit box — inline links are exempt from the 44px
+       rule. No horizontal padding so they stay flush with the title. */
+    .entry-item-meta {
+        margin-top: var(--space-2);
+        line-height: 1.7;
+    }
     .entry-item-meta a {
-        display: inline-flex;
-        align-items: center;
-        min-height: 24px;
+        padding: 0.375rem 0;
     }
 
     /* Actions: full-width equal thirds, 44px tall, big icon, small padding,

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -1800,8 +1800,15 @@ summary {
         min-height: var(--touch-min);
     }
 
-    /* The entry-row toggles ship with padding:0 — give them horizontal room. */
-    .entry-action-btn {
+    /* Keep the full-row tap target for block-level title links. */
+    .search-result-title {
+        display: flex;
+    }
+
+    /* The entry-row toggles ship with padding:0 (.entry-item-actions
+       .entry-action-btn) — match that specificity here so the horizontal
+       room actually applies on mobile. */
+    .entry-item-actions .entry-action-btn {
         padding: var(--space-1) var(--space-2);
     }
 
@@ -1832,6 +1839,11 @@ summary {
     select,
     textarea {
         min-height: var(--touch-min);
+        font-size: var(--font-base);
+    }
+
+    /* Filter-bar selects need the 16px floor too (beats .filter-bar select). */
+    .filter-bar select {
         font-size: var(--font-base);
     }
 

--- a/templates/_entry_row.html
+++ b/templates/_entry_row.html
@@ -1,32 +1,41 @@
-{# Single entry row. Matches the pre-SSR `.entry-item-*` DOM the existing
-   CSS rules target. The form-wrapped buttons in `.entry-item-actions`
-   are styled to read as inline action links via the `.entry-action-btn`
-   rule. `id="entry-row-{id}"` is the swap target used by the multi-target
-   star/read action endpoints. #}
+{# Single entry row — editorial CSS-grid layout (see
+   docs/superpowers/specs/2026-06-13-entry-item-redesign-design.md).
+   Grid areas: "fav head" / "fav meta" / "foot foot". The form-wrapped
+   action buttons keep their data-testids and POST targets so triage and
+   responsive e2e keep working; on mobile the .action-label spans are
+   hidden (CSS) leaving icon-only 44px buttons. #}
 <div id="entry-row-{{ r.id }}" class="entry-item{% if r.is_read %} entry-read{% endif %}" data-entry-row data-entry-id="{{ r.id }}" data-testid="entry-item">
-    <div>
+    {% if r.feed_has_icon %}
+    <img class="entry-favicon" src="/api/feeds/{{ r.feed_id }}/icon" alt="" loading="lazy" width="24" height="24">
+    {% else %}
+    <span class="entry-favicon entry-favicon-chip fav-c{{ r.feed_color_index() }}" aria-hidden="true">{{ r.feed_initial() }}</span>
+    {% endif %}
+
+    <div class="entry-head">
         <a href="/entries/{{ r.id }}/fragment" data-swap="#reading-pane" class="entry-item-title {% if r.is_read %}entry-title-normal{% else %}entry-title-bold{% endif %}" data-testid="entry-title-link">{{ r.title }}</a>
-        <span class="entry-item-badges">{% if r.is_starred %}<span title="Starred" class="star-icon">⭐</span>{% endif %}{% match r.summary_status_str() %}
+        <span class="entry-item-badges">{% match r.summary_status_str() %}
             {% when Some("completed") %}<span title="Has Summary" class="summary-badge">✅</span>
             {% when Some("pending") %}<span title="Pending" class="summary-badge-pending">⏳</span>
             {% when Some("processing") %}<span title="Processing" class="summary-badge-processing">🔄</span>
             {% when Some("failed") %}<span title="Failed" class="summary-badge-failed">❌</span>
             {% when _ %}
         {% endmatch %}</span>
+        <time class="entry-time" datetime="{{ r.published_at_iso }}">{{ r.published_relative }}</time>
     </div>
+
     <div class="muted entry-item-meta">
-        {% if r.feed_has_icon %}<img class="feed-icon" src="/api/feeds/{{ r.feed_id }}/icon" alt="" loading="lazy" width="16" height="16">{% endif %}
-        <a href="/feeds/{{ r.feed_id }}/entries">{{ r.feed_title }}</a> &middot;
-        <a href="/categories/{{ r.category_id }}/entries">{{ r.category_name }}</a> &middot;
-        <time datetime="{{ r.published_at_iso }}">{{ r.published_relative }}</time>
+        <a href="/feeds/{{ r.feed_id }}/entries">{{ r.feed_title }}</a>
+        <span class="meta-sep">·</span>
+        <a href="/categories/{{ r.category_id }}/entries">{{ r.category_name }}</a>
     </div>
+
     <div class="entry-item-actions">
         <form method="post" action="/entries/{{ r.id }}/{% if r.is_read %}unread{% else %}read{% endif %}" data-swap="#entry-row-{{ r.id }}">
-            <button type="submit" class="entry-action-btn" data-testid="entry-read-action">{% if r.is_read %}unread{% else %}read{% endif %}</button>
+            <button type="submit" class="entry-action-btn" data-testid="entry-read-action" aria-label="{% if r.is_read %}Mark unread{% else %}Mark read{% endif %}"><span class="action-icon" aria-hidden="true">{% if r.is_read %}↺{% else %}✓{% endif %}</span><span class="action-label">{% if r.is_read %}unread{% else %}read{% endif %}</span></button>
         </form>
         <form method="post" action="/entries/{{ r.id }}/{% if r.is_starred %}unstar{% else %}star{% endif %}" data-swap="#entry-row-{{ r.id }}">
-            <button type="submit" class="entry-action-btn" data-testid="entry-star-action">{% if r.is_starred %}unstar{% else %}star{% endif %}</button>
+            <button type="submit" class="entry-action-btn" data-testid="entry-star-action" aria-label="{% if r.is_starred %}Unstar{% else %}Star{% endif %}"><span class="action-icon" aria-hidden="true">{% if r.is_starred %}★{% else %}☆{% endif %}</span><span class="action-label">{% if r.is_starred %}starred{% else %}star{% endif %}</span></button>
         </form>
-        {% if let Some(link) = r.link.as_ref() %}<a href="{{ link }}" target="_blank" rel="noopener noreferrer" data-testid="entry-original-link">original</a>{% endif %}
+        {% if let Some(link) = r.link.as_ref() %}<a href="{{ link }}" target="_blank" rel="noopener noreferrer" data-testid="entry-original-link" aria-label="Open original"><span class="action-icon" aria-hidden="true">↗</span><span class="action-label">original</span></a>{% endif %}
     </div>
 </div>

--- a/tests/handlers_test.rs
+++ b/tests/handlers_test.rs
@@ -3926,8 +3926,8 @@ async fn test_star_entry_form_is_idempotent_mark_starred() {
         "multi-target sidebar block must be present"
     );
     assert!(
-        html.contains("star-icon"),
-        "row must reflect starred state via the .star-icon span after first call"
+        html.contains("aria-label=\"Unstar\""),
+        "row must reflect starred state via the star toggle's Unstar aria-label after first call"
     );
     // Pane Star button swap must be present so the reading-pane button label
     // can flip to "Unstar" when the pane is visible.
@@ -3948,8 +3948,8 @@ async fn test_star_entry_form_is_idempotent_mark_starred() {
     assert_eq!(resp2.status_code(), StatusCode::OK);
     let html2 = resp2.text();
     assert!(
-        html2.contains("star-icon"),
-        "second /star call must be a no-op — row must still carry .star-icon"
+        html2.contains("aria-label=\"Unstar\""),
+        "second /star call must be a no-op — row star toggle must still show Unstar"
     );
     assert!(
         html2.contains(">Unstar<"),
@@ -4021,8 +4021,8 @@ async fn test_unstar_entry_form_is_idempotent_mark_unstarred() {
     assert_eq!(resp.status_code(), StatusCode::OK);
     let html = resp.text();
     assert!(
-        !html.contains("star-icon"),
-        "row must drop .star-icon after /unstar"
+        !html.contains("aria-label=\"Unstar\""),
+        "row star toggle must show Star (not Unstar) after /unstar"
     );
     assert!(
         html.contains(">Star<"),
@@ -4037,7 +4037,7 @@ async fn test_unstar_entry_form_is_idempotent_mark_unstarred() {
     assert_eq!(resp2.status_code(), StatusCode::OK);
     let html2 = resp2.text();
     assert!(
-        !html2.contains("star-icon"),
+        !html2.contains("aria-label=\"Unstar\""),
         "second /unstar call must be a no-op — row must still be unstarred"
     );
 }


### PR DESCRIPTION
## Summary

Improves the mobile experience where interactive elements were too small to tap reliably, then rebuilds the entry-list row as one coherent layout for desktop and mobile.

**1. Mobile touch baseline (CSS-only)**
- New `--touch-min: 44px` token; a touch baseline inside `@media (max-width: 1024px)` raising buttons, links, inputs, sidebar items, tabs, the hamburger/close, and the banner dismiss to ≥44px (text-only controls turned into real flex hit areas).
- Inputs forced to 16px on mobile to suppress iOS focus-zoom; wider gaps between adjacent controls; fixed the entry-row padding regression; banner/header clearance unified around the larger hamburger.

**2. Editorial entry-row redesign (Option C)**
- CSS grid (`fav / head / meta / foot`) used identically on desktop and mobile.
- Always-present leading feed favicon, with a deterministic 6-colour letter-chip fallback (`EntryRowView::feed_initial()` / `feed_color_index()`) when a feed has no icon.
- Sans title + right-aligned time; darker `feed · category` meta with a 24px mobile tap area flush-left with the title.
- Actions: quiet hover text links on desktop; full-width 44px icon buttons on mobile (icon-only with `aria-label`s). All existing `data-testid`s and POST endpoints preserved.

## Test Plan
- [x] `cargo nextest run` — 894 passed (incl. new favicon-helper unit tests: unicode, empty title, negative-id `rem_euclid`).
- [x] Full Playwright-BDD e2e — 112 passed, including new `@mobile` tap-target and entry-row-redesign scenarios; triage/responsive/keyboard suites green.
- [x] Star/unstar idempotency handler tests updated to assert starred state via the `aria-label="Unstar"` toggle (the redesign removed the standalone star badge).
- [ ] Manual check on a real phone: inbox list, reading pane, sidebar drawer, tables, flash banner.

## Notes
- All work sits on one branch as a single mobile-layout effort. Specs/plans under `docs/superpowers/`.
- Optional follow-ups (non-blocking): broaden the e2e span-% assertion to cover the original-link control; consolidate the two `.entry-item-badges` rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)