### PR TITLE
Sidebar: completed-summary count badge

### DIFF
--- a/docs/superpowers/plans/2026-06-14-sidebar-summary-count.md
+++ b/docs/superpowers/plans/2026-06-14-sidebar-summary-count.md
@@ -1,0 +1,504 @@
+# Sidebar Completed-Summary Count Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a "Summarized" nav item to the sidebar with a badge showing the count of the user's completed summaries.
+
+**Architecture:** Thread one global integer `total_summarized` through the existing unread-count plumbing (`entry_summary::count_completed` → `read_chrome_data` cached closure → `ChromeData`/`SidebarResponse` → `/api/sidebar` + `#rdrs-sidebar-bootstrap`). The CSR `<rdrs-sidebar>` renders the new item + badge and patches it on revalidate. Bust the chrome cache when a summary completes (worker) or is dismissed.
+
+**Tech Stack:** Rust (Axum, rusqlite, Askama), vanilla-JS custom element (`static/js/components/rdrs-sidebar.js`), Playwright-BDD e2e.
+
+---
+
+## Notes for the implementer
+
+- **NixOS box:** `source /tmp/rdrs-env.sh` before EVERY cargo/e2e command.
+- **`pwd` first**; expect `/home/nixos/Develop/claude/rdrs`.
+- **Tests:** `cargo nextest run` (NOT `cargo test`), `RDRS_FAST_HASH=1`. `cargo fmt` before commit. CI runs `cargo clippy -- -D warnings` — keep it clean.
+- **e2e:** run from `e2e/`; **`cargo build` first** (CSS/JS are served from the binary's static dir — actually JS is served from `static/` on disk, but the e2e harness builds the binary; rebuild after Rust changes). `npx bddgen` runs automatically via `npx playwright test`.
+- **Commits GPG-signed** (`git commit -S`); trailer `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`. Stage files explicitly; never `git add -A`/`.`. No version/CHANGELOG edits.
+- Current branch is `feat/sidebar-summary-count` (already created).
+
+## Verified facts
+
+- `entry_summary` table: columns include `user_id`, `entry_id`, `status` (`'pending'|'processing'|'completed'|'failed'`). Index `idx_entry_summary_user_status (user_id, status)`.
+- `CachedChrome` (`src/services/sidebar_cache.rs:11`): `{ theme: Option<String>, categories: Vec<SidebarCategoryDto>, total_unread: i64 }`. `SidebarCache::bust(&self, user_id: i64)`. `AppState.sidebar_cache: Arc<SidebarCache>`.
+- `ChromeData` + `SidebarResponse` in `src/handlers/user.rs`. `read_chrome_data` builds `CachedChrome` + `ChromeData` (cache-hit branch ~line 190 and fresh branch). `build_sidebar_response` (line 245) maps `ChromeData` → `SidebarResponse`. `get_sidebar` (line 279) calls `build_sidebar_response`.
+- `serialize_sidebar_for_script` (`src/handlers/pages/script_json.rs:14`) does `serde_json::to_string(&SidebarResponse)` → bootstrap field flows automatically. **No change needed there.**
+- Summary worker `src/services/summary_worker.rs`: `start_summary_worker(rx, cache: Arc<SummaryCache>, db: DbPool, cancel_token)`; `process_summary_job(job, cache, db)` calls `entry_summary::set_completed(conn, user_id, entry_id, &summary_text)` (~line 131) inside a `db.user(...)` closure. Started in `src/main.rs`.
+- Dismiss: `delete_entry_summary` (`src/handlers/entry.rs:285`) has `State(state)`, calls `entry_summary::delete`, then `state.summary_cache.remove`.
+- CSR sidebar `static/js/components/rdrs-sidebar.js`: `_updateBadges(data)` (~line 103) patches `#unread-count`; `render(data)` (~line 130) builds the nav. First section has Unread / Starred / All Entries; All Entries active set is `['all','read','summarized','entries']`. e2e/seed helper `insertSummary(entryId, userId, text)` inserts a `status='completed'` row.
+
+---
+
+## Task 1: `entry_summary::count_completed`
+
+**Files:**
+- Modify: `src/models/entry_summary.rs` (add fn + unit test in its `mod tests`)
+
+- [ ] **Step 1: Write the failing test**
+
+Append inside the `mod tests` block of `src/models/entry_summary.rs` (mirror the
+existing tests' setup — they create an in-memory DB via the crate's schema and
+insert summaries with `set_completed` / `upsert_pending`):
+
+```rust
+    #[test]
+    fn count_completed_counts_only_completed_for_user() {
+        let conn = test_conn(); // same helper the existing tests use to build schema
+        // user 1: two completed, one pending, one failed
+        super::set_completed(&conn, 1, 101, "s").unwrap();
+        super::set_completed(&conn, 1, 102, "s").unwrap();
+        super::upsert_pending(&conn, 1, 103).unwrap();
+        super::set_failed(&conn, 1, 104, "e").unwrap();
+        // user 2: one completed (must not leak into user 1's count)
+        super::set_completed(&conn, 2, 201, "s").unwrap();
+
+        assert_eq!(super::count_completed(&conn, 1).unwrap(), 2);
+        assert_eq!(super::count_completed(&conn, 2).unwrap(), 1);
+        assert_eq!(super::count_completed(&conn, 999).unwrap(), 0);
+    }
+```
+
+If the existing tests use a different conn-builder than `test_conn()`, use
+whatever they use (read the top of the `mod tests` block first and match it).
+
+- [ ] **Step 2: Run to verify it FAILS**
+
+```bash
+pwd
+source /tmp/rdrs-env.sh
+RDRS_FAST_HASH=1 cargo nextest run -p rdrs count_completed 2>&1 | tail -15
+```
+Expected: compile error — `count_completed` not found.
+
+- [ ] **Step 3: Implement `count_completed`**
+
+Add to `src/models/entry_summary.rs` (near the other query fns):
+
+```rust
+/// Count the user's entries that have a COMPLETED summary. Index-covered by
+/// `idx_entry_summary_user_status`. Used for the sidebar "Summarized" badge.
+pub fn count_completed(conn: &Connection, user_id: i64) -> AppResult<i64> {
+    let count: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM entry_summary WHERE user_id = ?1 AND status = 'completed'",
+        [user_id],
+        |row| row.get(0),
+    )?;
+    Ok(count)
+}
+```
+
+(Confirm `Connection` and `AppResult` are already imported in the file — they are,
+used by the other fns.)
+
+- [ ] **Step 4: Run to verify PASS**
+
+```bash
+pwd
+source /tmp/rdrs-env.sh
+cargo fmt
+RDRS_FAST_HASH=1 cargo nextest run -p rdrs count_completed 2>&1 | tail -15
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/nixos/Develop/claude/rdrs
+git add src/models/entry_summary.rs
+git commit -S -m "feat(entry_summary): add count_completed query
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Thread `total_summarized` through the chrome/sidebar payload
+
+**Files:**
+- Modify: `src/services/sidebar_cache.rs` (`CachedChrome`)
+- Modify: `src/handlers/user.rs` (`ChromeData`, `SidebarResponse`, `read_chrome_data`, `build_sidebar_response`)
+- Modify: `tests/handlers_test.rs` (extend the `/api/sidebar` test)
+
+- [ ] **Step 1: Add the failing handler assertion**
+
+Find the existing `/api/sidebar` test (`test_api_sidebar_returns_categories_with_unread`
+in `tests/handlers_test.rs`). After it seeds data, seed a completed summary and
+assert the response JSON has `total_summarized`. Add near its existing assertions:
+
+```rust
+    // Seed a completed summary for one of the user's entries, then assert the
+    // sidebar payload reports it.
+    app.db
+        .user(move |conn| {
+            rdrs::models::entry_summary::set_completed(conn, user_id, entry_id, "sum")
+        })
+        .await
+        .unwrap()
+        .unwrap();
+    // bust so the cached chrome is recomputed (the seed bypassed handler busts)
+    app.state.sidebar_cache.bust(user_id);
+    let body: serde_json::Value = app.server.get("/api/sidebar").await.json();
+    assert_eq!(body["total_summarized"], 1);
+```
+
+Adapt `user_id` / `entry_id` / how the test accesses `app.state` / `app.db` to the
+test's existing helpers (read the test first). If the test has no handle to a
+seeded entry id, seed a feed+entry like the other handler tests do.
+
+- [ ] **Step 2: Run to verify it FAILS**
+
+```bash
+pwd
+source /tmp/rdrs-env.sh
+RDRS_FAST_HASH=1 cargo nextest run -p rdrs test_api_sidebar 2>&1 | tail -15
+```
+Expected: FAIL — `total_summarized` is null / field missing.
+
+- [ ] **Step 3: Add the field to `CachedChrome`**
+
+In `src/services/sidebar_cache.rs`, add to `CachedChrome` (after `total_unread`):
+
+```rust
+    pub total_unread: i64,
+    pub total_summarized: i64,
+```
+
+- [ ] **Step 4: Add the field to `ChromeData` and `SidebarResponse`**
+
+In `src/handlers/user.rs`:
+- `SidebarResponse` (after `total_unread`): `pub total_summarized: i64,`
+- `ChromeData` (after `total_unread`): `pub total_summarized: i64,`
+
+- [ ] **Step 5: Populate it in `read_chrome_data`**
+
+In `read_chrome_data`:
+1. In the **cache-hit** branch (the `if let Some(cached) = ... { return ChromeData { ... } }`), add `total_summarized: cached.total_summarized,`.
+2. In the **fresh** `read_user` closure, add the query and include it in the constructed `CachedChrome`:
+   ```rust
+   let total_summarized =
+       crate::models::entry_summary::count_completed(conn, user_id).unwrap_or(0);
+   ```
+   and in the `CachedChrome { theme, categories, total_unread }` literal add `total_summarized,`.
+3. In the **final** `ChromeData { ... }` return (the fresh branch), add `total_summarized: fresh.total_summarized,`.
+4. The `unwrap_or_default()` on the fresh tuple relies on `CachedChrome: Default` — `total_summarized: i64` defaults to 0, fine.
+
+- [ ] **Step 6: Map it in `build_sidebar_response`**
+
+In `build_sidebar_response`, add to the `SidebarResponse { ... }` literal:
+
+```rust
+        total_unread: chrome.total_unread,
+        total_summarized: chrome.total_summarized,
+```
+
+- [ ] **Step 7: Run to verify PASS + clippy**
+
+```bash
+pwd
+source /tmp/rdrs-env.sh
+cargo fmt
+RDRS_FAST_HASH=1 cargo nextest run -p rdrs test_api_sidebar 2>&1 | tail -15
+cargo clippy -- -D warnings 2>&1 | tail -8
+```
+Expected: PASS; clippy clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /home/nixos/Develop/claude/rdrs
+git add src/services/sidebar_cache.rs src/handlers/user.rs tests/handlers_test.rs
+git commit -S -m "feat(sidebar): thread total_summarized through chrome payload
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Bust the chrome cache when summaries change
+
+**Files:**
+- Modify: `src/handlers/entry.rs` (`delete_entry_summary`)
+- Modify: `src/services/summary_worker.rs` (`start_summary_worker`, `process_summary_job`)
+- Modify: `src/main.rs` (pass the sidebar cache into the worker)
+
+- [ ] **Step 1: Bust on dismiss**
+
+In `src/handlers/entry.rs`, in `delete_entry_summary`, after
+`state.summary_cache.remove(user_id, id);` add:
+
+```rust
+    // The completed-summary count dropped — refresh the sidebar badge.
+    state.sidebar_cache.bust(user_id);
+```
+
+- [ ] **Step 2: Plumb the sidebar cache into the summary worker**
+
+In `src/services/summary_worker.rs`:
+1. Add import: `use crate::services::sidebar_cache::SidebarCache;` (confirm the module path; `SidebarCache` lives in `crate::services::sidebar_cache`).
+2. Change `start_summary_worker` signature to accept the cache:
+   ```rust
+   pub fn start_summary_worker(
+       mut rx: mpsc::Receiver<SummaryJob>,
+       cache: Arc<SummaryCache>,
+       sidebar_cache: Arc<SidebarCache>,
+       db: DbPool,
+       cancel_token: CancellationToken,
+   ) -> JoinHandle<()> {
+   ```
+3. Thread `sidebar_cache` into both `process_summary_job(&job, &cache, &db)` call sites — change to `process_summary_job(&job, &cache, &sidebar_cache, &db)` (the normal path and the cancel-drain path). Clone as needed for the `async move` (the closure already moves `cache`, `db`; add `let sidebar_cache = sidebar_cache;` move).
+4. Change `process_summary_job` signature:
+   ```rust
+   async fn process_summary_job(
+       job: &SummaryJob,
+       cache: &Arc<SummaryCache>,
+       sidebar_cache: &Arc<SidebarCache>,
+       db: &DbPool,
+   ) {
+   ```
+5. After the DB `set_completed` succeeds (the branch around line 125-135 that does `cache.set_completed(...)` + the `db.user(... entry_summary::set_completed ...)`), bust the sidebar cache for that user:
+   ```rust
+   // A summary just completed — the sidebar "Summarized" badge must tick up.
+   sidebar_cache.bust(job.user_id);
+   ```
+   Place it in the success path only (not on `set_failed`).
+
+- [ ] **Step 3: Update the worker start site in `main.rs`**
+
+In `src/main.rs`, find the `start_summary_worker(...)` call and pass the sidebar
+cache (the `AppState`'s `sidebar_cache`, an `Arc<SidebarCache>`), e.g.:
+
+```rust
+    let summary_worker_handle = services::start_summary_worker(
+        summary_rx,
+        state.summary_cache.clone(),
+        state.sidebar_cache.clone(),
+        state.db.clone(),
+        cancel_token.clone(),
+    );
+```
+Match the actual variable names at the call site (read it first).
+
+- [ ] **Step 4: Fix the worker's own tests**
+
+`src/services/summary_worker.rs` has tests that call `start_summary_worker` /
+`process_summary_job`. Update them to pass an `Arc<SidebarCache>`
+(`Arc::new(SidebarCache::new(...))` — match `SidebarCache`'s constructor; read
+`sidebar_cache.rs` for it). The bust is a no-op cache invalidation, so the tests'
+assertions on summary status are unaffected.
+
+- [ ] **Step 5: Build + test + clippy**
+
+```bash
+pwd
+source /tmp/rdrs-env.sh
+cargo fmt
+cargo build 2>&1 | tail -6
+RDRS_FAST_HASH=1 cargo nextest run -p rdrs summary 2>&1 | tail -20
+cargo clippy -- -D warnings 2>&1 | tail -8
+```
+Expected: clean build/clippy; summary worker + summary tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/nixos/Develop/claude/rdrs
+git add src/handlers/entry.rs src/services/summary_worker.rs src/main.rs
+git commit -S -m "feat(sidebar): bust chrome cache on summary complete/dismiss
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Render the "Summarized" nav item + badge (CSR)
+
+**Files:**
+- Modify: `static/js/components/rdrs-sidebar.js`
+
+- [ ] **Step 1: Add the item to `render()`**
+
+In `render(data)`, after `const totalUnread = data ? data.total_unread : 0;` add:
+
+```javascript
+        const totalSummarized = data ? data.total_summarized : 0;
+```
+
+In the first `.sidebar-section`, insert a new item **between** the "Starred" item
+and the "All Entries" item:
+
+```html
+            <a href="/entries/summarized" class="sidebar-item${isActive('summarized')}" data-testid="nav-summarized">
+                <span class="sidebar-item-icon">&#x2728;</span>
+                <span>Summarized</span>
+                <span class="sidebar-badge" id="summarized-count">${totalSummarized > 0 ? totalSummarized : ''}</span>
+            </a>
+```
+
+- [ ] **Step 2: Fix the All-Entries active set**
+
+The "All Entries" item currently uses
+`${['all', 'read', 'summarized', 'entries'].includes(active) ? ' active' : ''}`.
+Remove `'summarized'` so the new dedicated item owns that active state:
+
+```javascript
+            <a href="/entries" class="sidebar-item${['all', 'read', 'entries'].includes(active) ? ' active' : ''}" data-testid="nav-entries">
+```
+
+- [ ] **Step 3: Patch the badge on revalidate**
+
+In `_updateBadges(data)`, after the `#unread-count` block (before the
+`#sidebar-categories` lookup), add:
+
+```javascript
+        const sumEl = this.querySelector('#summarized-count');
+        if (sumEl) {
+            const sum = data.total_summarized || 0;
+            sumEl.textContent = sum > 0 ? String(sum) : '';
+        }
+```
+
+- [ ] **Step 4: Build + manual sanity (no JS unit harness)**
+
+```bash
+pwd
+source /tmp/rdrs-env.sh
+cargo build 2>&1 | tail -3
+```
+JS has no unit-test harness in this repo; behavior is covered by the e2e in Task 5.
+Quick syntax check (optional): `node --check static/js/components/rdrs-sidebar.js`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/nixos/Develop/claude/rdrs
+git add static/js/components/rdrs-sidebar.js
+git commit -S -m "feat(sidebar): render Summarized nav item with count badge
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: e2e — sidebar shows the Summarized item + badge
+
+**Files:**
+- Modify: `e2e/features/*.feature` (add a scenario — pick the feature file that already exercises the sidebar; likely `reading.feature` or a `sidebar`/`responsive` feature) and a step if needed.
+
+- [ ] **Step 1: Inspect existing sidebar e2e + seed helper**
+
+```bash
+cd /home/nixos/Develop/claude/rdrs
+grep -rn "nav-unread\|nav-starred\|nav-entries\|sidebar-badge\|insertSummary\|main-nav" e2e/features e2e/steps e2e/support | head
+```
+Identify the feature/steps that already assert sidebar items and the
+`insertSummary` seed helper (`e2e/support/seed.js`).
+
+- [ ] **Step 2: Add a scenario**
+
+Append to the most appropriate existing feature file (one that has a Background
+seeding a feed + entries and a logged-in session). Use existing step phrasings;
+only the assertions below are new — reuse a generic "I see" / locator step if one
+exists, else add a minimal step in the matching steps file:
+
+```gherkin
+  Scenario: Sidebar shows a Summarized count badge
+    Given I have a feed with 5 test entries
+    And entry "Test Entry 1" has a completed summary
+    When I open the inbox
+    Then the sidebar "Summarized" item shows a count of "1"
+    And clicking the sidebar "Summarized" item lands on the summarized view
+```
+
+If those exact steps don't exist, implement them in the matching `*.steps.js`:
+- `Given("entry {string} has a completed summary", …)` → use the `SeedHelper.insertSummary(entryId, userId, text)` (resolve the entry id by title + the logged-in user id, mirroring how other steps resolve them).
+- `Then("the sidebar {string} item shows a count of {string}", …)` → locate
+  `[data-testid="nav-summarized"] #summarized-count` (or `.sidebar-badge` within
+  the item) and assert its text equals the count.
+- `Then("clicking the sidebar {string} item lands on the summarized view", …)` →
+  click `[data-testid="nav-summarized"]`, assert URL `/entries/summarized`.
+
+Prefer reusing existing step infrastructure; only add steps that are genuinely missing.
+
+- [ ] **Step 3: Build + run**
+
+```bash
+pwd
+source /tmp/rdrs-env.sh
+cargo build 2>&1 | tail -3
+cd e2e && npx playwright test <feature-file-you-edited> 2>&1 | tail -25
+```
+Expected: the new scenario PASSES (badge "1", click → `/entries/summarized`).
+If the badge is empty: confirm the bootstrap payload carries `total_summarized`
+(Task 2) and the seed inserted a `completed` row before the page loaded; the
+sidebar reads the bootstrap synchronously on mount.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/nixos/Develop/claude/rdrs
+git add e2e/features/<file>.feature e2e/steps/<file>.steps.js
+git commit -S -m "test(e2e): assert sidebar Summarized count badge
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Full regression sweep
+
+**Files:** none (verification)
+
+- [ ] **Step 1: Rust + clippy + fmt**
+
+```bash
+pwd
+source /tmp/rdrs-env.sh
+cargo fmt --check
+RDRS_FAST_HASH=1 cargo nextest run -p rdrs 2>&1 | tail -20
+cargo clippy -- -D warnings 2>&1 | tail -6
+```
+Expected: all pass, clean.
+
+- [ ] **Step 2: e2e — sidebar-touching + triage (summarize) suites**
+
+```bash
+pwd
+source /tmp/rdrs-env.sh
+cargo build 2>&1 | tail -3
+cd e2e && npx playwright test reading triage responsive 2>&1 | tail -25
+```
+Expected: all pass (sidebar still renders; existing nav items + summarize flow
+unaffected). The new Summarized item must not break sidebar layout/active-state
+assertions; if a test asserted the sidebar item set, update it to include the new
+item.
+
+- [ ] **Step 3: Fix any regressions and re-run.**
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- New "Summarized" nav item (after Starred) + badge → Task 4. ✅
+- `count_completed` (status='completed', per-user, index-covered) → Task 1. ✅
+- `total_summarized` through CachedChrome/ChromeData/SidebarResponse/read_chrome_data/build_sidebar_response → Task 2. ✅
+- Bootstrap carries it automatically (serialize whole struct) → no task needed (verified). ✅
+- `/api/sidebar` includes it → Task 2 (via build_sidebar_response) + test. ✅
+- CSR surgical badge patch (`#summarized-count`) → Task 4 Step 3. ✅
+- Active-state: move `'summarized'` off All Entries onto the new item → Task 4 Step 2. ✅
+- Cache bust on complete (worker) + dismiss → Task 3. ✅
+- View filter unchanged → no task touches `filters.rs`. ✅
+- Tests: model count, /api/sidebar payload, e2e badge+nav → Tasks 1, 2, 5. ✅
+
+**Placeholder scan:** No TBD/TODO. The two "match the test/seed helper to what
+exists" notes are concrete instructions (read the existing helper, mirror it), not
+deferrals.
+
+**Type/name consistency:** `count_completed(conn, user_id) -> AppResult<i64>` (Task 1)
+called in Task 2 read_chrome_data. `total_summarized: i64` added consistently to
+CachedChrome (Task 2.3), ChromeData (2.4), SidebarResponse (2.4), and read in
+build_sidebar_response (2.6) and JS `data.total_summarized` (Task 4). `SidebarCache`
+plumbed as `Arc<SidebarCache>` into the worker (Task 3) matching `AppState.sidebar_cache`.
+JS ids `#summarized-count` / testid `nav-summarized` consistent between Task 4 and Task 5.

--- a/docs/superpowers/specs/2026-06-14-sidebar-summary-count-design.md
+++ b/docs/superpowers/specs/2026-06-14-sidebar-summary-count-design.md
@@ -1,0 +1,129 @@
+# Sidebar Completed-Summary Count — Design
+
+**Date:** 2026-06-14
+**Branch:** `feat/sidebar-summary-count`
+**Status:** Approved design, pending implementation plan
+
+## Problem
+
+The user often forgets they have already summarized entries. The sidebar surfaces
+unread counts but gives no signal about summaries, and there is no "Summarized"
+navigation entry at all (the `/entries/summarized` view is only reachable via the
+`m` keyboard shortcut).
+
+## Goal
+
+Add a **"Summarized" navigation item** to the sidebar's first section (after
+"Starred"), carrying a **count badge** of the user's completed summaries — both a
+reminder ("you have N summaries") and a way to jump to `/entries/summarized`.
+
+## Non-Goals
+
+- Do **not** change the `/entries/summarized` view's filter. It currently lists
+  entries that have *any* `entry_summary` row (any status). The badge counts
+  `status='completed'` only, so the badge may differ slightly from the view's
+  row count (failed / in-flight summaries). This minor divergence is accepted
+  (user decision) — the badge's intent is "summaries I can actually read."
+- No per-category summary counts (the count is global, like `total_unread` is a
+  global badge on "Unread").
+- No new frontend build tooling. The sidebar is pure CSR (`<rdrs-sidebar>` +
+  the `#rdrs-sidebar-bootstrap` JSON); there is no SSR sidebar macro to update.
+
+## Approach
+
+Reuse the existing unread-count plumbing end to end. The count is a single
+global integer `total_summarized` threaded through the same path as
+`total_unread`.
+
+### Data
+
+- **New model fn** `entry_summary::count_completed(conn, user_id) -> AppResult<i64>`:
+  `SELECT COUNT(*) FROM entry_summary WHERE user_id = ?1 AND status = 'completed'`.
+  Index-covered by the existing `idx_entry_summary_user_status (user_id, status)`.
+- **`CachedChrome`** (`src/services/sidebar_cache.rs`): add `total_summarized: i64`.
+- **`ChromeData`** + **`SidebarResponse`** (`src/handlers/user.rs`): add
+  `total_summarized: i64`.
+- **`read_chrome_data`** (`src/handlers/user.rs`): in the SAME `read_user`
+  closure that already fetches theme + categories + unread + has_feeds, add the
+  `count_completed` query — one extra cheap query, no extra round-trip. Populate
+  the cache + `ChromeData` with it.
+- **`get_sidebar`** (`GET /api/sidebar`, the CSR background-revalidate endpoint):
+  include `total_summarized` in its `SidebarResponse`.
+- **Bootstrap** (`serialize_sidebar_for_script` in
+  `src/handlers/pages/script_json.rs`): it does `serde_json::to_string(payload)`
+  on the whole `SidebarResponse`, so the new field flows into
+  `#rdrs-sidebar-bootstrap` automatically — **no change needed in this file**.
+
+### UI (`static/js/components/rdrs-sidebar.js`)
+
+- In the first `.sidebar-section`, after the "Starred" item, add a "Summarized"
+  item mirroring the existing pattern:
+  ```html
+  <a href="/entries/summarized" class="sidebar-item${isActive('summarized')}" data-testid="nav-summarized">
+      <span class="sidebar-item-icon">✨</span>
+      <span>Summarized</span>
+      <span class="sidebar-badge" id="summarized-count">${totalSummarized > 0 ? totalSummarized : ''}</span>
+  </a>
+  ```
+  where `totalSummarized = data ? data.total_summarized : 0`.
+- **Active state:** add `'summarized'` handling so the item highlights on the
+  summarized view. Note the existing "All Entries" item currently treats
+  `active === 'summarized'` as active; remove `'summarized'` from that item's
+  active set so the new dedicated item owns the active state for that view.
+- **Surgical badge patch:** in the same place the code updates `#unread-count`
+  on a background revalidate, also update `#summarized-count` from
+  `data.total_summarized` (show the number when > 0, else empty), so the badge
+  advances without a full re-render.
+
+### Cache invalidation
+
+`total_summarized` lives in `sidebar_cache` (60 s TTL). Bust it when the count
+changes so the badge updates promptly instead of lagging up to the TTL:
+
+- `entry_summary::set_completed` path — the background summary worker that
+  finishes a summary. After it persists `completed`, `state.sidebar_cache.bust(user_id)`.
+- Summary **dismiss** (`entry_summary::delete`, the `data-summary-dismiss`
+  endpoint) — bust after delete.
+
+If a bust site is missed, the badge still self-heals within the 60 s TTL and on
+the CSR's per-mount `/api/sidebar` revalidate. (Bulk deletions via retention are
+not explicitly busted; they reconcile on TTL/revalidate — acceptable.)
+
+## Testing
+
+- **Rust unit:** `count_completed` returns the right number (0 when none; counts
+  only `completed`, not pending/processing/failed; scoped per user).
+- **Rust handler:** `GET /api/sidebar` response JSON includes `total_summarized`
+  with the correct value after seeding a completed summary; the page bootstrap
+  (`#rdrs-sidebar-bootstrap`) includes `total_summarized`.
+- **Cache:** completing a summary (or dismissing one) leads to an updated count
+  on the next read (bust verified — e.g. assert the count changes without
+  waiting for TTL).
+- **e2e:** the sidebar shows a "Summarized" item (`nav-summarized`); after
+  seeding/creating a completed summary the `#summarized-count` badge shows the
+  expected number; clicking it lands on `/entries/summarized`.
+
+## Files Touched
+
+- `src/models/entry_summary.rs` — `count_completed` + unit test.
+- `src/services/sidebar_cache.rs` — `CachedChrome.total_summarized`.
+- `src/handlers/user.rs` — `ChromeData` + `SidebarResponse` field;
+  `read_chrome_data` query; `get_sidebar` includes it.
+- `src/handlers/pages/script_json.rs` — no change (serializes the whole
+  `SidebarResponse`; the new field flows through automatically).
+- `static/js/components/rdrs-sidebar.js` — Summarized nav item + badge + active
+  state + surgical patch.
+- summary worker (`set_completed` caller) + dismiss handler — `sidebar_cache.bust`.
+- `tests/handlers_test.rs` (+ model test) and `e2e/features/*.feature` — coverage.
+
+## Risks & Mitigations
+
+- **Stale badge** → cache bust on complete/dismiss + 60 s TTL + per-mount
+  revalidate. Acceptable.
+- **Active-state double-highlight** (All Entries + Summarized both active on the
+  summarized view) → remove `'summarized'` from the All-Entries active set when
+  adding the dedicated item.
+- **Count/view divergence** (badge=completed, view=any-row) → accepted, documented
+  in Non-Goals.
+- **Extra query per chrome build** → folded into the existing cached `read_user`
+  closure; index-covered; negligible.

--- a/e2e/features/reading.feature
+++ b/e2e/features/reading.feature
@@ -219,7 +219,7 @@ Feature: Reading entries
     When I open the read entries page
     Then the sidebar highlights All Entries
     When I open the summarized entries page
-    Then the sidebar highlights All Entries
+    Then the sidebar highlights Summarized
     When I open the all entries page
     Then the sidebar highlights All Entries
     When I open the starred entries page

--- a/e2e/features/reading.feature
+++ b/e2e/features/reading.feature
@@ -40,6 +40,11 @@ Feature: Reading entries
     Then I see 1 entry in the entry list
     And the first entry is titled "Test Entry 3"
 
+  Scenario: Sidebar shows a Summarized count badge
+    Given the entry titled "Test Entry 1" has a summary
+    When I open the inbox
+    Then the sidebar Summarized item shows a count of "1"
+
   Scenario: Single-feed view filters by that feed
     When I open the entries page for feed "Reading Feed"
     Then I see 5 entries in the entry list

--- a/e2e/steps/entries.steps.js
+++ b/e2e/steps/entries.steps.js
@@ -421,6 +421,10 @@ Then("the sidebar highlights All Entries", async ({ page }) => {
   await expect(page.getByTestId("nav-entries")).toHaveClass(/active/);
 });
 
+Then("the sidebar highlights Summarized", async ({ page }) => {
+  await expect(page.getByTestId("nav-summarized")).toHaveClass(/active/);
+});
+
 Then("the sidebar Summarized item shows a count of {string}", async ({ page }, count) => {
   await expect(page.locator('[data-testid="nav-summarized"] #summarized-count')).toHaveText(count);
 });

--- a/e2e/steps/entries.steps.js
+++ b/e2e/steps/entries.steps.js
@@ -421,6 +421,10 @@ Then("the sidebar highlights All Entries", async ({ page }) => {
   await expect(page.getByTestId("nav-entries")).toHaveClass(/active/);
 });
 
+Then("the sidebar Summarized item shows a count of {string}", async ({ page }, count) => {
+  await expect(page.locator('[data-testid="nav-summarized"] #summarized-count')).toHaveText(count);
+});
+
 Then("the sidebar highlights Starred", async ({ page }) => {
   // The Starred sidebar item carries no data-testid — target by href.
   await expect(page.locator('rdrs-sidebar a[href="/entries/starred"]')).toHaveClass(/active/);

--- a/src/handlers/entry.rs
+++ b/src/handlers/entry.rs
@@ -310,7 +310,7 @@ pub async fn delete_entry_summary(
 
     // Remove from cache
     state.summary_cache.remove(user_id, id);
-    // The completed-summary count dropped — refresh the sidebar badge.
+    // A summary was removed; the completed-summary count may have dropped — refresh the sidebar badge.
     state.sidebar_cache.bust(user_id);
 
     Ok(Json(serde_json::json!({ "success": true })))

--- a/src/handlers/entry.rs
+++ b/src/handlers/entry.rs
@@ -310,6 +310,8 @@ pub async fn delete_entry_summary(
 
     // Remove from cache
     state.summary_cache.remove(user_id, id);
+    // The completed-summary count dropped — refresh the sidebar badge.
+    state.sidebar_cache.bust(user_id);
 
     Ok(Json(serde_json::json!({ "success": true })))
 }

--- a/src/handlers/pages/mod.rs
+++ b/src/handlers/pages/mod.rs
@@ -2014,6 +2014,7 @@ pub async fn build_app_layout(
         is_masquerading,
         categories: chrome.categories,
         total_unread: chrome.total_unread,
+        total_summarized: chrome.total_summarized,
     };
     let sidebar_bootstrap_json = serialize_sidebar_for_script(&sidebar);
     let flash_bootstrap_json = flash_bootstrap_json(&flash.messages);

--- a/src/handlers/user.rs
+++ b/src/handlers/user.rs
@@ -134,6 +134,7 @@ pub struct SidebarResponse {
     pub is_masquerading: bool,
     pub categories: Vec<SidebarCategoryDto>,
     pub total_unread: i64,
+    pub total_summarized: i64,
 }
 
 /// Raw chrome data needed for every authenticated page render: theme,
@@ -146,6 +147,7 @@ pub struct ChromeData {
     pub theme: Option<String>,
     pub categories: Vec<SidebarCategoryDto>,
     pub total_unread: i64,
+    pub total_summarized: i64,
     /// Only set when `original_user_id` is passed (i.e. session is
     /// masquerading). `None` outside the masquerade path.
     pub original_user_is_admin: Option<bool>,
@@ -185,6 +187,7 @@ pub async fn read_chrome_data(
             theme: cached.theme,
             categories: cached.categories,
             total_unread: cached.total_unread,
+            total_summarized: cached.total_summarized,
             original_user_is_admin,
         };
     }
@@ -198,6 +201,8 @@ pub async fn read_chrome_data(
             // Total unread is the sum of the per-category map already fetched —
             // avoids a second full scan via count_unread_by_user.
             let total_unread: i64 = unread_by_cat.values().sum();
+            let total_summarized =
+                crate::models::entry_summary::count_completed(conn, user_id).unwrap_or(0);
             let has_feeds = crate::models::feed::count_by_user(conn, user_id).unwrap_or(0) > 0;
             let categories: Vec<SidebarCategoryDto> = cats
                 .into_iter()
@@ -212,6 +217,7 @@ pub async fn read_chrome_data(
                     theme,
                     categories,
                     total_unread,
+                    total_summarized,
                 },
                 has_feeds,
             )
@@ -235,6 +241,7 @@ pub async fn read_chrome_data(
         theme: fresh.theme,
         categories: fresh.categories,
         total_unread: fresh.total_unread,
+        total_summarized: fresh.total_summarized,
         original_user_is_admin,
     }
 }
@@ -271,6 +278,7 @@ pub async fn build_sidebar_response(
         is_masquerading,
         categories: chrome.categories,
         total_unread: chrome.total_unread,
+        total_summarized: chrome.total_summarized,
     })
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,10 +50,14 @@ async fn main() {
     // Create summary worker channel (buffer size 100)
     let (summary_tx, summary_rx) = services::create_summary_channel(100);
 
+    // Create sidebar cache
+    let sidebar_cache = Arc::new(services::SidebarCache::default());
+
     // Start summary worker
     let summary_worker_handle = services::start_summary_worker(
         summary_rx,
         summary_cache.clone(),
+        sidebar_cache.clone(),
         db.clone(),
         cancel_token.clone(),
     );
@@ -81,7 +85,7 @@ async fn main() {
         webauthn: Arc::new(webauthn),
         summary_cache,
         summary_tx,
-        sidebar_cache: Arc::new(services::SidebarCache::default()),
+        sidebar_cache,
     };
 
     // Start background sync task

--- a/src/models/entry_summary.rs
+++ b/src/models/entry_summary.rs
@@ -282,7 +282,7 @@ pub fn delete_expired(conn: &Connection, hours: i64) -> AppResult<usize> {
 pub fn count_completed(conn: &Connection, user_id: i64) -> AppResult<i64> {
     let count: i64 = conn.query_row(
         "SELECT COUNT(*) FROM entry_summary WHERE user_id = ?1 AND status = 'completed'",
-        [user_id],
+        params![user_id],
         |row| row.get(0),
     )?;
     Ok(count)

--- a/src/models/entry_summary.rs
+++ b/src/models/entry_summary.rs
@@ -277,6 +277,17 @@ pub fn delete_expired(conn: &Connection, hours: i64) -> AppResult<usize> {
     Ok(rows)
 }
 
+/// Count the user's entries that have a COMPLETED summary. Index-covered by
+/// `idx_entry_summary_user_status`. Used for the sidebar "Summarized" badge.
+pub fn count_completed(conn: &Connection, user_id: i64) -> AppResult<i64> {
+    let count: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM entry_summary WHERE user_id = ?1 AND status = 'completed'",
+        [user_id],
+        |row| row.get(0),
+    )?;
+    Ok(count)
+}
+
 /// Check if a summary record exists (any status)
 pub fn exists(conn: &Connection, user_id: i64, entry_id: i64) -> AppResult<bool> {
     let count: i64 = conn.query_row(
@@ -514,5 +525,69 @@ mod tests {
         );
         assert_eq!(SummaryStatus::parse("failed"), Some(SummaryStatus::Failed));
         assert_eq!(SummaryStatus::parse("invalid"), None);
+    }
+
+    #[test]
+    fn count_completed_counts_only_completed_for_user() {
+        let conn = setup_db();
+        let u1 = create_test_user(&conn, "u1");
+        let u2 = create_test_user(&conn, "u2");
+
+        // create_test_entry reuses the same category name per user, so build
+        // entries manually with unique GUIDs for the multi-entry u1 scenario.
+        let cat1 = category::create_category(&conn, u1, "Tech1").unwrap().id;
+        let feed1 = feed::create_feed(
+            &conn,
+            &feed::CreateFeedParams {
+                category_id: cat1,
+                url: "https://example.com/feed1.xml",
+                title: Some("Feed 1"),
+                description: None,
+                site_url: None,
+                custom_user_agent: None,
+                http2_disabled: None,
+                custom_referrer: None,
+            },
+        )
+        .unwrap()
+        .id;
+
+        let make_entry = |guid: &str| -> i64 {
+            entry::upsert_entry(
+                &conn,
+                feed1,
+                guid,
+                Some("Test Entry"),
+                Some("https://example.com/entry"),
+                Some("Content"),
+                None,
+                None,
+                None,
+            )
+            .unwrap()
+            .0
+            .id
+        };
+
+        let e1 = make_entry("g1");
+        let e2 = make_entry("g2");
+        let e3 = make_entry("g3");
+        let e4 = make_entry("g4");
+        // u2 gets its own entry via the helper (first call, no conflict)
+        let e5 = create_test_entry(&conn, u2);
+
+        upsert_pending(&conn, u1, e1).unwrap();
+        set_completed(&conn, u1, e1, "s").unwrap();
+        upsert_pending(&conn, u1, e2).unwrap();
+        set_completed(&conn, u1, e2, "s").unwrap();
+        upsert_pending(&conn, u1, e3).unwrap();
+        upsert_pending(&conn, u1, e4).unwrap();
+        set_failed(&conn, u1, e4, "err").unwrap();
+        upsert_pending(&conn, u2, e5).unwrap();
+        set_completed(&conn, u2, e5, "s").unwrap();
+
+        assert_eq!(count_completed(&conn, u1).unwrap(), 2);
+        assert_eq!(count_completed(&conn, u2).unwrap(), 1);
+        assert_eq!(count_completed(&conn, 99999).unwrap(), 0);
     }
 }

--- a/src/services/sidebar_cache.rs
+++ b/src/services/sidebar_cache.rs
@@ -12,6 +12,7 @@ pub struct CachedChrome {
     pub theme: Option<String>,
     pub categories: Vec<SidebarCategoryDto>,
     pub total_unread: i64,
+    pub total_summarized: i64,
 }
 
 /// In-memory per-user cache for sidebar chrome data — replaces the 4 SQL
@@ -74,6 +75,7 @@ mod tests {
                 unread_count: unread,
             }],
             total_unread: unread,
+            total_summarized: 0,
         }
     }
 

--- a/src/services/summary_worker.rs
+++ b/src/services/summary_worker.rs
@@ -4,6 +4,7 @@ use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
+use super::sidebar_cache::SidebarCache;
 use super::summarize::kagi::{self, KagiConfig};
 use super::summary_cache::SummaryCache;
 use crate::db::DbPool;
@@ -21,6 +22,7 @@ pub struct SummaryJob {
 pub fn start_summary_worker(
     mut rx: mpsc::Receiver<SummaryJob>,
     cache: Arc<SummaryCache>,
+    sidebar_cache: Arc<SidebarCache>,
     db: DbPool,
     cancel_token: CancellationToken,
 ) -> JoinHandle<()> {
@@ -33,7 +35,7 @@ pub fn start_summary_worker(
                     tracing::info!("Summary worker stopping, draining remaining jobs...");
                     // Drain remaining jobs before exiting
                     while let Ok(job) = rx.try_recv() {
-                        process_summary_job(&job, &cache, &db).await;
+                        process_summary_job(&job, &cache, &sidebar_cache, &db).await;
                     }
                     break;
                 }
@@ -45,14 +47,19 @@ pub fn start_summary_worker(
                 }
             };
 
-            process_summary_job(&job, &cache, &db).await;
+            process_summary_job(&job, &cache, &sidebar_cache, &db).await;
         }
 
         tracing::info!("Summary worker stopped");
     })
 }
 
-async fn process_summary_job(job: &SummaryJob, cache: &Arc<SummaryCache>, db: &DbPool) {
+async fn process_summary_job(
+    job: &SummaryJob,
+    cache: &Arc<SummaryCache>,
+    sidebar_cache: &Arc<SidebarCache>,
+    db: &DbPool,
+) {
     tracing::debug!(
         "Processing summary job: user={}, entry={}, link={}",
         job.user_id,
@@ -131,6 +138,8 @@ async fn process_summary_job(job: &SummaryJob, cache: &Arc<SummaryCache>, db: &D
                     entry_summary::set_completed(conn, user_id, entry_id, &summary_text)
                 })
                 .await;
+            // A summary just completed — the sidebar "Summarized" badge must tick up.
+            sidebar_cache.bust(job.user_id);
         }
         Err(error) => {
             tracing::warn!("Summary failed for entry {}: {}", job.entry_id, error);
@@ -308,7 +317,13 @@ mod tests {
         let db = setup_test_db();
         let cancel_token = CancellationToken::new();
 
-        let handle = start_summary_worker(rx, cache, db, cancel_token.clone());
+        let handle = start_summary_worker(
+            rx,
+            cache,
+            Arc::new(SidebarCache::default()),
+            db,
+            cancel_token.clone(),
+        );
 
         // Send a job (it won't be processed properly without Kagi config, but that's OK)
         let _ = tx
@@ -334,7 +349,13 @@ mod tests {
         let db = setup_test_db();
         let cancel_token = CancellationToken::new();
 
-        let handle = start_summary_worker(rx, cache, db, cancel_token);
+        let handle = start_summary_worker(
+            rx,
+            cache,
+            Arc::new(SidebarCache::default()),
+            db,
+            cancel_token,
+        );
 
         // Drop the sender to close the channel
         drop(tx);
@@ -486,7 +507,13 @@ mod tests {
         .await
         .unwrap();
 
-        let handle = start_summary_worker(rx, cache.clone(), db, cancel_token.clone());
+        let handle = start_summary_worker(
+            rx,
+            cache.clone(),
+            Arc::new(SidebarCache::default()),
+            db,
+            cancel_token.clone(),
+        );
 
         // Send multiple jobs
         for i in 1..=3 {

--- a/static/js/components/rdrs-sidebar.js
+++ b/static/js/components/rdrs-sidebar.js
@@ -189,7 +189,7 @@ class RdrsSidebar extends HTMLElement {
                 <span>Starred</span>
             </a>
             <a href="/entries/summarized" class="sidebar-item${isActive('summarized')}" data-testid="nav-summarized">
-                <span class="sidebar-item-icon">&#x2728;</span>
+                <span class="sidebar-item-icon">&#x2728;&#xFE0F;</span>
                 <span>Summarized</span>
                 <span class="sidebar-badge" id="summarized-count">${totalSummarized > 0 ? totalSummarized : ''}</span>
             </a>

--- a/static/js/components/rdrs-sidebar.js
+++ b/static/js/components/rdrs-sidebar.js
@@ -106,6 +106,11 @@ class RdrsSidebar extends HTMLElement {
             const total = data.total_unread || 0;
             totalEl.textContent = total > 0 ? String(total) : '';
         }
+        const sumEl = this.querySelector('#summarized-count');
+        if (sumEl) {
+            const sum = data.total_summarized || 0;
+            sumEl.textContent = sum > 0 ? String(sum) : '';
+        }
         const catContainer = this.querySelector('#sidebar-categories');
         if (!catContainer) return;
         for (const cat of data.categories || []) {
@@ -135,6 +140,7 @@ class RdrsSidebar extends HTMLElement {
         const isMasq = data ? !!data.is_masquerading : false;
         const cats = data ? data.categories : [];
         const totalUnread = data ? data.total_unread : 0;
+        const totalSummarized = data ? data.total_summarized : 0;
 
         const isActive = (name) => active === name ? ' active' : '';
 
@@ -182,7 +188,12 @@ class RdrsSidebar extends HTMLElement {
                 <span class="sidebar-item-icon">&#x2B50;&#xFE0F;</span>
                 <span>Starred</span>
             </a>
-            <a href="/entries" class="sidebar-item${['all', 'read', 'summarized', 'entries'].includes(active) ? ' active' : ''}" data-testid="nav-entries">
+            <a href="/entries/summarized" class="sidebar-item${isActive('summarized')}" data-testid="nav-summarized">
+                <span class="sidebar-item-icon">&#x2728;</span>
+                <span>Summarized</span>
+                <span class="sidebar-badge" id="summarized-count">${totalSummarized > 0 ? totalSummarized : ''}</span>
+            </a>
+            <a href="/entries" class="sidebar-item${['all', 'read', 'entries'].includes(active) ? ' active' : ''}" data-testid="nav-entries">
                 <span class="sidebar-item-icon">&#x1F4F0;&#xFE0F;</span>
                 <span>All Entries</span>
             </a>

--- a/tests/statistics_test.rs
+++ b/tests/statistics_test.rs
@@ -371,3 +371,27 @@ async fn test_api_sidebar_returns_categories_with_unread() {
     assert_eq!(cats[0]["unread_count"], 2);
     assert_eq!(body["total_unread"], 2);
 }
+
+#[tokio::test]
+async fn test_api_sidebar_total_summarized() {
+    let app = create_test_app("test_api_sidebar_total_summarized");
+    let (admin_id, _user_id) = setup_users(&app.db).await;
+    seed_entries(&app.db, admin_id).await;
+
+    // Seed a completed summary for entry 1 (belongs to admin_id).
+    // upsert_pending first — set_completed is a no-op without an existing row.
+    // Do this BEFORE hitting /api/sidebar so the cache is cold when we read.
+    app.db
+        .user(move |conn| {
+            rdrs::models::entry_summary::upsert_pending(conn, admin_id, 1)?;
+            rdrs::models::entry_summary::set_completed(conn, admin_id, 1, "summary text")
+        })
+        .await
+        .unwrap()
+        .unwrap();
+
+    login(&app.server, "admin").await;
+
+    let body: Value = app.server.get("/api/sidebar").await.json();
+    assert_eq!(body["total_summarized"], 1);
+}

--- a/tests/statistics_test.rs
+++ b/tests/statistics_test.rs
@@ -378,13 +378,15 @@ async fn test_api_sidebar_total_summarized() {
     let (admin_id, _user_id) = setup_users(&app.db).await;
     seed_entries(&app.db, admin_id).await;
 
-    // Seed a completed summary for entry 1 (belongs to admin_id).
+    // Seed a completed summary for the first entry (belongs to admin_id).
     // upsert_pending first — set_completed is a no-op without an existing row.
     // Do this BEFORE hitting /api/sidebar so the cache is cold when we read.
     app.db
         .user(move |conn| {
-            rdrs::models::entry_summary::upsert_pending(conn, admin_id, 1)?;
-            rdrs::models::entry_summary::set_completed(conn, admin_id, 1, "summary text")
+            let entry_id: i64 =
+                conn.query_row("SELECT id FROM entry ORDER BY id LIMIT 1", [], |r| r.get(0))?;
+            rdrs::models::entry_summary::upsert_pending(conn, admin_id, entry_id)?;
+            rdrs::models::entry_summary::set_completed(conn, admin_id, entry_id, "summary text")
         })
         .await
         .unwrap()


### PR DESCRIPTION
## Summary

Adds a **"Summarized" navigation item** to the sidebar (between Starred and All Entries) with a **count badge** of the user's completed summaries. Motivation: it's easy to forget you've already summarized entries — the badge surfaces that and links to `/entries/summarized`.

- New `entry_summary::count_completed(user_id)` (`COUNT WHERE status='completed'`, index-covered by `idx_entry_summary_user_status`).
- `total_summarized` threaded through the existing unread-count plumbing: `read_chrome_data`'s cached read closure → `CachedChrome` / `ChromeData` / `SidebarResponse` → `/api/sidebar` + the page bootstrap (`serialize_sidebar_for_script` serializes the whole struct, so the field flows automatically).
- CSR `<rdrs-sidebar>` renders the item + `#summarized-count` badge and patches it on revalidate; the `/entries/summarized` active-highlight moves from "All Entries" onto the new item.
- Chrome cache (`sidebar_cache`) is busted when a summary **completes** (summary worker — same shared `Arc<SidebarCache>` as the request path) or is **dismissed**, so the badge updates promptly (else 60s TTL + per-mount revalidate).

**Accepted divergence (by design):** the badge counts `status='completed'` only, while the `/entries/summarized` *view* still lists any-status summary rows (filter unchanged). So the badge may read slightly lower than the list when failed/in-flight summaries exist.

## Test Plan
- [x] `cargo nextest run` — 902/902 (`RDRS_FAST_HASH=1`); `cargo fmt --check` + `cargo clippy -- -D warnings` clean
- [x] Unit: `count_completed` (per-user isolation, excludes pending/failed)
- [x] Handler: `GET /api/sidebar` reports `total_summarized` (cold-cache seed)
- [x] e2e: sidebar shows the Summarized badge ("1" after a completed summary); the summarized page highlights the Summarized item; reading/triage/responsive suites green (55/55)

🤖 Generated with [Claude Code](https://claude.com/claude-code)