### PR TITLE
Reading pane redesign: mobile bottom action bar + editorial chrome + inline SVG icon set

### DIFF
--- a/docs/superpowers/plans/2026-06-14-reading-pane-redesign.md
+++ b/docs/superpowers/plans/2026-06-14-reading-pane-redesign.md
@@ -1,0 +1,714 @@
+# Reading Pane Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Redesign the reading-pane chrome (toolbar, header/meta, action controls, summary-box controls) for desktop and mobile — mobile gets a fixed bottom action bar, desktop a same-level inline action row — reusing the entry-row visual language (favicon chip, icon + label controls, generous tap targets). Article body typography is untouched.
+
+**Architecture:** Presentation-layer change. A small Rust addition gives `ReadingPaneView` the feed identity for the favicon chip (with the `feed_initial` / `feed_color_index` logic extracted to shared free functions so `EntryRowView` and `ReadingPaneView` both delegate). The template swaps the per-button `.btn-secondary .btn-sm` cluster for a shared `.rp-action` control (icon + label spans, stable `aria-label`s), adds the favicon chip to the meta line, and makes the prev/next nav icon-only on mobile. CSS restyles the actions: a fixed bottom bar inside the existing `@media (max-width: 1024px)` block on mobile, a single nowrap inline row on desktop. No new JS.
+
+**Tech Stack:** Rust (Axum + Askama, `src/handlers/`), Askama templates (`templates/`), CSS (`static/css/app.css`), Playwright-BDD e2e (`e2e/`).
+
+---
+
+## Notes for the implementer
+
+- **Environment:** This is a NixOS box; re-source the OpenSSL env before **every**
+  cargo/e2e command: `source /tmp/rdrs-env.sh`.
+- **`pwd` first** for build/test/git (multi-project workspace rule); expect
+  `/home/nixos/Develop/claude/rdrs`.
+- **Run Rust tests with `cargo nextest run`** (not `cargo test`), and set
+  `RDRS_FAST_HASH=1` to use minimal Argon2 cost (much faster).
+- **Run `cargo fmt` before committing Rust.**
+- **e2e runs from `e2e/`** and **requires `cargo build` first** — the CSS is
+  `include_str!`'d into the binary and the e2e global-setup skips rebuild if the
+  binary exists. After any CSS/Rust/template change: `cargo build`, then e2e.
+  After `.feature` edits run `npx bddgen` (the test command does this for you,
+  but if you run a single generated spec directly, regenerate first).
+- **Commits are GPG-signed** (`git commit -S`). End each message with the
+  `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>` trailer.
+- **Stage files explicitly by name** — never `git add -A` / `git add .`.
+- Current branch is `feat/reading-pane-redesign` (already created).
+
+---
+
+## File Structure
+
+- `src/handlers/pages/mod.rs` — extract `feed_initial(&str)` / `feed_color_index(i64)`
+  free functions; `EntryRowView` methods delegate to them; add `feed_id` /
+  `feed_has_icon` fields + delegating methods to `ReadingPaneView`; unit tests.
+- `src/handlers/entries.rs` — populate the two new `ReadingPaneView` fields in
+  the single constructor `build_reading_pane_view` (`entries.rs:213`).
+- `templates/_reading_pane.html` — favicon chip in meta; `.rp-action` controls
+  with icon/label spans + `aria-label`s; nav icon-only + `.nav-label`;
+  summary-box Copy/Dismiss restyle.
+- `static/css/app.css` — title size; meta favicon override + favicon-safe
+  separator rule; `.rp-action` base + desktop row; `.nav-label`; mobile fixed
+  bottom bar + content padding-bottom + icon-only nav (inside the existing
+  `@media (max-width: 1024px)` block, which ends at the lone `}` after the
+  mobile rules).
+- `tests/handlers_test.rs` — extend `test_entry_fragment_renders_reading_pane`
+  with favicon-chip + `.rp-action`/`aria-label` assertions.
+- `e2e/features/reading.feature` — new `@mobile` bottom-bar scenario.
+- `e2e/steps/responsive.steps.js` — already has the generic
+  `the "{selector}" control is at least {int}px tall/wide` steps (reuse them).
+
+---
+
+## Task 1: Rust — shared favicon helpers + `ReadingPaneView` feed identity
+
+Extract the favicon-chip logic into free functions, have both view-models
+delegate, and give `ReadingPaneView` the `feed_id` / `feed_has_icon` it needs.
+
+**Files:**
+- Modify: `src/handlers/pages/mod.rs` (`EntryRowView` impl ~48-72; `ReadingPaneView` struct ~80-101; tests module ~2826)
+- Modify: `src/handlers/entries.rs:213` (constructor)
+
+- [ ] **Step 1: Write failing unit tests for the free functions**
+
+Append inside the `mod tests { … }` block in `src/handlers/pages/mod.rs`
+(near the existing `feed_initial_*` / `feed_color_index_*` tests, ~line 2861):
+
+```rust
+    #[test]
+    fn feed_initial_fn_uppercases_first_char() {
+        assert_eq!(super::feed_initial("daring fireball"), "D");
+    }
+
+    #[test]
+    fn feed_initial_fn_handles_empty() {
+        assert_eq!(super::feed_initial(""), "?");
+    }
+
+    #[test]
+    fn feed_initial_fn_uppercases_unicode() {
+        assert_eq!(super::feed_initial("über"), "Ü");
+    }
+
+    #[test]
+    fn feed_color_index_fn_is_bounded() {
+        assert_eq!(super::feed_color_index(13), 1); // 13 % 6 == 1
+        assert_eq!(super::feed_color_index(-1), 5); // (-1).rem_euclid(6) == 5
+        assert!(super::feed_color_index(123_456) < 6);
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they FAIL (functions undefined)**
+
+```bash
+pwd   # /home/nixos/Develop/claude/rdrs
+source /tmp/rdrs-env.sh
+RDRS_FAST_HASH=1 cargo nextest run -p rdrs feed_initial_fn 2>&1 | tail -20
+```
+
+Expected: compile error — `super::feed_initial` / `super::feed_color_index` not
+found.
+
+- [ ] **Step 3: Add the free functions and delegate from `EntryRowView`**
+
+In `src/handlers/pages/mod.rs`, add these two free functions just above the
+`EntryRowView` struct (~line 30, after the section comment):
+
+```rust
+/// Uppercased first character of a feed title, for the favicon letter-chip
+/// fallback shown when a feed has no icon. Returns "?" for an empty title.
+pub(crate) fn feed_initial(feed_title: &str) -> String {
+    feed_title
+        .chars()
+        .next()
+        .map(|c| c.to_uppercase().to_string())
+        .unwrap_or_else(|| "?".to_string())
+}
+
+/// Stable index 0..6 into the favicon fallback colour palette, derived from
+/// the feed id so the same feed always gets the same colour.
+pub(crate) fn feed_color_index(feed_id: i64) -> u8 {
+    feed_id.rem_euclid(6) as u8
+}
+```
+
+Then replace the bodies of the existing `EntryRowView` methods (~lines 59-71) to
+delegate:
+
+```rust
+    pub fn feed_initial(&self) -> String {
+        feed_initial(&self.feed_title)
+    }
+
+    pub fn feed_color_index(&self) -> u8 {
+        feed_color_index(self.feed_id)
+    }
+```
+
+- [ ] **Step 4: Add fields + delegating methods to `ReadingPaneView`**
+
+In the `ReadingPaneView` struct (`src/handlers/pages/mod.rs`, ~80-101), add two
+fields (place them after `feed_title`):
+
+```rust
+    pub feed_title: String,
+    pub feed_id: i64,
+    pub feed_has_icon: bool,
+```
+
+Add an `impl` block immediately after the struct's closing `}` (~line 101):
+
+```rust
+impl ReadingPaneView {
+    /// Uppercased first character of the feed title for the favicon
+    /// letter-chip fallback (mirrors `EntryRowView::feed_initial`).
+    pub fn feed_initial(&self) -> String {
+        feed_initial(&self.feed_title)
+    }
+
+    /// Stable favicon-palette index derived from the feed id (mirrors
+    /// `EntryRowView::feed_color_index`).
+    pub fn feed_color_index(&self) -> u8 {
+        feed_color_index(self.feed_id)
+    }
+}
+```
+
+- [ ] **Step 5: Populate the new fields in the constructor**
+
+In `src/handlers/entries.rs`, in `build_reading_pane_view` (the `Ok(ReadingPaneView {`
+literal at line 213), add the two fields right after `feed_title`:
+
+```rust
+        feed_title: ewf.feed_title.clone().unwrap_or_default(),
+        feed_id: ewf.entry.feed_id,
+        feed_has_icon: ewf.feed_has_icon,
+```
+
+- [ ] **Step 6: Run the tests to verify they PASS**
+
+```bash
+pwd
+source /tmp/rdrs-env.sh
+cargo fmt
+RDRS_FAST_HASH=1 cargo nextest run -p rdrs feed_initial 2>&1 | tail -20
+RDRS_FAST_HASH=1 cargo nextest run -p rdrs feed_color_index 2>&1 | tail -20
+```
+
+Expected: all `feed_initial_*` / `feed_color_index_*` tests PASS (the new
+free-fn tests plus the pre-existing `EntryRowView` delegating tests). Also
+confirm the crate builds: `cargo build 2>&1 | tail -5`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /home/nixos/Develop/claude/rdrs
+git add src/handlers/pages/mod.rs src/handlers/entries.rs
+git commit -S -m "refactor(pane): share favicon helpers, add feed identity to ReadingPaneView
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Template — favicon chip, `.rp-action` controls, icon-only nav
+
+Rewrite the reading-pane chrome markup. Keep every swap target, `data-testid`,
+form action, and accessible name. The handler test assertions are the test.
+
+**Files:**
+- Modify: `templates/_reading_pane.html`
+- Modify: `tests/handlers_test.rs` (`test_entry_fragment_renders_reading_pane`, ~3624)
+
+- [ ] **Step 1: Add favicon-chip + `.rp-action` + nav assertions (failing)**
+
+In `tests/handlers_test.rs`, inside `test_entry_fragment_renders_reading_pane`,
+after the existing `assert!(html.contains("Body text here") …)` (~line 3630),
+add:
+
+```rust
+    // Editorial redesign: meta shows the feed favicon chip (feed "Test Feed"
+    // has no icon -> coloured initial chip "T").
+    assert!(
+        html.contains("entry-favicon-chip"),
+        "reading pane meta must render the favicon chip fallback"
+    );
+    // Actions use the shared .rp-action control with stable aria-labels.
+    assert!(
+        html.contains(r#"class="rp-action""#),
+        "reading pane actions must use the .rp-action control"
+    );
+    assert!(
+        html.contains(r#"aria-label="Mark Unread""#),
+        "Mark Unread action must keep its accessible name"
+    );
+```
+
+- [ ] **Step 2: Run to verify it FAILS**
+
+```bash
+pwd
+source /tmp/rdrs-env.sh
+RDRS_FAST_HASH=1 cargo nextest run -p rdrs test_entry_fragment_renders_reading_pane 2>&1 | tail -20
+```
+
+Expected: FAIL — `entry-favicon-chip` / `rp-action` not yet in the template.
+
+- [ ] **Step 3: Rewrite the toolbar nav (icon-only on mobile)**
+
+In `templates/_reading_pane.html`, replace the two `.reading-pane-nav-btn`
+buttons (~lines 22-23) with versions that carry an `aria-label` and wrap the
+word in a `.nav-label` span (hidden on mobile via CSS):
+
+```html
+            <button type="button" class="reading-pane-nav-btn" data-pane-prev data-testid="reading-pane-prev" aria-label="Previous" disabled>‹<span class="nav-label"> Previous</span></button>
+            <button type="button" class="reading-pane-nav-btn" data-pane-next data-testid="reading-pane-next" aria-label="Next" disabled><span class="nav-label">Next </span>›</button>
+```
+
+- [ ] **Step 4: Add the favicon chip to the meta line**
+
+Replace the `.reading-pane-meta` block (~lines 30-34) with:
+
+```html
+        <div class="reading-pane-meta">
+            {% if pane.feed_has_icon %}
+            <img class="entry-favicon" src="/api/feeds/{{ pane.feed_id }}/icon" alt="" width="24" height="24">
+            {% else %}
+            <span class="entry-favicon entry-favicon-chip fav-c{{ pane.feed_color_index() }}" aria-hidden="true">{{ pane.feed_initial() }}</span>
+            {% endif %}
+            <span data-testid="reading-pane-feed-title">{{ pane.feed_title }}</span>
+            {% if let Some(author) = pane.author.as_ref() %}<span>{{ author }}</span>{% endif %}
+            {% if let Some(ts) = pane.published_at_iso.as_ref() %}<time datetime="{{ ts }}" data-testid="reading-pane-published-at">{{ pane.published_relative }}</time>{% endif %}
+        </div>
+```
+
+(The mid-dot separator is handled in CSS Task 3 Step 2 — the new rule is
+favicon-safe and only dots when an author is present, matching today.)
+
+- [ ] **Step 5: Rewrite the actions block to `.rp-action` controls**
+
+Replace the entire `.reading-pane-actions` block (~lines 35-69) with the
+following. Each control is `icon span (aria-hidden) + label span`; the
+`aria-label` carries the canonical name the e2e suite relies on:
+
+```html
+        <div class="reading-pane-actions">
+            <form id="reading-pane-star-form-{{ pane.id }}" method="post" action="/entries/{{ pane.id }}/{% if pane.is_starred %}unstar{% else %}star{% endif %}" data-swap="#entry-row-{{ pane.id }}">
+                <button type="submit" class="rp-action" aria-label="{% if pane.is_starred %}Unstar{% else %}Star{% endif %}"><span class="action-icon" aria-hidden="true">{% if pane.is_starred %}★{% else %}☆{% endif %}</span><span class="action-label">{% if pane.is_starred %}Starred{% else %}Star{% endif %}</span></button>
+            </form>
+            <form method="post" action="/entries/{{ pane.id }}/unread" data-swap="#entry-row-{{ pane.id }}">
+                <button type="submit" class="rp-action" aria-label="Mark Unread"><span class="action-icon" aria-hidden="true">↺</span><span class="action-label">Unread</span></button>
+            </form>
+            {% if let Some(link) = pane.link.as_ref() %}
+            {% if pane.is_full_content %}
+            <a href="/entries/{{ pane.id }}/fragment" data-swap="#reading-pane" class="rp-action" aria-label="Show Original"><span class="action-icon" aria-hidden="true">↩</span><span class="action-label">Original</span></a>
+            {% else %}
+            <form method="post" action="/entries/{{ pane.id }}/fetch-full-content" data-swap="#reading-pane">
+                <button type="submit" class="rp-action" aria-label="Fetch Full Content"><span class="action-icon" aria-hidden="true">⤓</span><span class="action-label">Full content</span></button>
+            </form>
+            {% endif %}
+            {% if pane.has_kagi || pane.summary_in_flight %}
+            <form method="post" action="/entries/{{ pane.id }}/summarize" data-swap="#rp-summary-container">
+                <button type="submit" class="rp-action" aria-label="Summarize"{% if pane.summary_in_flight %} disabled{% endif %}><span class="action-icon" aria-hidden="true">✦</span><span class="action-label">Summarize</span></button>
+            </form>
+            {% endif %}
+            {% if pane.has_save %}
+            <form method="post" action="/entries/{{ pane.id }}/save" data-swap="#reading-pane">
+                <button type="submit" class="rp-action" aria-label="Save"><span class="action-icon" aria-hidden="true">⬇</span><span class="action-label">Save</span></button>
+            </form>
+            {% endif %}
+            {% endif %}
+        </div>
+```
+
+- [ ] **Step 6: Restyle the summary-box Copy / Dismiss controls**
+
+In the same file, replace the two `.summary-actions` buttons (~lines 81-83) with
+`.rp-action` controls:
+
+```html
+                <div class="summary-actions">
+                    <button type="button" class="rp-action" data-summary-copy aria-label="Copy summary"><span class="action-icon" aria-hidden="true">⧉</span><span class="action-label">Copy</span></button>
+                    <button type="button" class="rp-action" data-summary-dismiss data-entry-id="{{ pane.id }}" aria-label="Dismiss summary"><span class="action-icon" aria-hidden="true">✕</span><span class="action-label">Dismiss</span></button>
+                </div>
+```
+
+- [ ] **Step 7: Run the handler test to verify it PASSES**
+
+```bash
+pwd
+source /tmp/rdrs-env.sh
+RDRS_FAST_HASH=1 cargo nextest run -p rdrs test_entry_fragment_renders_reading_pane 2>&1 | tail -20
+```
+
+Expected: PASS. Then run the full reading-pane-related Rust suite to catch any
+assertion that referenced the old markup:
+
+```bash
+RDRS_FAST_HASH=1 cargo nextest run -p rdrs reading 2>&1 | tail -20
+RDRS_FAST_HASH=1 cargo nextest run -p rdrs star 2>&1 | tail -20
+```
+
+Expected: PASS. If a test asserted the old `btn-sm` / "Star"/"Mark Unread" plain
+text, update it to the new markup (the star toggle still exposes
+`aria-label="Unstar"` when starred; the swap target `#reading-pane-star-form-…`
+is unchanged).
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /home/nixos/Develop/claude/rdrs
+git add templates/_reading_pane.html tests/handlers_test.rs
+git commit -S -m "feat(pane): favicon chip + .rp-action controls + icon-only nav markup
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: CSS — title size, `.rp-action`, desktop row, mobile bottom bar
+
+All new mobile rules go **inside** the existing `@media (max-width: 1024px)`
+block. Desktop rules go in the main (top) section near the existing
+`.reading-pane-*` rules (~lines 449-571).
+
+**Files:**
+- Modify: `static/css/app.css`
+
+- [ ] **Step 1: Shrink the title (desktop)**
+
+Change `.reading-pane-title` `font-size` (line ~532) from `var(--font-3xl)` to:
+
+```css
+    font-size: var(--font-2xl);
+```
+
+- [ ] **Step 2: Replace the meta separator rule with a favicon-safe one**
+
+The current rule (~lines 552-555) assumes the feed title is the first child; the
+favicon now precedes it. Replace that rule with one anchored to the feed-title
+span and gated on an author being present (a `<span>` that is neither the
+feed-title nor the favicon chip):
+
+```css
+/* Mid-dot separators before author/time, only when an author span is present.
+   Anchored to the feed-title so the leading favicon (img or chip span) never
+   gets a dot. */
+.reading-pane-meta:has(> span:not([data-testid]):not(.entry-favicon)) [data-testid="reading-pane-feed-title"] ~ *::before {
+    content: "·";
+    margin-right: var(--space-2);
+}
+```
+
+Add, right after it, a small override so the reused entry-row favicon centers in
+the flex meta line (its base rule has `margin-top: 2px` for the entry grid):
+
+```css
+.reading-pane-meta .entry-favicon {
+    margin-top: 0;
+}
+```
+
+- [ ] **Step 3: Add the `.rp-action` base + desktop action row**
+
+Replace the existing `.reading-pane-actions` rule (~lines 557-564) with the row
+container plus the shared control. (Desktop: same-level, nowrap, no grouping.)
+
+```css
+.reading-pane-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+    margin-bottom: var(--space-8);
+    padding-bottom: var(--space-6);
+    border-bottom: 1px solid var(--color-border-light);
+}
+
+/* Shared pane action control (also used by the summary-box Copy/Dismiss).
+   Icon + label, never wraps its label; desktop ~40px tall. */
+.rp-action {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    min-height: 2.5rem;
+    padding: 0 var(--space-4);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: var(--color-bg);
+    color: var(--color-text-secondary);
+    font-family: var(--font-ui);
+    font-size: var(--font-sm);
+    line-height: 1;
+    white-space: nowrap;
+    cursor: pointer;
+    text-decoration: none;
+}
+
+.rp-action:hover {
+    color: var(--color-accent);
+    border-color: var(--color-accent);
+}
+
+.rp-action .action-icon {
+    color: var(--color-accent);
+}
+
+.rp-action:disabled {
+    opacity: 0.5;
+    cursor: default;
+}
+```
+
+- [ ] **Step 4: Add the `.nav-label` rule (visible by default)**
+
+Add near the `.reading-pane-nav-btn` rules (~line 510):
+
+```css
+/* The prev/next word labels; hidden on mobile (icon-only) in the media block. */
+.nav-label {
+    display: inline;
+}
+```
+
+- [ ] **Step 5: Add the mobile rules inside `@media (max-width: 1024px)`**
+
+Find the `@media (max-width: 1024px)` block. Add the following just after the
+existing `.reading-pane-back-link { … }` rule (~line 1789), still inside the
+media block:
+
+```css
+    /* Title is smaller on mobile (no sidebar to size against on desktop). */
+    .reading-pane-title {
+        font-size: var(--font-xl);
+    }
+
+    /* Prev/next become icon-only to save toolbar width; keep a square-ish
+       touch target (the generic baseline already sets min-height). */
+    .nav-label {
+        display: none;
+    }
+
+    .reading-pane-nav-btn {
+        min-width: var(--touch-min);
+        justify-content: center;
+    }
+
+    /* Actions move to a fixed bottom bar: thumb-reachable, available while the
+       article scrolls. flex:1 + space-around spreads 2-5 controls evenly. */
+    .reading-pane-actions {
+        position: fixed;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        z-index: 101;
+        margin: 0;
+        padding: var(--space-2);
+        gap: var(--space-1);
+        justify-content: space-around;
+        background: var(--color-bg-secondary);
+        border-top: 1px solid var(--color-border);
+        border-bottom: none;
+    }
+
+    /* Both the form-wrapped buttons and the bare <a> are direct children. */
+    .reading-pane-actions > * {
+        flex: 1;
+    }
+
+    .reading-pane-actions form {
+        display: flex;
+    }
+
+    /* Stacked icon-over-label, borderless, big icon, ≥48px tall. */
+    .reading-pane-actions .rp-action {
+        flex: 1;
+        flex-direction: column;
+        gap: 2px;
+        min-height: 3rem;
+        padding: var(--space-1);
+        border-color: transparent;
+        background: transparent;
+        font-size: var(--font-xs);
+    }
+
+    .reading-pane-actions .rp-action .action-icon {
+        font-size: var(--font-xl);
+    }
+
+    /* Clear the fixed bar so the last paragraph isn't hidden behind it. */
+    .reading-pane-content {
+        padding-bottom: calc(3rem + 2 * var(--space-2) + var(--space-4));
+    }
+```
+
+- [ ] **Step 6: Build so the binary picks up the CSS, then eyeball it**
+
+```bash
+pwd
+source /tmp/rdrs-env.sh
+cargo build 2>&1 | tail -5
+```
+
+Expected: clean build. (Visual confirmation happens via the e2e scenario in
+Task 4; there is no Rust unit test for CSS.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /home/nixos/Develop/claude/rdrs
+git add static/css/app.css
+git commit -S -m "style(pane): editorial chrome — bottom action bar (mobile), inline row (desktop)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: e2e — mobile bottom action bar scenario
+
+Add a `@mobile` scenario asserting the redesigned chrome. Reuse the generic
+size step already in `responsive.steps.js`
+(`the "{selector}" control is at least {int}px tall`).
+
+**Files:**
+- Modify: `e2e/features/reading.feature`
+
+- [ ] **Step 1: Inspect the existing mobile reading scenario for reuse**
+
+Read `e2e/features/reading.feature` around the existing mobile nav scenario
+(~line 180, "Reading-pane navigation survives Fetch Full Content on mobile") to
+reuse its Given/When steps for opening the pane on mobile (`I am viewing on a
+mobile screen`, seeding a feed with entries, opening the inbox, clicking an
+entry, `the reading pane is visible on mobile`).
+
+- [ ] **Step 2: Append the new scenario**
+
+Append to `e2e/features/reading.feature`:
+
+```gherkin
+  @mobile
+  Scenario: Reading-pane actions sit in a touch-sized bottom bar on mobile
+    Given I am viewing on a mobile screen
+    And I have a feed with 5 test entries
+    When I open the inbox
+    And I click the entry titled "Test Entry 1"
+    Then the reading pane is visible on mobile
+    And the ".rp-action" control is at least 44px tall
+    And the ".reading-pane-actions" control is at least 300px wide
+```
+
+(The 44px height confirms the touch target; the ≥300px width confirms the bar
+spans the 375px viewport — i.e. it is the fixed full-width bar, not an inline
+content-width cluster.)
+
+- [ ] **Step 3: Confirm the step phrasings already exist**
+
+The steps `Given I am viewing on a mobile screen`, `Given I have a feed with 5
+test entries`, `When I open the inbox`, `When I click the entry titled "…"`,
+`Then the reading pane is visible on mobile`, and the generic
+`the "{selector}" control is at least {int}px tall` / `…wide` all already exist
+(used by `responsive.feature` and the existing mobile reading scenarios). No new
+step definitions are required. If `grep -rn` shows any phrase missing, stop and
+report rather than inventing a step.
+
+```bash
+pwd
+grep -rn "control is at least" e2e/steps/responsive.steps.js
+grep -rn "reading pane is visible on mobile" e2e/steps
+```
+
+Expected: both phrasings are found.
+
+- [ ] **Step 4: Build + run the new scenario (TDD: it must pass with Task 3 CSS)**
+
+```bash
+pwd
+source /tmp/rdrs-env.sh
+cargo build 2>&1 | tail -5
+cd e2e && npx playwright test reading --grep @mobile 2>&1 | tail -30
+```
+
+Expected: the new scenario PASSES (bottom bar ≥44px tall, ≥300px wide) along
+with the existing mobile reading scenarios.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/nixos/Develop/claude/rdrs
+git add e2e/features/reading.feature
+git commit -S -m "test(e2e): assert mobile reading-pane bottom action bar
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Full regression sweep
+
+Confirm nothing regressed across Rust + e2e. Verification only.
+
+**Files:** none
+
+- [ ] **Step 1: Full Rust suite**
+
+```bash
+pwd
+source /tmp/rdrs-env.sh
+cargo fmt --check
+RDRS_FAST_HASH=1 cargo nextest run -p rdrs 2>&1 | tail -25
+```
+
+Expected: all tests PASS, fmt clean.
+
+- [ ] **Step 2: e2e — the suites that touch the reading pane and responsive chrome**
+
+```bash
+pwd
+source /tmp/rdrs-env.sh
+cargo build 2>&1 | tail -5
+cd e2e && npx playwright test reading triage responsive keyboard_shortcuts_mobile 2>&1 | tail -40
+```
+
+Expected: all scenarios PASS. Key ones to confirm by name:
+- `reading.feature`: Fetch Full Content (desktop) + navigation survives Fetch
+  Full Content on mobile + the new bottom-bar scenario.
+- `triage.feature`: the Summarize flow (clicks the `Summarize` button by
+  accessible name — must still resolve).
+- `responsive.feature`: existing `@mobile` tap-target + reading-pane-back
+  scenarios.
+
+- [ ] **Step 3: If anything failed, fix and re-run**
+
+Most likely failure modes and fixes:
+- A Rust test asserted old pane markup (`btn-sm`, plain "Star"/"Mark Unread")
+  → update to the new `.rp-action` + `aria-label` markup.
+- e2e `getByRole("button", { name: … })` could not find an action → confirm the
+  `aria-label` exactly matches the feature's string (`Summarize`,
+  `Fetch Full Content`).
+- Desktop label wrapped → confirm `white-space: nowrap` + the `.rp-action` rule
+  shipped.
+
+Then re-run the failing suite.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Mobile fixed bottom action bar, flex:1 + space-around, 2-5 adaptive → Task 3 Step 5. ✅
+- Desktop same-level inline row, nowrap, no grouping → Task 3 Step 3. ✅
+- Title serif, smaller (2xl desktop / xl mobile) → Task 3 Steps 1 & 5. ✅
+- Favicon chip in meta (img or coloured initial) → Task 2 Step 4 + Task 1. ✅
+- Shared `feed_initial` / `feed_color_index` (DRY) → Task 1 Steps 3-4. ✅
+- `.rp-action` icon + label, stable `aria-label`s → Task 2 Steps 5-6. ✅
+- Icon-only prev/next on mobile, `aria-label` kept → Task 2 Step 3 + Task 3 Step 5. ✅
+- Summary-box Copy/Dismiss restyled → Task 2 Step 6. ✅
+- Article body untouched → no task edits `.reading-pane-article`. ✅
+- Favicon-safe meta separator → Task 3 Step 2. ✅
+- Content padding-bottom clears the fixed bar → Task 3 Step 5. ✅
+- e2e mobile bottom-bar coverage → Task 4. ✅
+- Accessible names preserved for existing e2e (Summarize, Fetch Full Content,
+  Star/Unstar) → Task 2 Step 5 + Task 5 Step 2. ✅
+
+**Placeholder scan:** No TBD/TODO; every code/step is concrete. ✅
+
+**Type/name consistency:** `feed_initial(&str)` / `feed_color_index(i64)` free
+fns defined in Task 1 Step 3 and delegated in Steps 3-4; `ReadingPaneView.feed_id`
+/ `feed_has_icon` defined Task 1 Step 4, populated Step 5; `.rp-action` class
+used identically across Task 2 (template), Task 3 (CSS), Task 4 (e2e selector);
+`aria-label="Mark Unread"` asserted (Task 2 Step 1) matches the template (Task 2
+Step 5). ✅

--- a/docs/superpowers/specs/2026-06-14-reading-pane-redesign-design.md
+++ b/docs/superpowers/specs/2026-06-14-reading-pane-redesign-design.md
@@ -1,0 +1,206 @@
+# Reading Pane Redesign — Design
+
+**Date:** 2026-06-14
+**Branch:** `feat/reading-pane-redesign`
+**Status:** Approved design, pending implementation plan
+
+## Problem
+
+The reading pane has the same mobile ergonomics problem the entry list row had
+before its redesign (see
+`docs/superpowers/specs/2026-06-13-entry-item-redesign-design.md`): the chrome
+elements are small and cramped, hard to tap and easy to mis-tap on a phone. The
+specific offenders:
+
+- **Action buttons** (`Star`, `Mark Unread`, `Fetch Full Content` / `Show
+  Original`, `Summarize`, `Save`) are a wrapping cluster of five equal-weight
+  `.btn-secondary .btn-sm` buttons. On a narrow viewport they wrap into uneven
+  rows that are noisy to scan and easy to fat-finger.
+- **Top toolbar** (`.reading-pane-back`) packs the Back affordance and the
+  prev/next nav into one small sticky bar.
+- **Header** title is serif `--font-3xl` (2rem) on every viewport; the meta
+  line is plain muted text with no feed identity.
+
+The 44px touch baseline from the mobile-touch-targets work already raised raw
+button heights, but the *composition* on mobile is still awkward — the same
+"redesign from scratch" treatment the entry row received is wanted here.
+
+## Goals
+
+- Redesign the reading-pane **chrome** (toolbar, header/meta, action controls,
+  summary-box controls) for both desktop and mobile, sharing the entry-row
+  visual language (favicon chip, icon + label controls, generous tap targets).
+- On mobile, move the action controls into a **fixed bottom action bar** that is
+  thumb-reachable and stays available while the article scrolls.
+- On desktop, present the actions as a single same-level row under the meta line
+  (no grouping), icon + label, that never line-wraps its labels.
+- Keep every action's accessible name stable so existing e2e and a11y hold.
+
+## Non-Goals
+
+- **Article body typography is unchanged** — `.reading-pane-article` and all its
+  descendant rules (`p`, `h1`–`h6`, `pre`, `blockquote`, `img`, tables, …) stay
+  exactly as they are. Long-form reading already works.
+- No change to the pane's data flow, swap targets, form actions, or the
+  prev/next neighbor JS. This is a presentation-layer redesign (template + CSS +
+  a small Rust view addition for the favicon).
+- No new JS behavior. The bottom bar is pure CSS (`position: fixed`).
+- No new build tooling (vanilla only, per project constraints).
+
+## Approach
+
+Adopt **Approach B** from brainstorming: a mobile bottom action bar, desktop
+inline actions. The chrome reuses the entry-row redesign vocabulary.
+
+### 1. Header + meta (both viewports)
+
+- **Title** stays serif (`--font-display`) but shrinks: `--font-2xl` (1.5rem)
+  on desktop, `--font-xl` (1.25rem) on mobile. This matches the entry-row
+  decision to shrink the desktop title so it reads in proportion next to the
+  sidebar.
+- **Meta** gains a **favicon chip** matching the entry row: the feed favicon
+  (`/api/feeds/{feed_id}/icon`) when present, else a colored initial chip
+  (`.entry-favicon-chip .fav-c{0..5}`). The chip sits before the feed title;
+  `feed · author · time` follow with the existing mid-dot separator logic.
+
+### 2. Action controls — shared `.rp-action` class
+
+Replace the per-button `.btn-secondary .btn-sm` with a dedicated `.rp-action`
+control used by every pane action. Each control is `icon span (aria-hidden) +
+label span`, mirroring `_entry_row.html`:
+
+```html
+<button type="submit" class="rp-action" aria-label="Mark Unread">
+  <span class="action-icon" aria-hidden="true">↺</span>
+  <span class="action-label">Unread</span>
+</button>
+```
+
+**Accessible name is carried by `aria-label`** (the icon is `aria-hidden`, so
+the visible short label does not pollute the name). This keeps the names the
+e2e suite relies on stable while letting the visible label be short:
+
+| Action            | `aria-label` (stable) | visible label   | icon |
+|-------------------|-----------------------|-----------------|------|
+| Star / Unstar     | `Star` / `Unstar`     | `Star`/`Starred`| ☆ / ★ |
+| Mark Unread       | `Mark Unread`         | `Unread`        | ↺ |
+| Fetch Full Content| `Fetch Full Content`  | `Full content`  | ⤓ |
+| Show Original     | `Show Original`       | `Original`      | ↩ |
+| Summarize         | `Summarize`           | `Summarize`     | ✦ |
+| Save              | `Save`                | `Save`          | ⬇ |
+
+(Glyphs are unicode, consistent with the entry-row `.action-icon` set; they may
+be swapped during implementation but the table is the default.)
+
+**Desktop layout** (`.reading-pane-actions`, in normal flow under the meta):
+single row, `display: flex; flex-wrap: wrap; gap`. Each `.rp-action` is
+`inline-flex` (icon left of label), `white-space: nowrap` so a label never
+breaks mid-word, `flex: none` so buttons keep natural width. All five are the
+**same visual level — no grouping / no separators**. `flex-wrap: wrap` is kept
+only as a safety net for extreme narrow desktop widths (whole buttons wrap, not
+text).
+
+**Mobile layout** (≤1024px): `.reading-pane-actions` becomes a **fixed bottom
+bar**:
+
+- `position: fixed; left: 0; right: 0; bottom: 0; z-index: 101` (above the pane
+  overlay's content; the pane is `position: fixed` with no transform, so a fixed
+  child is viewport-positioned and not clipped).
+- `display: flex; justify-content: space-around;` with each form / control as a
+  `flex: 1` child so 2–5 actions always spread evenly across the full width.
+- Each `.rp-action` is **stacked** (icon over small label), `min-height:
+  var(--touch-min)` (≥44px; bar renders ~48–56px tall with padding), centered.
+- The forms wrap the buttons, so the **form** is the flex child (`form { flex: 1
+  }`) and its button stretches — same pattern the entry row uses.
+- The pane content gets `padding-bottom` equal to the bar height so the last
+  paragraph is not hidden behind the fixed bar.
+
+**Conditional/variable count:** the action set is already conditionally rendered
+(`Fetch/Show`, `Summarize`, `Save` only inside `if link`, gated further by
+`has_kagi` / `summary_in_flight` / `has_save`). With `flex: 1 + space-around`,
+2, 3, 4, or 5 buttons all spread evenly with no left-bias or gaps. `Summarize`
+keeps its existing `disabled` state while `summary_in_flight`.
+
+### 3. Toolbar (`.reading-pane-back`)
+
+- **Desktop:** unchanged placement — prev/next nav right-aligned, no Back.
+- **Mobile:** Back affordance left (accent text, ≥44px hit box, as today),
+  prev/next on the right rendered **icon-only** (`‹` / `›`) to save width. The
+  word labels (`Previous` / `Next`) move into a `.nav-label` span hidden on
+  mobile; the buttons gain `aria-label="Previous"` / `"Next"` so the accessible
+  name survives. (e2e targets these by `data-testid`, not by name.)
+
+### 4. Summary box controls
+
+The summary box (`.summary-box`) keeps its structure (header title + link,
+blockquote body). Its `Copy` / `Dismiss` controls adopt the same `.rp-action`
+style (icon + label, touch-sized) so they match the new action vocabulary.
+Glyphs: `⧉ Copy`, `✕ Dismiss`. Their `data-summary-copy` / `data-summary-dismiss`
+hooks and behavior are unchanged.
+
+## Rust changes (favicon data)
+
+`ReadingPaneView` (`src/handlers/pages/mod.rs`) currently lacks the feed
+identity needed for the chip. Add:
+
+- Fields: `feed_id: i64`, `feed_has_icon: bool`.
+- Methods `feed_initial(&self) -> String` and `feed_color_index(&self) -> u8`
+  with the **same logic** as `EntryRowView`. To stay DRY, extract that logic
+  into two free functions (`feed_initial(title: &str)` and
+  `feed_color_index(feed_id: i64)`) in `pages/mod.rs` and have both
+  `EntryRowView` and `ReadingPaneView` delegate to them.
+- Populate the new fields in `build_reading_pane_view`
+  (`src/handlers/entries.rs`) from `ewf.entry.feed_id` and `ewf.feed_has_icon`.
+
+## Files Touched
+
+- `templates/_reading_pane.html` — favicon chip in meta; `.rp-action` controls
+  with icon/label spans + aria-labels; nav icon-only + `.nav-label`; summary-box
+  Copy/Dismiss restyle.
+- `static/css/app.css` — title size tweak; meta favicon chip (reuse entry-row
+  rules); `.rp-action` base + desktop row; `.nav-label`; mobile `@media
+  (max-width:1024px)` block: fixed bottom action bar, stacked controls, content
+  `padding-bottom`, icon-only nav.
+- `src/handlers/pages/mod.rs` — `ReadingPaneView` fields + helpers; extract
+  shared `feed_initial` / `feed_color_index` free functions; unit tests.
+- `src/handlers/entries.rs` — populate new fields in `build_reading_pane_view`.
+- `tests/handlers_test.rs` — adjust/extend reading-pane render assertions if any
+  reference the old button classes/markup; add coverage for the favicon chip in
+  the pane.
+- `e2e/features/reading.feature` + a step or two — add a `@mobile` scenario
+  asserting the bottom action bar (controls ≥44px, full-width spread); existing
+  `Fetch Full Content` / `Summarize` clicks must keep passing (accessible names
+  preserved).
+
+## Testing
+
+- **Rust (`cargo nextest run`, with `RDRS_FAST_HASH=1`):** unit tests for the
+  extracted `feed_initial` / `feed_color_index` (uppercase, empty→`?`, unicode,
+  modulo bounds) and a handler test asserting the pane renders the favicon chip
+  (or `/api/feeds/{id}/icon` img) and the `.rp-action` controls with their
+  aria-labels. Existing pane render tests stay green.
+- **e2e (`cd e2e && npx playwright test`):** re-source `/tmp/rdrs-env.sh`;
+  **`cargo build` first** (CSS is `include_str!`'d into the binary, the e2e
+  harness does not rebuild on CSS change). New `@mobile` scenario:
+  - open an entry → reading pane visible on mobile,
+  - the action controls live in a bottom bar, each `.rp-action` ≥44px tall,
+  - the bar spans the viewport width.
+  Existing `reading.feature` (Fetch Full Content desktop + mobile nav) and
+  `triage.feature` (Summarize) scenarios must continue to pass.
+
+## Risks & Mitigations
+
+- **Fixed bar clipped/scrolling with content** — the pane overlay is
+  `position: fixed` with no `transform`/`filter`, so a `position: fixed` child is
+  viewport-anchored and not clipped. Verified pattern; the mobile e2e scenario
+  guards it.
+- **Content hidden behind the bar** — add `padding-bottom` on the pane content
+  equal to the bar height on mobile.
+- **Accessible-name drift breaking e2e** — every control keeps an explicit
+  `aria-label` equal to its canonical full name; visible short labels do not
+  affect the name. The Rust/e2e tests assert the names.
+- **Desktop label wrap (the `Full content` issue seen in the mockup)** —
+  `white-space: nowrap` on `.rp-action` plus `flex: none`; the row only wraps
+  whole buttons, never mid-label.
+- **Desktop regression from mobile rules** — every mobile rule stays inside the
+  existing `@media (max-width: 1024px)` block.

--- a/e2e/features/reading.feature
+++ b/e2e/features/reading.feature
@@ -227,4 +227,4 @@ Feature: Reading entries
     And I click the entry titled "Test Entry 1"
     Then the reading pane is visible on mobile
     And the ".rp-action" control is at least 44px tall
-    And the ".reading-pane-actions" control is at least 300px wide
+    And the ".reading-pane-actions" control is at least 360px wide

--- a/e2e/features/reading.feature
+++ b/e2e/features/reading.feature
@@ -219,3 +219,12 @@ Feature: Reading entries
     Then the sidebar highlights All Entries
     When I open the starred entries page
     Then the sidebar highlights Starred
+
+  @mobile
+  Scenario: Reading-pane actions sit in a touch-sized bottom bar on mobile
+    Given I am viewing on a mobile screen
+    When I open the inbox
+    And I click the entry titled "Test Entry 1"
+    Then the reading pane is visible on mobile
+    And the ".rp-action" control is at least 44px tall
+    And the ".reading-pane-actions" control is at least 300px wide

--- a/src/handlers/entries.rs
+++ b/src/handlers/entries.rs
@@ -220,6 +220,8 @@ pub(crate) async fn build_reading_pane_view(
             .unwrap_or_else(|| "(no title)".to_string()),
         link: ewf.entry.link.clone(),
         feed_title: ewf.feed_title.clone().unwrap_or_default(),
+        feed_id: ewf.entry.feed_id,
+        feed_has_icon: ewf.feed_has_icon,
         author: ewf
             .entry
             .author

--- a/src/handlers/pages/mod.rs
+++ b/src/handlers/pages/mod.rs
@@ -2906,8 +2906,10 @@ mod tests {
 
     #[test]
     fn feed_color_index_fn_is_bounded() {
+        assert_eq!(super::feed_color_index(0), 0); // boundary: id 0
+        assert_eq!(super::feed_color_index(6), 0); // wraps at palette size
         assert_eq!(super::feed_color_index(13), 1); // 13 % 6 == 1
         assert_eq!(super::feed_color_index(-1), 5); // (-1).rem_euclid(6) == 5
-        assert!(super::feed_color_index(123_456) < 6);
+        assert!(super::feed_color_index(i64::MAX) < 6);
     }
 }

--- a/src/handlers/pages/mod.rs
+++ b/src/handlers/pages/mod.rs
@@ -27,6 +27,22 @@ pub use time_format::{compute_freshness, format_relative_time, format_relative_t
 // Entries-family shared view structs (PR-10)
 // ============================================================================
 
+/// Uppercased first character of a feed title, for the favicon letter-chip
+/// fallback shown when a feed has no icon. Returns "?" for an empty title.
+pub(crate) fn feed_initial(feed_title: &str) -> String {
+    feed_title
+        .chars()
+        .next()
+        .map(|c| c.to_uppercase().to_string())
+        .unwrap_or_else(|| "?".to_string())
+}
+
+/// Stable index 0..6 into the favicon fallback colour palette, derived from
+/// the feed id so the same feed always gets the same colour.
+pub(crate) fn feed_color_index(feed_id: i64) -> u8 {
+    feed_id.rem_euclid(6) as u8
+}
+
 /// View-model for one row in the entries list (`_entry_row.html`).
 #[derive(Debug, Clone)]
 pub struct EntryRowView {
@@ -57,17 +73,13 @@ impl EntryRowView {
     /// letter-chip fallback shown when a feed has no icon. Returns "?" for
     /// an empty title.
     pub fn feed_initial(&self) -> String {
-        self.feed_title
-            .chars()
-            .next()
-            .map(|c| c.to_uppercase().to_string())
-            .unwrap_or_else(|| "?".to_string())
+        feed_initial(&self.feed_title)
     }
 
     /// Stable index 0..6 into the favicon fallback colour palette, derived
     /// from the feed id so the same feed always gets the same colour.
     pub fn feed_color_index(&self) -> u8 {
-        self.feed_id.rem_euclid(6) as u8
+        feed_color_index(self.feed_id)
     }
 }
 
@@ -82,6 +94,8 @@ pub struct ReadingPaneView {
     pub title: String,
     pub link: Option<String>,
     pub feed_title: String,
+    pub feed_id: i64,
+    pub feed_has_icon: bool,
     pub author: Option<String>,
     pub published_at_iso: Option<String>,
     pub published_relative: String,
@@ -98,6 +112,20 @@ pub struct ReadingPaneView {
     /// pane swaps "Fetch Full Content" for a "Show Original" link in
     /// this case so the user can revert.
     pub is_full_content: bool,
+}
+
+impl ReadingPaneView {
+    /// Uppercased first character of the feed title for the favicon
+    /// letter-chip fallback (mirrors `EntryRowView::feed_initial`).
+    pub fn feed_initial(&self) -> String {
+        feed_initial(&self.feed_title)
+    }
+
+    /// Stable favicon-palette index derived from the feed id (mirrors
+    /// `EntryRowView::feed_color_index`).
+    pub fn feed_color_index(&self) -> u8 {
+        feed_color_index(self.feed_id)
+    }
 }
 
 /// One segment of a breadcrumb trail rendered above the page `<h1>`. `href =
@@ -2859,5 +2887,27 @@ mod tests {
         let row = row_view_from(&ewf, None);
         assert_eq!(row.feed_color_index(), 5); // (-1).rem_euclid(6) == 5
         assert!(row.feed_color_index() < 6);
+    }
+
+    #[test]
+    fn feed_initial_fn_uppercases_first_char() {
+        assert_eq!(super::feed_initial("daring fireball"), "D");
+    }
+
+    #[test]
+    fn feed_initial_fn_handles_empty() {
+        assert_eq!(super::feed_initial(""), "?");
+    }
+
+    #[test]
+    fn feed_initial_fn_uppercases_unicode() {
+        assert_eq!(super::feed_initial("über"), "Ü");
+    }
+
+    #[test]
+    fn feed_color_index_fn_is_bounded() {
+        assert_eq!(super::feed_color_index(13), 1); // 13 % 6 == 1
+        assert_eq!(super::feed_color_index(-1), 5); // (-1).rem_euclid(6) == 5
+        assert!(super::feed_color_index(123_456) < 6);
     }
 }

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -519,6 +519,11 @@ code {
     cursor: default;
 }
 
+/* The prev/next word labels; hidden on mobile (icon-only) in the media block. */
+.nav-label {
+    display: inline;
+}
+
 .reading-pane-content {
     padding: var(--space-8) var(--space-10);
     max-width: var(--content-max-width);
@@ -529,7 +534,7 @@ code {
 
 .reading-pane-title {
     font-family: var(--font-display);
-    font-size: var(--font-3xl);
+    font-size: var(--font-2xl);
     font-weight: 700;
     line-height: 1.25;
     margin-bottom: var(--space-4);
@@ -546,21 +551,59 @@ code {
     align-items: center;
 }
 
-/* Mid-dot separators only when the author span is present — the author is
-   the only non-first <span> child; the time element is a <time>. Without
-   an author, feed + time fall back to plain whitespace separation. */
-.reading-pane-meta:has(> span:not(:first-child)) > *:not(:first-child)::before {
+/* Mid-dot separators before author/time, only when an author span is present.
+   Anchored to the feed-title so the leading favicon (img or chip span) never
+   gets a dot. */
+.reading-pane-meta:has(> span:not([data-testid]):not(.entry-favicon)) [data-testid="reading-pane-feed-title"] ~ *::before {
     content: "·";
     margin-right: var(--space-2);
+}
+
+.reading-pane-meta .entry-favicon {
+    margin-top: 0;
 }
 
 .reading-pane-actions {
     display: flex;
     flex-wrap: wrap;
-    gap: var(--space-3);
+    gap: var(--space-2);
     margin-bottom: var(--space-8);
     padding-bottom: var(--space-6);
     border-bottom: 1px solid var(--color-border-light);
+}
+
+/* Shared pane action control (also used by the summary-box Copy/Dismiss).
+   Icon + label, never wraps its label; desktop ~40px tall. */
+.rp-action {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    min-height: 2.5rem;
+    padding: 0 var(--space-4);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: var(--color-bg);
+    color: var(--color-text-secondary);
+    font-family: var(--font-ui);
+    font-size: var(--font-sm);
+    line-height: 1;
+    white-space: nowrap;
+    cursor: pointer;
+    text-decoration: none;
+}
+
+.rp-action:hover {
+    color: var(--color-accent);
+    border-color: var(--color-accent);
+}
+
+.rp-action .action-icon {
+    color: var(--color-accent);
+}
+
+.rp-action:disabled {
+    opacity: 0.5;
+    cursor: default;
 }
 
 .reading-pane-article {
@@ -1786,6 +1829,69 @@ summary {
     .reading-pane-back-link {
         display: inline-flex;
         align-items: center;
+    }
+
+    /* Title is smaller on mobile (no sidebar to size against on desktop). */
+    .reading-pane-title {
+        font-size: var(--font-xl);
+    }
+
+    /* Prev/next become icon-only to save toolbar width; keep a square-ish
+       touch target (the generic baseline already sets min-height). */
+    .nav-label {
+        display: none;
+    }
+
+    .reading-pane-nav-btn {
+        min-width: var(--touch-min);
+        justify-content: center;
+    }
+
+    /* Actions move to a fixed bottom bar: thumb-reachable, available while the
+       article scrolls. flex:1 + space-around spreads 2-5 controls evenly. */
+    .reading-pane-actions {
+        position: fixed;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        z-index: 101;
+        margin: 0;
+        padding: var(--space-2);
+        gap: var(--space-1);
+        justify-content: space-around;
+        background: var(--color-bg-secondary);
+        border-top: 1px solid var(--color-border);
+        border-bottom: none;
+    }
+
+    /* Both the form-wrapped buttons and the bare <a> are direct children. */
+    .reading-pane-actions > * {
+        flex: 1;
+    }
+
+    .reading-pane-actions form {
+        display: flex;
+    }
+
+    /* Stacked icon-over-label, borderless, big icon, ≥48px tall. */
+    .reading-pane-actions .rp-action {
+        flex: 1;
+        flex-direction: column;
+        gap: 2px;
+        min-height: 3rem;
+        padding: var(--space-1);
+        border-color: transparent;
+        background: transparent;
+        font-size: var(--font-xs);
+    }
+
+    .reading-pane-actions .rp-action .action-icon {
+        font-size: var(--font-xl);
+    }
+
+    /* Clear the fixed bar so the last paragraph isn't hidden behind it. */
+    .reading-pane-content {
+        padding-bottom: calc(3rem + 2 * var(--space-2) + var(--space-4));
     }
 
     /* ===== Entry row (redesign) — mobile ===== */

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -507,6 +507,9 @@ code {
     font-size: var(--font-sm);
     line-height: 1;
     padding: var(--space-2) var(--space-4);
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
 }
 
 .reading-pane-nav-btn:hover:not(:disabled) {
@@ -604,6 +607,25 @@ code {
 .rp-action:disabled {
     opacity: 0.5;
     cursor: default;
+}
+
+/* Inline SVG icons (outline set) for action + nav controls. Scale with the
+   surrounding font-size; stroke uses currentColor so they inherit the control
+   colour. Star uses the same path filled (.is-filled) for the active state. */
+.action-icon .ico,
+.reading-pane-nav-btn .ico {
+    width: 1.15em;
+    height: 1.15em;
+    display: block;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+}
+.action-icon .ico.is-filled {
+    fill: currentColor;
+    stroke: none;
 }
 
 .reading-pane-article {

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -624,7 +624,7 @@ code {
     stroke-linejoin: round;
 }
 .action-icon .ico.is-filled {
-    fill: currentColor;
+    fill: var(--color-accent);
     stroke: none;
 }
 

--- a/templates/_entry_actions_multi.html
+++ b/templates/_entry_actions_multi.html
@@ -4,5 +4,5 @@
 <template data-flash data-level="{{ f.level }}">{{ f.message }}</template>
 {% endif %}
 {% if let Some(psf) = pane_star_form.as_ref() %}
-<template data-swap-target="#reading-pane-star-form-{{ psf.id }}"><form id="reading-pane-star-form-{{ psf.id }}" method="post" action="/entries/{{ psf.id }}/{% if psf.is_starred %}unstar{% else %}star{% endif %}" data-swap="#entry-row-{{ psf.id }}"><button type="submit" class="btn-secondary btn-sm">{% if psf.is_starred %}Unstar{% else %}Star{% endif %}</button></form></template>
+<template data-swap-target="#reading-pane-star-form-{{ psf.id }}"><form id="reading-pane-star-form-{{ psf.id }}" method="post" action="/entries/{{ psf.id }}/{% if psf.is_starred %}unstar{% else %}star{% endif %}" data-swap="#entry-row-{{ psf.id }}"><button type="submit" class="rp-action" aria-label="{% if psf.is_starred %}Unstar{% else %}Star{% endif %}"><span class="action-icon" aria-hidden="true">{% if psf.is_starred %}★{% else %}☆{% endif %}</span><span class="action-label">{% if psf.is_starred %}Starred{% else %}Star{% endif %}</span></button></form></template>
 {% endif %}

--- a/templates/_entry_actions_multi.html
+++ b/templates/_entry_actions_multi.html
@@ -1,8 +1,9 @@
+{%- import "_icons.html" as icons -%}
 <template data-swap-target="#entry-row-{{ r.id }}">{% include "_entry_row.html" %}</template>
 <template data-swap-target="#sidebar-unread"><div id="sidebar-unread" data-payload='{{ sidebar_unread_payload_json|safe }}' hidden></div></template>
 {% if let Some(f) = flash.as_ref() %}
 <template data-flash data-level="{{ f.level }}">{{ f.message }}</template>
 {% endif %}
 {% if let Some(psf) = pane_star_form.as_ref() %}
-<template data-swap-target="#reading-pane-star-form-{{ psf.id }}"><form id="reading-pane-star-form-{{ psf.id }}" method="post" action="/entries/{{ psf.id }}/{% if psf.is_starred %}unstar{% else %}star{% endif %}" data-swap="#entry-row-{{ psf.id }}"><button type="submit" class="rp-action" aria-label="{% if psf.is_starred %}Unstar{% else %}Star{% endif %}"><span class="action-icon" aria-hidden="true">{% if psf.is_starred %}★{% else %}☆{% endif %}</span><span class="action-label">{% if psf.is_starred %}Starred{% else %}Star{% endif %}</span></button></form></template>
+<template data-swap-target="#reading-pane-star-form-{{ psf.id }}"><form id="reading-pane-star-form-{{ psf.id }}" method="post" action="/entries/{{ psf.id }}/{% if psf.is_starred %}unstar{% else %}star{% endif %}" data-swap="#entry-row-{{ psf.id }}"><button type="submit" class="rp-action" aria-label="{% if psf.is_starred %}Unstar{% else %}Star{% endif %}"><span class="action-icon" aria-hidden="true">{% if psf.is_starred %}{% call icons::star(true) %}{% endcall %}{% else %}{% call icons::star(false) %}{% endcall %}{% endif %}</span><span class="action-label">{% if psf.is_starred %}Starred{% else %}Star{% endif %}</span></button></form></template>
 {% endif %}

--- a/templates/_entry_row.html
+++ b/templates/_entry_row.html
@@ -1,3 +1,4 @@
+{%- import "_icons.html" as icons -%}
 {# Single entry row — editorial CSS-grid layout (see
    docs/superpowers/specs/2026-06-13-entry-item-redesign-design.md).
    Grid areas: "fav head" / "fav meta" / "foot foot". The form-wrapped
@@ -31,11 +32,11 @@
 
     <div class="entry-item-actions">
         <form method="post" action="/entries/{{ r.id }}/{% if r.is_read %}unread{% else %}read{% endif %}" data-swap="#entry-row-{{ r.id }}">
-            <button type="submit" class="entry-action-btn" data-testid="entry-read-action" aria-label="{% if r.is_read %}Mark unread{% else %}Mark read{% endif %}"><span class="action-icon" aria-hidden="true">{% if r.is_read %}↺{% else %}✓{% endif %}</span><span class="action-label">{% if r.is_read %}unread{% else %}read{% endif %}</span></button>
+            <button type="submit" class="entry-action-btn" data-testid="entry-read-action" aria-label="{% if r.is_read %}Mark unread{% else %}Mark read{% endif %}"><span class="action-icon" aria-hidden="true">{% if r.is_read %}{% call icons::unread() %}{% endcall %}{% else %}{% call icons::check() %}{% endcall %}{% endif %}</span><span class="action-label">{% if r.is_read %}unread{% else %}read{% endif %}</span></button>
         </form>
         <form method="post" action="/entries/{{ r.id }}/{% if r.is_starred %}unstar{% else %}star{% endif %}" data-swap="#entry-row-{{ r.id }}">
-            <button type="submit" class="entry-action-btn" data-testid="entry-star-action" aria-label="{% if r.is_starred %}Unstar{% else %}Star{% endif %}"><span class="action-icon" aria-hidden="true">{% if r.is_starred %}★{% else %}☆{% endif %}</span><span class="action-label">{% if r.is_starred %}starred{% else %}star{% endif %}</span></button>
+            <button type="submit" class="entry-action-btn" data-testid="entry-star-action" aria-label="{% if r.is_starred %}Unstar{% else %}Star{% endif %}"><span class="action-icon" aria-hidden="true">{% if r.is_starred %}{% call icons::star(true) %}{% endcall %}{% else %}{% call icons::star(false) %}{% endcall %}{% endif %}</span><span class="action-label">{% if r.is_starred %}starred{% else %}star{% endif %}</span></button>
         </form>
-        {% if let Some(link) = r.link.as_ref() %}<a href="{{ link }}" target="_blank" rel="noopener noreferrer" data-testid="entry-original-link" aria-label="Open original"><span class="action-icon" aria-hidden="true">↗</span><span class="action-label">original</span></a>{% endif %}
+        {% if let Some(link) = r.link.as_ref() %}<a href="{{ link }}" target="_blank" rel="noopener noreferrer" data-testid="entry-original-link" aria-label="Open original"><span class="action-icon" aria-hidden="true">{% call icons::external() %}{% endcall %}</span><span class="action-label">original</span></a>{% endif %}
     </div>
 </div>

--- a/templates/_icons.html
+++ b/templates/_icons.html
@@ -1,0 +1,12 @@
+{% macro check() %}<svg class="ico" viewBox="0 0 24 24" aria-hidden="true"><path d="M5 13l4 4L19 7"/></svg>{% endmacro %}
+{% macro unread() %}<svg class="ico" viewBox="0 0 24 24" aria-hidden="true"><path d="M3 12a9 9 0 1 0 3-6.9L3 8"/><path d="M3 3v5h5"/></svg>{% endmacro %}
+{% macro star(filled) %}<svg class="ico{% if filled %} is-filled{% endif %}" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3.5l2.7 5.5 6 .9-4.3 4.2 1 6L12 17.3 6.6 20l1-6L3.3 9.9l6-.9z"/></svg>{% endmacro %}
+{% macro external() %}<svg class="ico" viewBox="0 0 24 24" aria-hidden="true"><path d="M14 4h6v6"/><path d="M20 4l-8.5 8.5"/><path d="M19 14v5H5V5h5"/></svg>{% endmacro %}
+{% macro document() %}<svg class="ico" viewBox="0 0 24 24" aria-hidden="true"><path d="M7 3h7l4 4v14H7z"/><path d="M14 3v4h4"/><path d="M9.5 12h6M9.5 16h6"/></svg>{% endmacro %}
+{% macro revert() %}<svg class="ico" viewBox="0 0 24 24" aria-hidden="true"><path d="M9 14L4 9l5-5"/><path d="M4 9h11a5 5 0 0 1 0 10h-4"/></svg>{% endmacro %}
+{% macro sparkle() %}<svg class="ico" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l1.7 4.6L18 9.3l-4.3 1.7L12 16l-1.7-4.9L6 9.3l4.3-1.7z"/><path d="M18 15l.7 1.8L20.5 17.5l-1.8.7L18 20l-.7-1.8L15.5 17.5l1.8-.7z"/></svg>{% endmacro %}
+{% macro bookmark() %}<svg class="ico" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 4h12v17l-6-4-6 4z"/></svg>{% endmacro %}
+{% macro copy() %}<svg class="ico" viewBox="0 0 24 24" aria-hidden="true"><rect x="9" y="9" width="11" height="11" rx="2"/><path d="M5 15V6a2 2 0 0 1 2-2h8"/></svg>{% endmacro %}
+{% macro close() %}<svg class="ico" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 6l12 12M18 6L6 18"/></svg>{% endmacro %}
+{% macro chevron_left() %}<svg class="ico" viewBox="0 0 24 24" aria-hidden="true"><path d="M15 6l-6 6 6 6"/></svg>{% endmacro %}
+{% macro chevron_right() %}<svg class="ico" viewBox="0 0 24 24" aria-hidden="true"><path d="M9 6l6 6-6 6"/></svg>{% endmacro %}

--- a/templates/_reading_pane.html
+++ b/templates/_reading_pane.html
@@ -1,3 +1,4 @@
+{%- import "_icons.html" as icons -%}
 {# Reading pane content. Matches the pre-SSR `.reading-pane-content` +
    `.reading-pane-article` + `.reading-pane-actions` DOM the existing
    CSS rules target. `id="reading-pane"` is the swap target.
@@ -19,8 +20,8 @@
            (up the list), "Next" = older (down the list), matching the
            list's published-desc order. #}
         <nav class="reading-pane-nav" aria-label="Entry navigation">
-            <button type="button" class="reading-pane-nav-btn" data-pane-prev data-testid="reading-pane-prev" aria-label="Previous" disabled>‹<span class="nav-label"> Previous</span></button>
-            <button type="button" class="reading-pane-nav-btn" data-pane-next data-testid="reading-pane-next" aria-label="Next" disabled><span class="nav-label">Next </span>›</button>
+            <button type="button" class="reading-pane-nav-btn" data-pane-prev data-testid="reading-pane-prev" aria-label="Previous" disabled>{% call icons::chevron_left() %}{% endcall %}<span class="nav-label">Previous</span></button>
+            <button type="button" class="reading-pane-nav-btn" data-pane-next data-testid="reading-pane-next" aria-label="Next" disabled><span class="nav-label">Next</span>{% call icons::chevron_right() %}{% endcall %}</button>
         </nav>
     </div>
     <div class="reading-pane-content">
@@ -39,14 +40,14 @@
         </div>
         <div class="reading-pane-actions">
             <form id="reading-pane-star-form-{{ pane.id }}" method="post" action="/entries/{{ pane.id }}/{% if pane.is_starred %}unstar{% else %}star{% endif %}" data-swap="#entry-row-{{ pane.id }}">
-                <button type="submit" class="rp-action" aria-label="{% if pane.is_starred %}Unstar{% else %}Star{% endif %}"><span class="action-icon" aria-hidden="true">{% if pane.is_starred %}★{% else %}☆{% endif %}</span><span class="action-label">{% if pane.is_starred %}Starred{% else %}Star{% endif %}</span></button>
+                <button type="submit" class="rp-action" aria-label="{% if pane.is_starred %}Unstar{% else %}Star{% endif %}"><span class="action-icon" aria-hidden="true">{% if pane.is_starred %}{% call icons::star(true) %}{% endcall %}{% else %}{% call icons::star(false) %}{% endcall %}{% endif %}</span><span class="action-label">{% if pane.is_starred %}Starred{% else %}Star{% endif %}</span></button>
             </form>
             {# Pane action is a fixed Mark-Unread: idempotent on /unread, no
                "Mark Read" toggle. Reading an entry already auto-marks it as
                read on open, so the only manual operation worth a button is
                the override-back-to-unread. #}
             <form method="post" action="/entries/{{ pane.id }}/unread" data-swap="#entry-row-{{ pane.id }}">
-                <button type="submit" class="rp-action" aria-label="Mark Unread"><span class="action-icon" aria-hidden="true">↺</span><span class="action-label">Unread</span></button>
+                <button type="submit" class="rp-action" aria-label="Mark Unread"><span class="action-icon" aria-hidden="true">{% call icons::unread() %}{% endcall %}</span><span class="action-label">Unread</span></button>
             </form>
             {% if let Some(link) = pane.link.as_ref() %}
             {% if pane.is_full_content %}
@@ -54,20 +55,20 @@
                reading pane (plus row + sidebar-unread, which are already in
                their post-open state, so the swap is effectively a no-op for
                them). Lets the user revert from a Fetch-Full-Content view. #}
-            <a href="/entries/{{ pane.id }}/fragment" data-swap="#reading-pane" class="rp-action" aria-label="Show Original"><span class="action-icon" aria-hidden="true">↩</span><span class="action-label">Original</span></a>
+            <a href="/entries/{{ pane.id }}/fragment" data-swap="#reading-pane" class="rp-action" aria-label="Show Original"><span class="action-icon" aria-hidden="true">{% call icons::revert() %}{% endcall %}</span><span class="action-label">Original</span></a>
             {% else %}
             <form method="post" action="/entries/{{ pane.id }}/fetch-full-content" data-swap="#reading-pane">
-                <button type="submit" class="rp-action" aria-label="Fetch Full Content"><span class="action-icon" aria-hidden="true">⤓</span><span class="action-label">Full content</span></button>
+                <button type="submit" class="rp-action" aria-label="Fetch Full Content"><span class="action-icon" aria-hidden="true">{% call icons::document() %}{% endcall %}</span><span class="action-label">Full content</span></button>
             </form>
             {% endif %}
             {% if pane.has_kagi || pane.summary_in_flight %}
             <form method="post" action="/entries/{{ pane.id }}/summarize" data-swap="#rp-summary-container">
-                <button type="submit" class="rp-action" aria-label="Summarize"{% if pane.summary_in_flight %} disabled{% endif %}><span class="action-icon" aria-hidden="true">✦</span><span class="action-label">Summarize</span></button>
+                <button type="submit" class="rp-action" aria-label="Summarize"{% if pane.summary_in_flight %} disabled{% endif %}><span class="action-icon" aria-hidden="true">{% call icons::sparkle() %}{% endcall %}</span><span class="action-label">Summarize</span></button>
             </form>
             {% endif %}
             {% if pane.has_save %}
             <form method="post" action="/entries/{{ pane.id }}/save" data-swap="#reading-pane">
-                <button type="submit" class="rp-action" aria-label="Save"><span class="action-icon" aria-hidden="true">⬇</span><span class="action-label">Save</span></button>
+                <button type="submit" class="rp-action" aria-label="Save"><span class="action-icon" aria-hidden="true">{% call icons::bookmark() %}{% endcall %}</span><span class="action-label">Save</span></button>
             </form>
             {% endif %}
             {% endif %}
@@ -84,8 +85,8 @@
             {% else if let Some(summary) = pane.summary_text.as_ref() %}
             <div class="summary-box">
                 <div class="summary-actions">
-                    <button type="button" class="rp-action" data-summary-copy aria-label="Copy summary"><span class="action-icon" aria-hidden="true">⧉</span><span class="action-label">Copy</span></button>
-                    <button type="button" class="rp-action" data-summary-dismiss data-entry-id="{{ pane.id }}" aria-label="Dismiss summary"><span class="action-icon" aria-hidden="true">✕</span><span class="action-label">Dismiss</span></button>
+                    <button type="button" class="rp-action" data-summary-copy aria-label="Copy summary"><span class="action-icon" aria-hidden="true">{% call icons::copy() %}{% endcall %}</span><span class="action-label">Copy</span></button>
+                    <button type="button" class="rp-action" data-summary-dismiss data-entry-id="{{ pane.id }}" aria-label="Dismiss summary"><span class="action-icon" aria-hidden="true">{% call icons::close() %}{% endcall %}</span><span class="action-label">Dismiss</span></button>
                 </div>
                 {# Title + link rendered inside the box so what users see
                    matches what the Copy button writes to the clipboard. #}

--- a/templates/_reading_pane.html
+++ b/templates/_reading_pane.html
@@ -19,8 +19,8 @@
            (up the list), "Next" = older (down the list), matching the
            list's published-desc order. #}
         <nav class="reading-pane-nav" aria-label="Entry navigation">
-            <button type="button" class="reading-pane-nav-btn" data-pane-prev data-testid="reading-pane-prev" disabled>‹ Previous</button>
-            <button type="button" class="reading-pane-nav-btn" data-pane-next data-testid="reading-pane-next" disabled>Next ›</button>
+            <button type="button" class="reading-pane-nav-btn" data-pane-prev data-testid="reading-pane-prev" aria-label="Previous" disabled>‹<span class="nav-label"> Previous</span></button>
+            <button type="button" class="reading-pane-nav-btn" data-pane-next data-testid="reading-pane-next" aria-label="Next" disabled><span class="nav-label">Next </span>›</button>
         </nav>
     </div>
     <div class="reading-pane-content">
@@ -28,20 +28,25 @@
             {% if let Some(link) = pane.link.as_ref() %}<a href="{{ link }}" target="_blank" rel="noopener noreferrer">{{ pane.title }}</a>{% else %}{{ pane.title }}{% endif %}
         </h1>
         <div class="reading-pane-meta">
+            {% if pane.feed_has_icon %}
+            <img class="entry-favicon" src="/api/feeds/{{ pane.feed_id }}/icon" alt="" width="24" height="24">
+            {% else %}
+            <span class="entry-favicon entry-favicon-chip fav-c{{ pane.feed_color_index() }}" aria-hidden="true">{{ pane.feed_initial() }}</span>
+            {% endif %}
             <span data-testid="reading-pane-feed-title">{{ pane.feed_title }}</span>
             {% if let Some(author) = pane.author.as_ref() %}<span>{{ author }}</span>{% endif %}
             {% if let Some(ts) = pane.published_at_iso.as_ref() %}<time datetime="{{ ts }}" data-testid="reading-pane-published-at">{{ pane.published_relative }}</time>{% endif %}
         </div>
         <div class="reading-pane-actions">
             <form id="reading-pane-star-form-{{ pane.id }}" method="post" action="/entries/{{ pane.id }}/{% if pane.is_starred %}unstar{% else %}star{% endif %}" data-swap="#entry-row-{{ pane.id }}">
-                <button type="submit" class="btn-secondary btn-sm">{% if pane.is_starred %}Unstar{% else %}Star{% endif %}</button>
+                <button type="submit" class="rp-action" aria-label="{% if pane.is_starred %}Unstar{% else %}Star{% endif %}"><span class="action-icon" aria-hidden="true">{% if pane.is_starred %}★{% else %}☆{% endif %}</span><span class="action-label">{% if pane.is_starred %}Starred{% else %}Star{% endif %}</span></button>
             </form>
             {# Pane action is a fixed Mark-Unread: idempotent on /unread, no
                "Mark Read" toggle. Reading an entry already auto-marks it as
                read on open, so the only manual operation worth a button is
                the override-back-to-unread. #}
             <form method="post" action="/entries/{{ pane.id }}/unread" data-swap="#entry-row-{{ pane.id }}">
-                <button type="submit" class="btn-secondary btn-sm">Mark Unread</button>
+                <button type="submit" class="rp-action" aria-label="Mark Unread"><span class="action-icon" aria-hidden="true">↺</span><span class="action-label">Unread</span></button>
             </form>
             {% if let Some(link) = pane.link.as_ref() %}
             {% if pane.is_full_content %}
@@ -49,20 +54,20 @@
                reading pane (plus row + sidebar-unread, which are already in
                their post-open state, so the swap is effectively a no-op for
                them). Lets the user revert from a Fetch-Full-Content view. #}
-            <a href="/entries/{{ pane.id }}/fragment" data-swap="#reading-pane" class="btn btn-secondary btn-sm">Show Original</a>
+            <a href="/entries/{{ pane.id }}/fragment" data-swap="#reading-pane" class="rp-action" aria-label="Show Original"><span class="action-icon" aria-hidden="true">↩</span><span class="action-label">Original</span></a>
             {% else %}
             <form method="post" action="/entries/{{ pane.id }}/fetch-full-content" data-swap="#reading-pane">
-                <button type="submit" class="btn-secondary btn-sm">Fetch Full Content</button>
+                <button type="submit" class="rp-action" aria-label="Fetch Full Content"><span class="action-icon" aria-hidden="true">⤓</span><span class="action-label">Full content</span></button>
             </form>
             {% endif %}
             {% if pane.has_kagi || pane.summary_in_flight %}
             <form method="post" action="/entries/{{ pane.id }}/summarize" data-swap="#rp-summary-container">
-                <button type="submit" class="btn-secondary btn-sm"{% if pane.summary_in_flight %} disabled{% endif %}>Summarize</button>
+                <button type="submit" class="rp-action" aria-label="Summarize"{% if pane.summary_in_flight %} disabled{% endif %}><span class="action-icon" aria-hidden="true">✦</span><span class="action-label">Summarize</span></button>
             </form>
             {% endif %}
             {% if pane.has_save %}
             <form method="post" action="/entries/{{ pane.id }}/save" data-swap="#reading-pane">
-                <button type="submit" class="btn-secondary btn-sm">Save</button>
+                <button type="submit" class="rp-action" aria-label="Save"><span class="action-icon" aria-hidden="true">⬇</span><span class="action-label">Save</span></button>
             </form>
             {% endif %}
             {% endif %}
@@ -79,8 +84,8 @@
             {% else if let Some(summary) = pane.summary_text.as_ref() %}
             <div class="summary-box">
                 <div class="summary-actions">
-                    <button type="button" class="btn-secondary btn-sm" data-summary-copy>Copy</button>
-                    <button type="button" class="btn-secondary btn-sm" data-summary-dismiss data-entry-id="{{ pane.id }}">Dismiss</button>
+                    <button type="button" class="rp-action" data-summary-copy aria-label="Copy summary"><span class="action-icon" aria-hidden="true">⧉</span><span class="action-label">Copy</span></button>
+                    <button type="button" class="rp-action" data-summary-dismiss data-entry-id="{{ pane.id }}" aria-label="Dismiss summary"><span class="action-icon" aria-hidden="true">✕</span><span class="action-label">Dismiss</span></button>
                 </div>
                 {# Title + link rendered inside the box so what users see
                    matches what the Copy button writes to the clipboard. #}

--- a/tests/handlers_test.rs
+++ b/tests/handlers_test.rs
@@ -3628,6 +3628,21 @@ async fn test_entry_fragment_renders_reading_pane() {
     );
     assert!(html.contains("Hello World"), "entry title must appear");
     assert!(html.contains("Body text here"), "entry body must appear");
+    // Editorial redesign: meta shows the feed favicon chip (feed "Test Feed"
+    // has no icon -> coloured initial chip "T").
+    assert!(
+        html.contains("entry-favicon-chip"),
+        "reading pane meta must render the favicon chip fallback"
+    );
+    // Actions use the shared .rp-action control with stable aria-labels.
+    assert!(
+        html.contains(r#"class="rp-action""#),
+        "reading pane actions must use the .rp-action control"
+    );
+    assert!(
+        html.contains(r#"aria-label="Mark Unread""#),
+        "Mark Unread action must keep its accessible name"
+    );
     // Auto-mark-as-read: response carries the updated row + sidebar blocks.
     assert!(
         html.contains(&format!(r##"data-swap-target="#entry-row-{}""##, entry_id)),
@@ -3936,8 +3951,8 @@ async fn test_star_entry_form_is_idempotent_mark_starred() {
         "multi-target response must include the pane-star-form swap"
     );
     assert!(
-        html.contains(">Unstar<"),
-        "pane-star-form swap payload must render the Unstar label"
+        html.contains(r#"aria-label="Unstar""#),
+        "pane-star-form swap payload must render the Unstar aria-label"
     );
 
     // Second /star — idempotent, entry stays starred (no toggle back).
@@ -3952,8 +3967,8 @@ async fn test_star_entry_form_is_idempotent_mark_starred() {
         "second /star call must be a no-op — row star toggle must still show Unstar"
     );
     assert!(
-        html2.contains(">Unstar<"),
-        "pane-star-form payload must still show Unstar after no-op"
+        html2.contains(r#"aria-label="Unstar""#),
+        "pane-star-form payload must still show Unstar aria-label after no-op"
     );
 }
 


### PR DESCRIPTION
## Summary

Redesigns the reading-pane chrome (the entry-row redesign's sibling) and swaps the glyph icons across the reader for a shared inline-SVG set.

**Reading pane chrome (desktop + mobile)**
- **Mobile:** actions move into a **fixed bottom action bar** (thumb-reachable, available while the article scrolls); `flex: 1` + `space-around` so the 2–5 conditionally-rendered actions always spread evenly; each control ≥48px tall. Top toolbar keeps Back + icon-only prev/next.
- **Desktop:** actions are a single **same-level inline row** under the meta line (icon + label, `white-space: nowrap`, no grouping).
- **Header/meta:** serif title shrunk (1.5rem desktop / 1.25rem mobile); meta gains a **favicon chip** (reusing the entry-row vocabulary — feed favicon or coloured initial), with a favicon-safe mid-dot separator.
- **Summary box** Copy/Dismiss adopt the shared control style.
- Article body typography is unchanged.

**Inline SVG icon set (outline style)**
- New `templates/_icons.html` Askama macros (12 icons) shared by the reading pane, entry rows, the pane-star swap payload, and the prev/next nav chevrons — replacing the previous unicode/text glyphs.
- Icons use `currentColor` (no more glyph/theme colour mismatch) and scale with the control font-size; the star toggles outline (not starred) vs filled, with the active star rendered in the accent colour.
- No build tooling — inline SVG only.

**Rust**
- `feed_initial` / `feed_color_index` extracted to shared free functions (delegated by both `EntryRowView` and `ReadingPaneView`); `ReadingPaneView` gains `feed_id` / `feed_has_icon` for the chip.

All accessible names (`Star`/`Unstar`, `Mark Unread`, `Fetch Full Content`, `Show Original`, `Summarize`, `Save`) and swap targets / data-testids are preserved.

## Test Plan
- [x] `cargo nextest run` — 898/898 pass (`RDRS_FAST_HASH=1`)
- [x] `cargo fmt --check` clean
- [x] e2e `reading triage responsive keyboard_shortcuts_mobile` — all pass, incl. a new `@mobile` scenario asserting the bottom action bar is touch-sized (`.rp-action` ≥44px tall) and full-width (`.reading-pane-actions` ≥360px on a 375px viewport)
- [ ] Visual check: star empty vs filled, and `unread` (circular refresh) vs `show original` (u-turn) icons are clearly distinguishable

🤖 Generated with [Claude Code](https://claude.com/claude-code)