### PR TITLE
SVG icon migration, entry-row relayout & 44px touch-target audit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 *.sqlite3
 .superpowers/
+e2e/scripts/touch-audit-report.json

--- a/docs/superpowers/plans/2026-06-14-svg-icons-entry-relayout-touch.md
+++ b/docs/superpowers/plans/2026-06-14-svg-icons-entry-relayout-touch.md
@@ -1,0 +1,805 @@
+# SVG Icons, Entry-Row Relayout & Touch-Target Audit — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace all remaining emoji-as-icon usage with the inline SVG icon set, relayout the entry-list row to echo the reading pane (inline favicon + right-aligned status cluster), swap the reading-pane back arrow for a bordered chevron, and close every measured sub-44px touch-target gap plus the desktop "Mark Above as Read" sizing.
+
+**Architecture:** Askama SSR templates + a macro icon set in `templates/_icons.html`; the sidebar is a JS custom element (`rdrs-sidebar.js`) that builds `innerHTML`, so its icons are inlined in JS (path-identical to the macros). All styling lives in the single `static/css/app.css`. CSS is `include_str!`'d into the binary, so a `cargo build` is required before e2e after any CSS/template edit. Tests are Playwright-BDD under `e2e/`.
+
+**Tech Stack:** Rust + Askama, vanilla ES-module JS, hand-written CSS, Playwright-BDD (`@playwright/test`, `playwright-bdd`), `better-sqlite3` for seeding.
+
+**Spec:** `docs/superpowers/specs/2026-06-14-svg-icons-entry-relayout-touch-design.md`
+
+**Environment (this box):** `source /tmp/rdrs-env.sh` before every cargo/e2e command (OpenSSL). Tests run with `RDRS_FAST_HASH=1`. After `.feature` edits run `npx bddgen`. Already on branch `feat/entry-svg-icons-relayout-touch`.
+
+---
+
+## File Structure
+
+- **`templates/_icons.html`** — add macros: `summary(filled)`, `inbox`, `list`, `rss`, `folder`, `search`, `barchart`, `user`, `cog`, `shield`, `menu`. (Existing `star`, `sparkle`, `close`, `chevron_left/right` reused.)
+- **`templates/_entry_row.html`** — relayout into head / meta / actions; summary emoji → `summary()`; add starred status glyph; inline favicon in meta.
+- **`templates/_reading_pane.html`** — back button: `←` text → `chevron_left()` + "Back".
+- **`templates/macros.html`** — flash dismiss `&times;` → `close()`.
+- **`static/js/components/rdrs-sidebar.js`** — emoji entities → inline SVG strings (icon map); hamburger ☰ → `menu` SVG; close × → `close` SVG.
+- **`static/css/app.css`** — summary-badge classes; entry-row layout; `.entry-status` cluster; reading-pane back button border; generalize `.ico`/`.is-filled`; `.sidebar-item-icon` SVG sizing + remove dark opacity hack; `.sidebar-toggle`/`.sidebar-close` SVG sizing; touch fixes; Mark-Above desktop size.
+- **`e2e/scripts/touch-audit.spec.js`, `e2e/scripts/audit.config.js`** — already written; commit as a retained regression tool.
+- **`e2e/features/responsive.feature` + `e2e/steps/responsive.steps.js`** — touch-target assertions.
+- **`e2e/features/*.feature`** — update any assertion matching old "Back to list" text / emoji.
+- **`.gitignore`** — ignore `e2e/scripts/touch-audit-report.json`.
+
+---
+
+## Task 1: Summary-status icon macro
+
+**Files:**
+- Modify: `templates/_icons.html`
+
+- [ ] **Step 1: Add the `summary(filled)` macro**
+
+Append after the existing `chevron_right` macro in `templates/_icons.html`:
+
+```
+{% macro summary(filled) %}<svg class="ico{% if filled %} is-filled{% endif %}" viewBox="0 0 24 24" aria-hidden="true">{% if filled %}<path d="M12 3L14 10L21 12L14 14L12 21L10 14L3 12L10 10Z"/>{% else %}<g transform="translate(1.2 1.2) scale(0.9)"><path d="M12 3L14 10L21 12L14 14L12 21L10 14L3 12L10 10Z"/></g>{% endif %}</svg>{% endmacro %}
+```
+
+Rationale (from spec): filled = radius-9 sparkle centred at 12,12 (matches `star()`); outline = same path scaled 0.9 so path+stroke lands on the same footprint.
+
+- [ ] **Step 2: Verify template compiles**
+
+Run: `source /tmp/rdrs-env.sh && cargo build`
+Expected: builds clean (Askama compiles templates at build time; a macro typo fails the build).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add templates/_icons.html
+git commit -S -m "feat(icons): add summary() sparkle macro for status badges"
+```
+
+---
+
+## Task 2: Swap summary emoji → SVG in the entry row
+
+**Files:**
+- Modify: `templates/_entry_row.html:17-23`
+- Modify: `static/css/app.css` (`.summary-badge*` rules ~1585-1609)
+
+- [ ] **Step 1: Replace the emoji `match` block**
+
+In `templates/_entry_row.html`, replace lines 17-23 (the `.entry-item-badges` span) with:
+
+```
+<span class="entry-item-badges">{% match r.summary_status_str() %}
+    {% when Some("completed") %}<span title="Has Summary" class="summary-badge" aria-hidden="true">{% call icons::summary(true) %}{% endcall %}</span>
+    {% when Some("pending") %}<span title="Pending" class="summary-badge-pending" aria-hidden="true">{% call icons::summary(false) %}{% endcall %}</span>
+    {% when Some("processing") %}<span title="Processing" class="summary-badge-processing" aria-hidden="true">{% call icons::summary(false) %}{% endcall %}</span>
+    {% when Some("failed") %}<span title="Failed" class="summary-badge-failed" aria-hidden="true">{% call icons::summary(true) %}{% endcall %}</span>
+    {% when _ %}
+{% endmatch %}</span>
+```
+
+(`{%- import "_icons.html" as icons -%}` is already at the top of the file.)
+
+- [ ] **Step 2: Update `.summary-badge*` CSS**
+
+In `static/css/app.css`, replace the `.summary-badge*` block (~1585-1609) with:
+
+```css
+/* Summary-status badges — one sparkle glyph, colour + fill carry meaning.
+   Icon sizes via 1.15em of the status-cluster font (set on .entry-status). */
+.summary-badge,
+.summary-badge-pending,
+.summary-badge-processing,
+.summary-badge-failed {
+    display: inline-flex;
+    align-items: center;
+}
+.summary-badge { color: var(--color-accent); }            /* completed, filled */
+.summary-badge-pending { color: var(--color-text-muted); } /* outline */
+.summary-badge-processing {
+    color: var(--color-accent);                            /* outline, pulsing */
+    animation: summary-pulse 1s ease-in-out infinite;
+}
+.summary-badge-failed { color: var(--color-error); }       /* failed, filled */
+
+@keyframes summary-pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.3; }
+}
+```
+
+(If a `summary-pulse`/blink keyframe already exists, keep one definition — remove the old emoji-era one.)
+
+- [ ] **Step 3: Build**
+
+Run: `source /tmp/rdrs-env.sh && cargo build`
+Expected: clean build.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add templates/_entry_row.html static/css/app.css
+git commit -S -m "feat(entries): summary status emoji -> sparkle SVG badge"
+```
+
+(Icon sizing within the status cluster is set in Task 3 alongside the relayout.)
+
+---
+
+## Task 3: Entry-row relayout (inline favicon + status cluster)
+
+**Files:**
+- Modify: `templates/_entry_row.html` (whole body)
+- Modify: `static/css/app.css` (`.entry-item` grid block ~1055-1180; mobile ~1920-1958)
+- Test: `e2e/features/responsive.feature` (+ steps) for entry-title ≥44px
+
+- [ ] **Step 1: Add a failing e2e assertion for the entry-title tap height**
+
+In `e2e/features/responsive.feature`, under the existing mobile scenario that seeds entries (the one asserting `.filter-bar select` ≥44px), add a step:
+
+```gherkin
+    Then the "[data-testid=entry-title-link]" control is at least 44px tall
+```
+
+If a generic "control is at least {int}px tall" step does not already exist, add to `e2e/steps/responsive.steps.js`:
+
+```js
+Then(
+  'the {string} control is at least {int}px tall',
+  async ({ page }, selector, min) => {
+    const box = await page.locator(selector).first().boundingBox();
+    expect(box.height).toBeGreaterThanOrEqual(min);
+  }
+);
+```
+
+- [ ] **Step 2: Regenerate BDD + run, verify it fails**
+
+Run: `cd e2e && npx bddgen && source /tmp/rdrs-env.sh && RDRS_FAST_HASH=1 npx playwright test responsive -g "44px tall" --project=chromium`
+Expected: FAIL (entry title currently ~21px tall).
+
+- [ ] **Step 3: Rewrite `_entry_row.html` body**
+
+Replace the body of `templates/_entry_row.html` (keep the leading `{%- import ... -%}` and the doc comment) with:
+
+```
+<div id="entry-row-{{ r.id }}" class="entry-item{% if r.is_read %} entry-read{% endif %}" data-entry-row data-entry-id="{{ r.id }}" data-testid="entry-item">
+    <div class="entry-head">
+        <a href="/entries/{{ r.id }}/fragment" data-swap="#reading-pane" class="entry-item-title {% if r.is_read %}entry-title-normal{% else %}entry-title-bold{% endif %}" data-testid="entry-title-link">{{ r.title }}</a>
+        <span class="entry-status">
+            {% if r.is_starred %}<span class="entry-status-star" title="Starred" aria-hidden="true">{% call icons::star(true) %}{% endcall %}</span>{% endif %}
+            {% match r.summary_status_str() %}
+            {% when Some("completed") %}<span title="Has Summary" class="summary-badge" aria-hidden="true">{% call icons::summary(true) %}{% endcall %}</span>
+            {% when Some("pending") %}<span title="Pending" class="summary-badge-pending" aria-hidden="true">{% call icons::summary(false) %}{% endcall %}</span>
+            {% when Some("processing") %}<span title="Processing" class="summary-badge-processing" aria-hidden="true">{% call icons::summary(false) %}{% endcall %}</span>
+            {% when Some("failed") %}<span title="Failed" class="summary-badge-failed" aria-hidden="true">{% call icons::summary(true) %}{% endcall %}</span>
+            {% when _ %}
+            {% endmatch %}
+            <time class="entry-time" datetime="{{ r.published_at_iso }}">{{ r.published_relative }}</time>
+        </span>
+    </div>
+
+    <div class="muted entry-item-meta">
+        {% if r.feed_has_icon %}
+        <img class="entry-favicon" src="/api/feeds/{{ r.feed_id }}/icon" alt="" loading="lazy" width="24" height="24">
+        {% else %}
+        <span class="entry-favicon entry-favicon-chip fav-c{{ r.feed_color_index() }}" aria-hidden="true">{{ r.feed_initial() }}</span>
+        {% endif %}
+        <a href="/feeds/{{ r.feed_id }}/entries">{{ r.feed_title }}</a>
+        <span class="meta-sep">·</span>
+        <a href="/categories/{{ r.category_id }}/entries">{{ r.category_name }}</a>
+    </div>
+
+    <div class="entry-item-actions">
+        <form method="post" action="/entries/{{ r.id }}/{% if r.is_read %}unread{% else %}read{% endif %}" data-swap="#entry-row-{{ r.id }}">
+            <button type="submit" class="entry-action-btn" data-testid="entry-read-action" aria-label="{% if r.is_read %}Mark unread{% else %}Mark read{% endif %}"><span class="action-icon" aria-hidden="true">{% if r.is_read %}{% call icons::unread() %}{% endcall %}{% else %}{% call icons::check() %}{% endcall %}{% endif %}</span><span class="action-label">{% if r.is_read %}unread{% else %}read{% endif %}</span></button>
+        </form>
+        <form method="post" action="/entries/{{ r.id }}/{% if r.is_starred %}unstar{% else %}star{% endif %}" data-swap="#entry-row-{{ r.id }}">
+            <button type="submit" class="entry-action-btn" data-testid="entry-star-action" aria-label="{% if r.is_starred %}Unstar{% else %}Star{% endif %}"><span class="action-icon" aria-hidden="true">{% if r.is_starred %}{% call icons::star(true) %}{% endcall %}{% else %}{% call icons::star(false) %}{% endcall %}{% endif %}</span><span class="action-label">{% if r.is_starred %}starred{% else %}star{% endif %}</span></button>
+        </form>
+        {% if let Some(link) = r.link.as_ref() %}<a href="{{ link }}" target="_blank" rel="noopener noreferrer" data-testid="entry-original-link" aria-label="Open original"><span class="action-icon" aria-hidden="true">{% call icons::external() %}{% endcall %}</span><span class="action-label">original</span></a>{% endif %}
+    </div>
+</div>
+```
+
+- [ ] **Step 4: Replace the `.entry-item` layout CSS**
+
+In `static/css/app.css`, replace the `.entry-item` grid declaration and the favicon grid-area rules with block flow + the new cluster. Set `.entry-item`:
+
+```css
+.entry-item {
+    padding: var(--space-4) var(--space-5);
+    border-bottom: 1px solid var(--color-border-light);
+    cursor: pointer;
+    transition: background 0.1s;
+}
+```
+
+Remove the `grid-template-columns`/`grid-template-areas`/`column-gap` lines and the `grid-area: fav|head|meta|foot` assignments on `.entry-favicon`, `.entry-head`, `.entry-item-meta`, `.entry-item-actions`. Then add/replace:
+
+```css
+/* Head row: title + right-pinned status cluster */
+.entry-head {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--space-2);
+}
+.entry-item-title {
+    flex: 1;
+    min-width: 0;
+    font-family: var(--font-ui);
+    font-size: var(--font-sm);          /* 14px desktop */
+    font-weight: 600;
+    line-height: 1.32;
+    color: var(--color-text);
+    overflow-wrap: break-word;
+    word-break: break-word;
+}
+.entry-item-title:hover { color: var(--color-accent); }
+.entry-title-bold { font-weight: 600; }
+.entry-title-normal { font-weight: 400; }
+
+.entry-status {
+    flex: none;
+    align-self: flex-start;
+    height: 1.32em;                     /* == title first line */
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    font-size: var(--font-sm);          /* sizes the 1.15em icons (16px) */
+}
+.entry-status .ico { width: 1.15em; height: 1.15em; }
+.entry-status-star { color: var(--color-accent); display: inline-flex; }
+.entry-time {
+    flex: none;
+    font-family: var(--font-ui);
+    font-size: var(--font-xs);
+    color: var(--color-text-muted);
+    white-space: nowrap;
+}
+
+/* Meta row: inline favicon (reading-pane style) + feed · category */
+.entry-item-meta {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    margin-top: var(--space-1);
+    font-family: var(--font-ui);
+    font-size: var(--font-sm);
+    line-height: 1.5;
+    color: var(--color-text-secondary);
+}
+.entry-item-meta a { color: var(--color-text-secondary); }
+.entry-item-meta a:hover { color: var(--color-accent); }
+.entry-item-meta .meta-sep { color: var(--color-text-muted); }
+
+/* Favicon now inline in the meta row (was a grid column) */
+.entry-favicon { width: 24px; height: 24px; margin-top: 0; border-radius: var(--radius-control); flex: none; object-fit: cover; }
+
+.entry-item-actions {
+    display: flex;
+    gap: var(--space-5);
+    margin-top: var(--space-2);
+    font-family: var(--font-ui);
+    font-size: var(--font-sm);          /* 14px -> action icons 1.15em = 16px, matches reading pane */
+    opacity: 0.72;
+    transition: opacity 0.1s;
+}
+```
+
+Keep the existing `.entry-item:hover`, `.entry-item.selected`, `.entry-item.entry-read`, `.entry-favicon-chip`, `.fav-c*`, `.entry-action-btn`, and hover-opacity rules. (`.entry-item-badges` rule, if any, can be dropped — replaced by `.entry-status`.)
+
+- [ ] **Step 5: Mobile relayout adjustments**
+
+In the `@media (max-width: 1024px)` block, within the entry-item rules (~1920-1958): set the title to 16px and the status cluster to size mobile icons at 18px, and pad the title to a 44px tap target (spec §5 option A):
+
+```css
+    .entry-item-title {
+        font-size: var(--font-base);     /* 16px */
+        display: flex;
+        align-items: center;
+        min-height: var(--touch-min);    /* 44px primary tap (touch fix) */
+    }
+    .entry-status { font-size: var(--font-base); }   /* icons 1.15em = 18px */
+```
+
+Keep the existing mobile `.entry-item-actions` full-width equal-thirds rules and `.action-label { display:none }`. The mobile `.entry-item-actions` font-size stays `--font-xl` (20px → 23px icons, matches reading-pane bottom bar); verify that rule is present, add `font-size: var(--font-xl);` if not.
+
+- [ ] **Step 6: Build + run the title-height test**
+
+Run: `source /tmp/rdrs-env.sh && cargo build && cd e2e && RDRS_FAST_HASH=1 npx playwright test responsive -g "44px tall" --project=chromium`
+Expected: PASS.
+
+- [ ] **Step 7: Run triage + entries e2e (no regressions from relayout)**
+
+Run: `cd e2e && source /tmp/rdrs-env.sh && RDRS_FAST_HASH=1 npx playwright test triage entries --project=chromium`
+Expected: PASS (data-testids and POST targets unchanged). Fix any assertion that referenced the old favicon-as-grid-column or `.entry-item-badges`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add templates/_entry_row.html static/css/app.css e2e/features/responsive.feature e2e/steps/responsive.steps.js
+git commit -S -m "feat(entries): relayout row with inline favicon + right-aligned status cluster"
+```
+
+---
+
+## Task 4: Reading-pane back button → bordered chevron
+
+**Files:**
+- Modify: `templates/_reading_pane.html:15`
+- Modify: `static/css/app.css` (`.reading-pane-back-link` ~478-491; mobile ~1851)
+- Test: `e2e/features/reading-pane*.feature` (text assertion)
+
+- [ ] **Step 1: Update any e2e assertion of the old label**
+
+Run: `rg -n "Back to list" e2e`
+For each hit asserting the visible text, change the expected text to `Back`. (The `data-testid="reading-pane-back"` is unchanged, so locator-based steps need no change.)
+
+- [ ] **Step 2: Replace the back-button markup**
+
+`templates/_reading_pane.html:15` becomes:
+
+```
+        <button type="button" class="reading-pane-back-link" data-pane-back data-testid="reading-pane-back"><span class="action-icon" aria-hidden="true">{% call icons::chevron_left() %}{% endcall %}</span><span>Back</span></button>
+```
+
+- [ ] **Step 3: Add the bordered style**
+
+Replace the `.reading-pane-back-link` rule (~478-491) with:
+
+```css
+.reading-pane-back-link {
+    display: none;                       /* shown in the ≤1024px block */
+    margin-right: auto;
+    align-items: center;
+    gap: var(--space-2);
+    min-height: var(--touch-min);
+    padding: 0 var(--space-3);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: none;
+    font: inherit;
+    color: var(--color-accent);
+    cursor: pointer;
+}
+.reading-pane-back-link .action-icon .ico { width: 18px; height: 18px; }
+.reading-pane-back-link:hover {
+    color: var(--color-accent-hover);
+    border-color: var(--color-accent);
+}
+```
+
+In the `@media (max-width: 1024px)` block, where `.reading-pane-back-link` is revealed (~1851), change `display: inline-flex;` (it currently sets display to show it). Ensure it reads `display: inline-flex;` so the flex gap/centring applies.
+
+- [ ] **Step 4: Build + test**
+
+Run: `source /tmp/rdrs-env.sh && cargo build && cd e2e && npx bddgen && RDRS_FAST_HASH=1 npx playwright test reading-pane --project=chromium`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add templates/_reading_pane.html static/css/app.css e2e/features
+git commit -S -m "feat(reading-pane): back button uses bordered chevron + 'Back'"
+```
+
+---
+
+## Task 5: Flash dismiss → close() SVG
+
+**Files:**
+- Modify: `templates/macros.html:9`
+
+- [ ] **Step 1: Replace the `&times;`**
+
+In `templates/macros.html` line 9, replace the dismiss button content `&times;` with the icon call (keep the `aria-label` and `onclick`):
+
+```
+<button type="button" class="banner-dismiss" aria-label="Dismiss notification" data-testid="flash-close" onclick="this.closest('.banner').remove();">{% call icons::close() %}{% endcall %}</button>
+```
+
+Ensure `macros.html` imports the icon macros at the top: if not present, add `{%- import "_icons.html" as icons -%}` as the first line.
+
+- [ ] **Step 2: Size the icon**
+
+In `static/css/app.css`, add (near `.banner-dismiss`):
+
+```css
+.banner-dismiss .ico { width: 18px; height: 18px; }
+```
+
+- [ ] **Step 3: Build + test**
+
+Run: `source /tmp/rdrs-env.sh && cargo build && cd e2e && RDRS_FAST_HASH=1 npx playwright test -g "flash" --project=chromium`
+Expected: PASS (dismiss still works via `data-testid="flash-close"`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add templates/macros.html static/css/app.css
+git commit -S -m "feat(flash): dismiss button uses close() SVG"
+```
+
+---
+
+## Task 6: Generalize `.ico` base styling
+
+**Files:**
+- Modify: `static/css/app.css` (~612-629)
+
+- [ ] **Step 1: Promote `.ico`/`.is-filled` to base rules**
+
+Replace the scoped block:
+
+```css
+.action-icon .ico,
+.reading-pane-nav-btn .ico {
+    width: 1.15em;
+    height: 1.15em;
+    display: block;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+}
+.action-icon .ico.is-filled {
+    fill: var(--color-accent);
+    stroke: none;
+}
+```
+
+with a base + sizing split (so `.ico` works in the sidebar too):
+
+```css
+/* Base inline-icon styling (stroke set; size per context). */
+.ico {
+    display: block;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+}
+.ico.is-filled { fill: currentColor; stroke: none; }
+.action-icon .ico,
+.reading-pane-nav-btn .ico { width: 1.15em; height: 1.15em; }
+.action-icon .ico.is-filled { fill: var(--color-accent); }
+```
+
+(`.is-filled` now fills with `currentColor` by default; the reading-pane action star keeps its explicit accent fill. The entry-status star fills with accent because `.entry-status-star { color: var(--color-accent) }`.)
+
+- [ ] **Step 2: Build + smoke-test existing icons**
+
+Run: `source /tmp/rdrs-env.sh && cargo build && cd e2e && RDRS_FAST_HASH=1 npx playwright test reading-pane triage --project=chromium`
+Expected: PASS (existing action/star icons unchanged visually).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add static/css/app.css
+git commit -S -m "refactor(css): promote .ico/.is-filled to reusable base rules"
+```
+
+---
+
+## Task 7: Sidebar icons (JS inline SVGs)
+
+**Files:**
+- Modify: `static/js/components/rdrs-sidebar.js` (icon spans ~167-228, toggle 172, close 178)
+- Modify: `static/css/app.css` (`.sidebar-item-icon` ~290-306; `.sidebar-toggle`/`.sidebar-close`)
+- Test: `e2e/features/responsive.feature` or a sidebar feature (icons are `<svg>`, no emoji)
+
+- [ ] **Step 1: Add an icon map near the top of `rdrs-sidebar.js`**
+
+After the imports/constants, add a frozen map of SVG strings (path-identical to `_icons.html`):
+
+```js
+const ICON = {
+  inbox: '<svg class="ico" viewBox="0 0 24 24" aria-hidden="true"><path d="M22 12h-6l-2 3h-4l-2-3H2"/><path d="M5.4 5.1 2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.4-6.9A2 2 0 0 0 16.8 4H7.2a2 2 0 0 0-1.8 1.1z"/></svg>',
+  star: '<svg class="ico is-filled" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3.5l2.7 5.5 6 .9-4.3 4.2 1 6L12 17.3 6.6 20l1-6L3.3 9.9l6-.9z"/></svg>',
+  sparkle: '<svg class="ico" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l1.7 4.6L18 9.3l-4.3 1.7L12 16l-1.7-4.9L6 9.3l4.3-1.7z"/><path d="M18 15l.7 1.8L20.5 17.5l-1.8.7L18 20l-.7-1.8L15.5 17.5l1.8-.7z"/></svg>',
+  list: '<svg class="ico" viewBox="0 0 24 24" aria-hidden="true"><path d="M8 6h13M8 12h13M8 18h13"/><path d="M3.5 6h.01M3.5 12h.01M3.5 18h.01"/></svg>',
+  rss: '<svg class="ico" viewBox="0 0 24 24" aria-hidden="true"><path d="M4 11a9 9 0 0 1 9 9"/><path d="M4 4a16 16 0 0 1 16 16"/><circle cx="5" cy="19" r="1.6" fill="currentColor" stroke="none"/></svg>',
+  folder: '<svg class="ico" viewBox="0 0 24 24" aria-hidden="true"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></svg>',
+  search: '<svg class="ico" viewBox="0 0 24 24" aria-hidden="true"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg>',
+  barchart: '<svg class="ico" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 20v-6M12 20V4M18 20v-9"/><path d="M4 20h16"/></svg>',
+  user: '<svg class="ico" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="8" r="4"/><path d="M4.5 21a7.5 7.5 0 0 1 15 0"/></svg>',
+  cog: '<svg class="ico" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>',
+  shield: '<svg class="ico" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l8 3v5c0 5-3.5 8-8 9.5C7.5 19 4 16 4 11V6z"/></svg>',
+  menu: '<svg class="ico" viewBox="0 0 24 24" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18"/></svg>',
+  close: '<svg class="ico" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 6l12 12M18 6L6 18"/></svg>',
+};
+```
+
+- [ ] **Step 2: Replace each emoji span with `ICON.<name>`**
+
+In the `innerHTML` template, swap the entity contents of each `<span class="sidebar-item-icon">…</span>`:
+
+| Item | Old | New |
+| --- | --- | --- |
+| Admin (167) | `&#x1F6E1;&#xFE0F;` | `${ICON.shield}` |
+| Unread (183) | `&#x1F4EC;&#xFE0F;` | `${ICON.inbox}` |
+| Starred (188) | `&#x2B50;&#xFE0F;` | `${ICON.star}` |
+| Summarized (192) | `&#x2728;&#xFE0F;` | `${ICON.sparkle}` |
+| All Entries (197) | `&#x1F4F0;&#xFE0F;` | `${ICON.list}` |
+| Feeds (204) | `&#x1F4E1;&#xFE0F;` | `${ICON.rss}` |
+| Categories (208) | `&#x1F5C2;&#xFE0F;` | `${ICON.folder}` |
+| Search (214) | `&#x1F50D;&#xFE0F;` | `${ICON.search}` |
+| Statistics (218) | `&#x1F4CA;&#xFE0F;` | `${ICON.barchart}` |
+| Settings (222) | `&#x1F464;&#xFE0F;` | `${ICON.user}` |
+| App (226) | `&#x2699;&#xFE0F;` | `${ICON.cog}` |
+
+And the chrome:
+- Toggle (172): `>&#9776;<` → `>${ICON.menu}<`
+- Close (178): `>&times;<` → `>${ICON.close}<`
+
+- [ ] **Step 3: Update `.sidebar-item-icon` + toggle/close CSS, remove dark hack**
+
+In `static/css/app.css`, replace `.sidebar-item-icon` and the two dark-mode opacity rules (~290-306) with:
+
+```css
+.sidebar-item-icon {
+    width: var(--icon-md);
+    height: var(--icon-md);
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+.sidebar-item-icon .ico { width: var(--icon-md); height: var(--icon-md); }
+```
+
+(Delete the `[data-theme="dark"] .sidebar-item-icon { opacity: 0.85 }` and the `prefers-color-scheme: dark` variant — the emoji-rendering hack.) For the chrome buttons, add:
+
+```css
+.sidebar-toggle .ico { width: 22px; height: 22px; }
+.sidebar-close .ico { width: 20px; height: 20px; }
+```
+
+and remove any `font-size` on `.sidebar-toggle`/`.sidebar-close` that only sized the old glyph (keep their padding/border and the 44px mobile square sizing).
+
+- [ ] **Step 4: Add a failing-then-passing e2e assertion (icons are SVG)**
+
+In a sidebar-covering feature (e.g. add to `responsive.feature` a desktop scenario, or `auth.feature` after sign-in), add a step asserting the nav icon is an SVG:
+
+```gherkin
+    Then the "[data-testid=nav-feeds] .sidebar-item-icon svg" element is visible
+```
+
+Reuse or add a generic visibility step in steps if needed:
+
+```js
+Then('the {string} element is visible', async ({ page }, sel) => {
+  await expect(page.locator(sel).first()).toBeVisible();
+});
+```
+
+- [ ] **Step 5: Build + test**
+
+Run: `source /tmp/rdrs-env.sh && cargo build && cd e2e && npx bddgen && RDRS_FAST_HASH=1 npx playwright test responsive auth --project=chromium`
+Expected: PASS. Manually confirm (or via the audit) no emoji remain in the sidebar.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add static/js/components/rdrs-sidebar.js static/css/app.css e2e/features e2e/steps
+git commit -S -m "feat(sidebar): replace emoji nav icons + hamburger/close with SVGs"
+```
+
+---
+
+## Task 8: Touch-target fixes (CSS)
+
+**Files:**
+- Modify: `static/css/app.css` (mobile `@media (max-width: 1024px)` touch block ~1997-2072)
+- Test: `e2e/features/responsive.feature` (+ steps)
+
+- [ ] **Step 1: Add failing assertions for each fixed control**
+
+In `e2e/features/responsive.feature`, in the mobile scenario(s) that visit feeds/feed-edit/import, add (using the height/width steps; add a width step if missing):
+
+```gherkin
+    Then the "[data-testid=mark-above-btn]" control is at least 44px tall
+    # on feed-edit page:
+    Then the "input[type=checkbox]" control is at least 44px wide
+    Then the "input[type=file]" control is at least 44px tall
+    Then the "summary" control is at least 44px tall
+```
+
+Add to `e2e/steps/responsive.steps.js` if absent:
+
+```js
+Then(
+  'the {string} control is at least {int}px wide',
+  async ({ page }, selector, min) => {
+    const box = await page.locator(selector).first().boundingBox();
+    expect(box.width).toBeGreaterThanOrEqual(min);
+  }
+);
+```
+
+- [ ] **Step 2: Run, verify failures**
+
+Run: `cd e2e && npx bddgen && source /tmp/rdrs-env.sh && RDRS_FAST_HASH=1 npx playwright test responsive --project=chromium`
+Expected: FAIL on the new assertions.
+
+- [ ] **Step 3: Add the touch rules**
+
+In the mobile touch-baseline block (~1997-2072), append:
+
+```css
+    /* Sidebar chrome links */
+    .sidebar-logo,
+    .sidebar-footer a {
+        display: inline-flex;
+        align-items: center;
+        min-height: var(--touch-min);
+    }
+
+    /* Horizontal pills: tabs, feed filter, stats period, feed-row edit link */
+    .tab-bar a,
+    .feed-filter-link,
+    .stats-period-btn,
+    .feed-actions a {
+        min-width: var(--touch-min);
+        justify-content: center;
+    }
+
+    /* Checkbox + its wrapping label become a 44px tappable row */
+    label:has(> input[type="checkbox"]),
+    label:has(> input[type="radio"]) {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        min-height: var(--touch-min);
+    }
+    input[type="checkbox"],
+    input[type="radio"] {
+        width: 1.25rem;
+        height: 1.25rem;
+        accent-color: var(--color-accent);
+    }
+
+    /* File input + disclosure summary */
+    input[type="file"] { min-height: var(--touch-min); }
+    summary {
+        min-height: var(--touch-min);
+        padding: var(--space-3) 0;   /* keeps native ▸/▾ marker (no display:flex) */
+        box-sizing: border-box;
+    }
+```
+
+Note the feed-row "edit" link selector: confirm the actual class with `rg -n "edit" templates/feeds.html` and adjust `.feed-actions a` to match (e.g. it may be `.feed-row a` or a `.btn-sm`). Use the real selector.
+
+- [ ] **Step 4: Build + run**
+
+Run: `source /tmp/rdrs-env.sh && cargo build && cd e2e && RDRS_FAST_HASH=1 npx playwright test responsive --project=chromium`
+Expected: PASS.
+
+- [ ] **Step 5: Re-run the audit to confirm zero non-exempt gaps**
+
+Run: `cd e2e && source /tmp/rdrs-env.sh && npx playwright test --config=scripts/audit.config.js`
+Expected: the console summary reports only inline-text exemptions remaining.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add static/css/app.css e2e/features e2e/steps
+git commit -S -m "fix(a11y): 44px touch targets for sidebar chrome, pills, checkbox, file, summary"
+```
+
+---
+
+## Task 9: "Mark Above as Read" desktop sizing
+
+**Files:**
+- Modify: `static/css/app.css`
+- Test: `e2e/features/responsive.feature` (desktop viewport assertion)
+
+- [ ] **Step 1: Add a failing desktop assertion**
+
+In `responsive.feature`, add a desktop-viewport scenario (or reuse one at default size) visiting a feed page with entries:
+
+```gherkin
+    Then the "[data-testid=mark-above-btn]" control is at least 34px tall
+```
+
+(at the default/desktop viewport — do not set 375px for this one).
+
+- [ ] **Step 2: Run, verify it fails**
+
+Run: `cd e2e && npx bddgen && source /tmp/rdrs-env.sh && RDRS_FAST_HASH=1 npx playwright test responsive -g "Mark Above" --project=chromium`
+Expected: FAIL (~24px tall).
+
+- [ ] **Step 3: Add the desktop size rule**
+
+In `static/css/app.css`, near `.mark-above-form`, add a scoped override (the button keeps `.btn-sm` markup but is sized comfortably on desktop):
+
+```css
+/* "Mark Above as Read" reads cramped at btn-sm on desktop; give it a
+   comfortable size. Mobile still gets 44px from the touch baseline. */
+#mark-above-read {
+    font-size: var(--font-sm);
+    padding: var(--space-2) var(--space-4);
+}
+```
+
+- [ ] **Step 4: Build + run**
+
+Run: `source /tmp/rdrs-env.sh && cargo build && cd e2e && RDRS_FAST_HASH=1 npx playwright test responsive -g "Mark Above" --project=chromium`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add static/css/app.css e2e/features
+git commit -S -m "fix(ui): enlarge 'Mark Above as Read' on desktop"
+```
+
+---
+
+## Task 10: Retain the audit tool + ignore its report
+
+**Files:**
+- Create: `e2e/scripts/touch-audit.spec.js` (already on disk)
+- Create: `e2e/scripts/audit.config.js` (already on disk)
+- Modify: `.gitignore`
+
+- [ ] **Step 1: Ignore the generated report**
+
+Add to the repo `.gitignore`:
+
+```
+e2e/scripts/touch-audit-report.json
+```
+
+- [ ] **Step 2: Commit the audit tool**
+
+```bash
+git add e2e/scripts/touch-audit.spec.js e2e/scripts/audit.config.js .gitignore
+git commit -S -m "test(e2e): retain 375px touch-target audit as a regression tool"
+```
+
+---
+
+## Task 11: Full verification sweep
+
+- [ ] **Step 1: fmt + clippy + build**
+
+Run: `source /tmp/rdrs-env.sh && cargo fmt && cargo clippy --all-targets -- -D warnings && cargo build`
+Expected: clean.
+
+- [ ] **Step 2: Rust unit/integration tests**
+
+Run: `source /tmp/rdrs-env.sh && RDRS_FAST_HASH=1 cargo nextest run`
+Expected: PASS.
+
+- [ ] **Step 3: Full e2e suite**
+
+Run: `cd e2e && npx bddgen && source /tmp/rdrs-env.sh && RDRS_FAST_HASH=1 npx playwright test --project=chromium`
+Expected: all green; 0 `@skip`.
+
+- [ ] **Step 4: Final emoji sweep (entities + literals)**
+
+Run:
+```bash
+rg -nP '&#x?1F[0-9A-Fa-f]{3};|&#x?2[0-9A-Fa-f]{3};|[\x{1F000}-\x{1FAFF}\x{2600}-\x{27BF}\x{2B00}-\x{2BFF}]' templates static/js | rg -v 'macros.html|_icons.html'
+```
+Expected: no UI emoji remain (the onboarding `→` in `_entries_layout.html` is the only allowed glyph; `←`/`☰`/emoji gone).
+
+- [ ] **Step 5: Push the branch**
+
+```bash
+git push -u origin feat/entry-svg-icons-relayout-touch
+```
+
+---
+
+## Self-Review notes
+
+- **Spec coverage:** §1 summary icons → Tasks 1-2; §2 entry relayout → Task 3; §3 back button → Task 4; §4 sidebar (nav + chrome + flash) → Tasks 5, 7; §5 touch audit + all 11 fixes → Tasks 8, 10; entry-title (option A) → Task 3 step 5; Mark Above desktop → Task 9; `.ico` generalisation (needed by sidebar) → Task 6.
+- **Ordering:** macro (1) → entry badge (2) → relayout (3) depends on `summary()` + `.entry-status`; `.ico` generalisation (6) precedes sidebar (7) which relies on the base `.ico` rule; touch fixes (8) after layout so measurements are final.
+- **Naming consistency:** `entry-status` (cluster), `entry-status-star`, `summary-badge*`, `ICON.<name>` map, `summary(filled)` macro — used identically across tasks.
+- **No silent caps:** the audit (Task 8 step 5) re-runs to confirm only inline-text exemptions remain.

--- a/docs/superpowers/specs/2026-06-14-svg-icons-entry-relayout-touch-design.md
+++ b/docs/superpowers/specs/2026-06-14-svg-icons-entry-relayout-touch-design.md
@@ -1,0 +1,224 @@
+# SVG icon migration, entry-row relayout & touch-target audit — Design
+
+Date: 2026-06-14
+Status: Approved (visuals confirmed via brainstorming companion)
+
+## Context
+
+Three user-facing goals, shipped as one PR:
+
+1. Replace the **remaining emoji-as-icon** usage with inline SVGs from the existing
+   stroke-based icon set (`templates/_icons.html`).
+2. Re-lay out the **entry list row** so it echoes the reading-pane editorial
+   chrome (inline favicon leading the meta line, right-aligned status cluster).
+3. Audit **all interactive components** for adequate touch targets, completing
+   the 44px work started for buttons in `54b0008`.
+
+Builds on `2026-06-13-entry-item-redesign-design.md`,
+`2026-06-13-mobile-touch-targets-design.md`, and
+`2026-06-14-reading-pane-redesign-design.md`.
+
+### Corrected emoji inventory
+
+An initial scan undercounted: the sidebar is rendered by a JS custom element
+(`<rdrs-sidebar>`), not Askama, and its emoji are **HTML numeric entities**
+(`&#x1F4E1;`), so a codepoint regex over templates missed them. The complete
+inventory:
+
+| Surface | Location | Glyphs |
+| --- | --- | --- |
+| Summary-status badges | `templates/_entry_row.html:18–21` | ✅ ⏳ 🔄 ❌ |
+| Sidebar nav (11) | `static/js/components/rdrs-sidebar.js` | 📬 ⭐ ✨ 📰 📡 🗂️ 🔍 📊 👤 ⚙️ 🛡️ |
+| Sidebar chrome | `rdrs-sidebar.js` | ☰ (hamburger), × (close) |
+| Flash dismiss | `templates/macros.html:9` | × |
+
+Out of scope (kept as typography): the onboarding CTA arrow
+`Add your first feed →` (`_entries_layout.html:61`); mid-dots, em-dashes, and
+other punctuation.
+
+## Icon design language
+
+All icons follow the existing convention: inline `<svg class="ico"
+viewBox="0 0 24 24" aria-hidden="true">`, `fill:none; stroke:currentColor;
+stroke-width:2; round caps/joins`. Filled variants use `.is-filled`
+(`fill:currentColor; stroke:none`). Icons scale to their container at
+`1.15em` (the rule reading-pane actions already use), so every inline icon is
+sized consistently against its surrounding text.
+
+## 1. Summary-status icon set
+
+One **4-point sparkle** glyph carries all four states; colour + fill + motion
+disambiguate. Ties the badge to the AI-summary identity (same family as the
+Summarize action's `sparkle()`).
+
+New macro in `_icons.html`:
+
+```
+{% macro summary(filled) %}
+  <svg class="ico{% if filled %} is-filled{% endif %}" viewBox="0 0 24 24" aria-hidden="true">
+    {% if filled %}<path d="M12 3L14 10L21 12L14 14L12 21L10 14L3 12L10 10Z"/>
+    {% else %}<g transform="translate(1.2 1.2) scale(0.9)"><path d="M12 3L14 10L21 12L14 14L12 21L10 14L3 12L10 10Z"/></g>{% endif %}
+  </svg>
+{% endmacro %}
+```
+
+The outline variant is `scale(0.9)` on the same path (keeping `stroke-width:2`)
+so that path + stroke lands on the **same footprint as the filled glyph and the
+`star()` icon** — without it, a stroked shape reads ~1px larger than a filled
+one. The filled path is centred at 12,12 with radius 9 to match `star()`.
+
+State → treatment mapping in `_entry_row.html` (replaces the emoji `match`):
+
+| State | Macro | Colour token |
+| --- | --- | --- |
+| completed | `summary(true)` | `--color-accent` (gold) |
+| pending | `summary(false)` | `--color-text-muted` |
+| processing | `summary(false)` + pulse | `--color-accent` |
+| failed | `summary(true)` | `--color-error` (red) |
+
+CSS: `.summary-badge*` classes set the colour (applied to the SVG via
+`currentColor`); the existing processing **pulse** (opacity animation) is kept;
+emoji-specific styling is removed. The badge `.ico` is sized `1.15em` of the
+title (→ 16px desktop / 18px mobile).
+
+## 2. Entry-row relayout
+
+Drop the grid left-favicon column. Three stacked rows:
+
+```
+[title ........................] [★ ✦ · published-at]   ← head
+[favicon] feed · category                               ← meta
+[ read ] [ star ] [ original ]                          ← actions
+```
+
+`templates/_entry_row.html`:
+
+- **head** — `.entry-head` is `display:flex; align-items:flex-start`. Title is
+  `flex:1; min-width:0; overflow-wrap:break-word`. A right-pinned
+  `.entry-status` cluster (`flex:none; align-self:flex-start; height:1.32em;
+  align-items:center`) holds, in order: a **filled star** status glyph rendered
+  only when `is_starred`, the **summary** badge, then `.entry-time`. Fixed
+  height = title's first line, so icons centre on the first line and the cluster
+  stays put as the title wraps.
+- **meta** — `.entry-item-meta` becomes `display:flex; align-items:center;
+  gap:8px`, leading with the 24px favicon (img or colour chip, reading-pane
+  style, `margin-top:0`) followed by feed · category links.
+- **actions** — unchanged markup (read/star/original forms keep their
+  `data-testid`s and POST targets, so triage e2e is unaffected).
+
+**Note (intentional redundancy):** the star appears both as a read-only status
+glyph in the head (when starred) and as the toggle action in the actions row —
+glance vs. act. Approved during design review.
+
+CSS (`app.css`):
+
+- Replace `.entry-item` grid (`grid-template-areas`) with simple block flow of
+  the three rows. Remove the `fav` grid area.
+- `.entry-status` cluster styles; status icons `1.15em` (16px desktop / 18px
+  mobile); star filled `--color-accent`.
+- `.entry-item-meta` flex with inline 24px favicon.
+- **Action icon sizes aligned to reading pane:** set desktop
+  `.entry-item-actions` font-size to `--font-sm` (14px) so action icons render
+  16px (`1.15em`), pixel-matching `.rp-action`. Mobile already uses `--font-xl`
+  (20px) → 23px icons, matching the reading-pane bottom bar.
+- Favicon palette (`fav-c0…5`), `feed_initial()`, `feed_color_index()` reused
+  unchanged.
+
+## 3. Reading-pane back button
+
+`templates/_reading_pane.html:15`: replace the `← Back to list` text with
+`{% call icons::chevron_left() %}` + label **"Back"**.
+
+CSS `.reading-pane-back-link` (mobile-only): add the nav-button outline — `1px
+solid var(--color-border)`, `border-radius:var(--radius-md)`, `min-height:
+var(--touch-min)`, padding, `display:inline-flex; align-items:center; gap` — so
+it matches `.reading-pane-nav-btn` sitting beside it. Chevron 18px (matches the
+prev/next icons; same glyph as the prev button).
+
+## 4. Sidebar icons
+
+Add new macros to `_icons.html` (stroke style, 24×24): `inbox`, `list`, `rss`,
+`folder`, `search`, `barchart`, `user`, `cog`, `shield`, `menu`. Reuse
+`star()`, `sparkle()`, `close()`.
+
+| Item | Icon | Item | Icon |
+| --- | --- | --- | --- |
+| Unread | inbox | Statistics | bar chart |
+| Starred | `star()` | Settings (`/user-settings`) | user (person) |
+| Summarized | `sparkle()` | App (`/settings`) | cog (toothed gear) |
+| All Entries | list | Admin | shield |
+| Feeds | RSS mark | Menu toggle | hamburger |
+| Categories | folder | Close (sidebar + flash) | `close()` |
+| Search | magnifier | | |
+
+**Rendering split:** the sidebar is a JS custom element building `innerHTML`
+strings — it cannot call Askama macros. The SVG markup is therefore inlined in
+`rdrs-sidebar.js` (a small per-item icon map), kept path-identical to the
+`_icons.html` macros. This duplication is inherent to the JS-rendered sidebar
+and is documented here. The flash dismiss (`macros.html`) is Askama and uses
+`{% call icons::close() %}`.
+
+CSS (`app.css`):
+
+- Generalise the icon stroke styling so `.ico` works outside reading-pane
+  contexts: a base `.ico { fill:none; stroke:currentColor; stroke-width:2;
+  round caps/joins }`, sized per context (`.action-icon .ico { width:1.15em }`,
+  `.sidebar-item-icon .ico { width:var(--icon-md); height:var(--icon-md) }`).
+- `.sidebar-item-icon`: switch from font glyph (`font-size:1rem; text-align:
+  center`) to an 18px SVG box; icon inherits `currentColor` (item text colour,
+  accent when `.active`).
+- **Remove the dark-mode `opacity:0.85` hack** (`app.css` ~298–305) — it existed
+  only to tame emoji rendering and is unnecessary for stroke SVGs.
+- `.sidebar-toggle` / `.sidebar-close`: size the inline SVG (~22px) in place of
+  the font glyph; keep their 44px square mobile touch sizing and `aria-label`s.
+
+## 5. Touch-target audit (all interactive components)
+
+The 44px baseline (`54b0008`) already covers `button`/`.btn`, text links,
+icon-only chrome buttons, `.sidebar-item`, text `input`s, `<select>`,
+`textarea`. This task closes the remainder via **measurement, not inspection**.
+
+**Audit:** a Playwright pass at 375px walks every interactive element
+(`button, a, select, input, textarea, label:has(input), [role=button]`, custom
+elements) across the main pages (entries, feeds, feed-edit, import, categories,
+search, settings, user-settings, statistics) and records each rendered bounding
+box, flagging anything < 44px in either axis.
+
+**Classify & fix:** each sub-44px hit is either a genuine gap (fix in the mobile
+touch-baseline block, following the established per-control-type pattern) or an
+intentional exemption that is documented (no silent passes). Known going in:
+
+- `input[type="file"]` (`feeds_import.html`) — add to the touch block.
+- `input[type="checkbox"]` (`feed_edit.html`) — make the wrapping `<label>` a
+  44px tappable row (`min-height`, flex-centre) and enlarge the box.
+- `input[type="radio"]` — none exist; nothing to do.
+- `.entry-item-meta a` inline links — intentionally ~28px (WCAG 2.5.8 AA + wrap
+  preservation); documented exemption, unchanged.
+
+The audit may surface additional sites (e.g. table-row action links,
+pagination); those are fixed under the same pattern or documented.
+
+## Testing
+
+- **Summary icons / entry row:** existing triage & entries e2e rely on
+  `data-testid`s and POST targets, all preserved. Update any assertion that
+  matched the old emoji or favicon-as-grid-column structure.
+- **Back button:** update reading-pane e2e assertions matching the old
+  "Back to list" text (now "Back" + chevron); `data-testid="reading-pane-back"`
+  unchanged.
+- **Sidebar:** nav `data-testid`s (`nav-unread`, `nav-feeds`, …) and chrome
+  `aria-label`s unchanged; existing sidebar e2e should pass. Add an assertion
+  that sidebar item icons render as `<svg>` (no emoji).
+- **Touch targets:** extend `e2e/features/responsive.feature` with per-control
+  ≥44px assertions for each newly-covered control (checkbox label, file input,
+  plus any surfaced).
+- **Build/run notes:** CSS is `include_str!`'d into the binary — `cargo build`
+  before e2e after CSS/Rust edits; `npx bddgen` after `.feature` changes; tests
+  run with `RDRS_FAST_HASH`; this box needs the OpenSSL env re-sourced before
+  cargo/e2e.
+
+## Out of scope
+
+- Onboarding CTA arrow `Add your first feed →` (kept as CTA typography).
+- Any non-icon typographic glyphs (`·`, `—`, `&middot;`, etc.).
+- Behavioural changes to summary generation, starring, or navigation.

--- a/docs/superpowers/specs/2026-06-14-svg-icons-entry-relayout-touch-design.md
+++ b/docs/superpowers/specs/2026-06-14-svg-icons-entry-relayout-touch-design.md
@@ -184,19 +184,41 @@ elements) across the main pages (entries, feeds, feed-edit, import, categories,
 search, settings, user-settings, statistics) and records each rendered bounding
 box, flagging anything < 44px in either axis.
 
-**Classify & fix:** each sub-44px hit is either a genuine gap (fix in the mobile
-touch-baseline block, following the established per-control-type pattern) or an
-intentional exemption that is documented (no silent passes). Known going in:
+The audit is implemented as a reusable spec, `e2e/scripts/touch-audit.spec.js`
+(run via `scripts/audit.config.js`), kept in the tree as a regression tool.
 
-- `input[type="file"]` (`feeds_import.html`) — add to the touch block.
-- `input[type="checkbox"]` (`feed_edit.html`) — make the wrapping `<label>` a
-  44px tappable row (`min-height`, flex-centre) and enlarge the box.
+**Audit results** — 11 distinct genuine sub-44px targets (caption `<label>`s
+that pair with a separate control via `for=`, and inline `.entry-item-meta`
+links, are excluded as non-targets/exemptions). Fixes, all `min-height`/
+`min-width: 44px` with flex-centring, no background/text-decoration changes:
+
+| Target | Measured | Fix | Breakpoint |
+| --- | --- | --- | --- |
+| Sidebar logout link | 49×19 | min-height 44px | mobile |
+| Sidebar `.sidebar-logo` ("rdrs") | 41×30 | min-height 44px | mobile |
+| **Entry title link** (primary tap) | 87×21 | **min-height 44px on `.entry-item-title`** (option A — CSS only; pads short single-line titles, multi-line already exceed it) | mobile |
+| Filter tabs (`.tab-bar a`) | 39–42×44 | min-width 44px | mobile |
+| Feeds filter (`.feed-filter-link`) | 41×44 | min-width 44px | mobile |
+| Stats period (`.stats-period-btn`) | 41×44 | min-width 44px | mobile |
+| Feed "edit" link | 39×44 | min-width 44px | mobile |
+| Checkbox box (`input[type=checkbox]`) | 13×13 | enlarge to ~20px (`width/height` + `accent-color`) | mobile |
+| Checkbox label row ("Disable HTTP/2") | 317×21 | wrapping `<label>` → 44px flex row | mobile |
+| File input (`input[type=file]`) | 253×21 | min-height 44px | mobile |
+| `<summary>` disclosure ("HTTP Settings") | 317×27 | **min-height 44px via padding** (not `display:flex`, so the native ▸/▾ marker is preserved) | mobile |
+
 - `input[type="radio"]` — none exist; nothing to do.
 - `.entry-item-meta a` inline links — intentionally ~28px (WCAG 2.5.8 AA + wrap
   preservation); documented exemption, unchanged.
 
-The audit may surface additional sites (e.g. table-row action links,
-pagination); those are fixed under the same pattern or documented.
+### Desktop: "Mark Above as Read"
+
+Separately from the mobile audit, `#mark-above-read` (`.btn-sm`,
+`_entries_layout.html`) reads too small on **desktop**: `.btn-sm` is `--font-xs`
++ `space-1/space-2` padding (~24px tall), and the 44px floor only applies in the
+`≤1024px` block, so desktop has no minimum. Fix: give this button a comfortable
+desktop size — `--font-sm` with `space-2`/`space-4` padding (~36px tall) — while
+keeping the mobile 44px from the touch baseline. Scoped to this button (not a
+global `.btn-sm` change).
 
 ## Testing
 
@@ -209,9 +231,12 @@ pagination); those are fixed under the same pattern or documented.
 - **Sidebar:** nav `data-testid`s (`nav-unread`, `nav-feeds`, …) and chrome
   `aria-label`s unchanged; existing sidebar e2e should pass. Add an assertion
   that sidebar item icons render as `<svg>` (no emoji).
-- **Touch targets:** extend `e2e/features/responsive.feature` with per-control
-  ≥44px assertions for each newly-covered control (checkbox label, file input,
-  plus any surfaced).
+- **Touch targets:** the audit spec (`e2e/scripts/touch-audit.spec.js`) is
+  retained as a regression tool; extend `e2e/features/responsive.feature` with
+  per-control ≥44px assertions for each fixed control (entry title, sidebar
+  logout/logo, filter/period pills, feed-edit link, checkbox label row, file
+  input, `<summary>`). The "Mark Above as Read" fix is **desktop** — assert its
+  rendered height at a desktop viewport (not the 44px mobile rule).
 - **Build/run notes:** CSS is `include_str!`'d into the binary — `cargo build`
   before e2e after CSS/Rust edits; `npx bddgen` after `.feature` changes; tests
   run with `RDRS_FAST_HASH`; this box needs the OpenSSL env re-sourced before

--- a/e2e/features/responsive.feature
+++ b/e2e/features/responsive.feature
@@ -180,6 +180,7 @@ Feature: Responsive layout
     And I have a feed with 5 test entries
     When I open the feeds page
     And I open the edit page for feed "Mobile Feed"
+    And I expand the "HTTP Settings" disclosure
     Then the "label:has(> input[type='checkbox'])" control is at least 44px tall
     And the "summary" control is at least 44px tall
 

--- a/e2e/features/responsive.feature
+++ b/e2e/features/responsive.feature
@@ -158,3 +158,26 @@ Feature: Responsive layout
     And the ".entry-item-meta a" control is at least 24px tall
     And the ".entry-item-actions .entry-action-btn" controls each span at least 25% of the row
     And the ".entry-action-btn" control is at least 44px tall
+
+  @mobile
+  Scenario: Sidebar chrome links meet the 44px touch minimum on mobile
+    Given I am viewing on a mobile screen
+    When I open the inbox
+    And I tap the hamburger
+    Then the ".sidebar-logo" control is at least 44px tall
+    And the ".sidebar-footer a" control is at least 44px tall
+
+  @mobile
+  Scenario: Feed edit form controls meet the 44px touch minimum on mobile
+    Given I am viewing on a mobile screen
+    And I have a feed with 5 test entries
+    When I open the feeds page
+    And I open the edit page for feed "Mobile Feed"
+    Then the "label:has(> input[type='checkbox'])" control is at least 44px tall
+    And the "summary" control is at least 44px tall
+
+  @mobile
+  Scenario: Import page file input meets the 44px touch minimum on mobile
+    Given I am viewing on a mobile screen
+    When I open the import page
+    Then the "input[type='file']" control is at least 44px tall

--- a/e2e/features/responsive.feature
+++ b/e2e/features/responsive.feature
@@ -117,6 +117,7 @@ Feature: Responsive layout
     And the ".sidebar-toggle" control is at least 44px tall
     And the ".entry-action-btn" control is at least 44px tall
     And the ".filter-bar select" control is at least 44px tall
+    And the "[data-testid=entry-title-link]" control is at least 44px tall
     When I tap the hamburger
     Then the ".sidebar-close" control is at least 44px wide
     And the ".sidebar-close" control is at least 44px tall

--- a/e2e/features/responsive.feature
+++ b/e2e/features/responsive.feature
@@ -114,6 +114,13 @@ Feature: Responsive layout
     When I open the inbox
     Then the "[data-testid=nav-feeds] .sidebar-item-icon svg" element is visible
 
+  @desktop
+  Scenario: Mark Above as Read button is comfortably sized on desktop
+    Given I am viewing on a desktop screen
+    And I have a feed with 5 test entries
+    When I open the inbox
+    Then the "[data-testid=mark-above-btn]" control is at least 34px tall
+
   @mobile
   Scenario: Inbox and drawer controls meet the 44px touch minimum on mobile
     Given I am viewing on a mobile screen

--- a/e2e/features/responsive.feature
+++ b/e2e/features/responsive.feature
@@ -108,6 +108,12 @@ Feature: Responsive layout
     When I open the inbox
     Then the entry list pane is narrower than the viewport
 
+  @desktop
+  Scenario: Sidebar nav icons are rendered as SVG
+    Given I am viewing on a desktop screen
+    When I open the inbox
+    Then the "[data-testid=nav-feeds] .sidebar-item-icon svg" element is visible
+
   @mobile
   Scenario: Inbox and drawer controls meet the 44px touch minimum on mobile
     Given I am viewing on a mobile screen

--- a/e2e/scripts/audit.config.js
+++ b/e2e/scripts/audit.config.js
@@ -1,0 +1,12 @@
+// Standalone config so the touch-audit spec runs outside the BDD testDir.
+// Run: cd e2e && npx playwright test --config=scripts/audit.config.js
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: ".",
+  testMatch: /touch-audit\.spec\.js/,
+  globalSetup: "../global-setup.js",
+  reporter: "list",
+  use: { trace: "off" },
+  projects: [{ name: "chromium", use: { browserName: "chromium" } }],
+});

--- a/e2e/scripts/touch-audit.spec.js
+++ b/e2e/scripts/touch-audit.spec.js
@@ -1,0 +1,128 @@
+// Touch-target audit @ iPhone-SE width (375px).
+// Walks every interactive element on the main pages, records rendered
+// bounding boxes, and reports anything < 44px in either axis.
+// Run: cd e2e && npx playwright test scripts/touch-audit.spec.js --project=chromium
+import { test } from "../support/fixtures.js";
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const OUT = path.resolve(__dirname, "touch-audit-report.json");
+const MIN = 44;
+
+test("touch-target audit @ 375px", async ({ page, api, seed, serverUrl, currentUser }) => {
+  test.setTimeout(180_000);
+
+  // ---- seed a realistic account ----
+  await api.register(currentUser.username, currentUser.password);
+  const userId = seed.getUserId(currentUser.username);
+  const catId = seed.createCategory(userId, "Tech");
+  const feedId = seed.createFeed(catId, "https://example.com/feed.xml", "Example Feed");
+  seed.seedTestEntries(feedId, 12);
+  seed.configureKagi(userId);
+  seed.makeAdmin(userId);
+
+  // ---- UI login ----
+  await page.goto(`${serverUrl}/login`);
+  await page.getByTestId("username-input").fill(currentUser.username);
+  await page.getByTestId("password-input").fill(currentUser.password);
+  await page.getByTestId("login-submit").click();
+  await page.waitForURL(`${serverUrl}/`);
+
+  await page.setViewportSize({ width: 375, height: 667 });
+
+  const PAGES = [
+    { name: "Unread", url: "/" },
+    { name: "All Entries", url: "/entries" },
+    { name: "Starred", url: "/entries/starred" },
+    { name: "Summarized", url: "/entries/summarized" },
+    { name: "Feeds", url: "/feeds" },
+    { name: "Feed edit", url: `/feeds/${feedId}/edit` },
+    { name: "Categories", url: "/categories" },
+    { name: "Import OPML", url: "/feeds/import" },
+    { name: "Search", url: "/search?q=test" },
+    { name: "User settings", url: "/user-settings" },
+    { name: "App settings", url: "/settings" },
+    { name: "Statistics", url: "/statistics" },
+    { name: "Admin", url: "/admin" },
+  ];
+
+  const measure = (openSidebar) =>
+    page.evaluate(
+      async ({ MIN, openSidebar }) => {
+        if (openSidebar) {
+          document.querySelector(".sidebar-toggle")?.click();
+          await new Promise((r) => setTimeout(r, 250));
+        }
+        const sel =
+          'button, a[href], select, input:not([type=hidden]), textarea, label:has(input,select,textarea), [role="button"], summary';
+        const out = [];
+        for (const el of document.querySelectorAll(sel)) {
+          const r = el.getBoundingClientRect();
+          const cs = getComputedStyle(el);
+          if (cs.display === "none" || cs.visibility === "hidden") continue;
+          if (r.width === 0 || r.height === 0) continue;
+          if (r.width >= MIN && r.height >= MIN) continue;
+          const label =
+            el.getAttribute("data-testid") ||
+            el.getAttribute("aria-label") ||
+            (el.textContent || "").trim().replace(/\s+/g, " ").slice(0, 32);
+          // checkbox/radio inside a label: the label IS the tap target
+          const type = el.getAttribute("type") || "";
+          const labelWrapped =
+            (type === "checkbox" || type === "radio") &&
+            !!el.closest("label");
+          out.push({
+            tag: el.tagName.toLowerCase(),
+            type,
+            cls: (el.className?.toString() || "").slice(0, 44),
+            label,
+            w: Math.round(r.width),
+            h: Math.round(r.height),
+            // inline text links are an accepted exemption
+            inlineText:
+              !!el.closest("p, .entry-item-meta, .reading-pane-article, .breadcrumb") ||
+              labelWrapped,
+          });
+        }
+        return out;
+      },
+      { MIN, openSidebar }
+    );
+
+  const report = [];
+  for (const [i, p] of PAGES.entries()) {
+    await page.goto(`${serverUrl}${p.url}`, { waitUntil: "networkidle" }).catch(() => {});
+    const findings = await measure(false);
+    report.push({ page: p.name, url: p.url, findings });
+    // measure the off-canvas sidebar drawer once
+    if (i === 0) {
+      const sb = await measure(true);
+      report.push({ page: "Sidebar drawer", url: p.url, findings: sb });
+    }
+  }
+
+  fs.writeFileSync(OUT, JSON.stringify(report, null, 2));
+
+  // console summary
+  let total = 0,
+    realGaps = 0;
+  for (const r of report) {
+    if (!r.findings.length) {
+      console.log(`\n## ${r.page} (${r.url}) — OK (all >= ${MIN}px)`);
+      continue;
+    }
+    console.log(`\n## ${r.page} (${r.url}) — ${r.findings.length} sub-${MIN}px`);
+    for (const f of r.findings) {
+      total++;
+      if (!f.inlineText) realGaps++;
+      console.log(
+        `  ${String(f.w).padStart(3)}x${String(f.h).padStart(3)}  <${f.tag}${
+          f.type ? ` type=${f.type}` : ""
+        }> ${f.label}  [.${f.cls}]${f.inlineText ? "  (inline-text exempt)" : ""}`
+      );
+    }
+  }
+  console.log(`\n=== ${total} sub-${MIN}px hits; ${realGaps} non-inline (candidate gaps). Report: ${OUT} ===`);
+});

--- a/e2e/steps/responsive.steps.js
+++ b/e2e/steps/responsive.steps.js
@@ -140,6 +140,10 @@ Then("the {string} control is at least {int}px wide", async ({ page }, selector,
   expect(box.width).toBeGreaterThanOrEqual(min);
 });
 
+Then("the {string} element is visible", async ({ page }, selector) => {
+  await expect(page.locator(selector).first()).toBeVisible();
+});
+
 Then("the {string} controls each span at least {int}% of the row", async ({ page }, selector, pct) => {
   // "row" = the first entry-item; scope the controls to that same row so the
   // width comparison is against the row they live in (rows are uniform width).

--- a/e2e/steps/responsive.steps.js
+++ b/e2e/steps/responsive.steps.js
@@ -51,6 +51,10 @@ When("I open the edit page for feed {string}", async ({ page }, feedTitle) => {
     .click();
 });
 
+When("I expand the {string} disclosure", async ({ page }, label) => {
+  await page.locator("summary", { hasText: label }).click();
+});
+
 When("I tap the hamburger", async ({ page }) => {
   await page.locator(".sidebar-toggle").click();
 });

--- a/e2e/steps/responsive.steps.js
+++ b/e2e/steps/responsive.steps.js
@@ -34,6 +34,23 @@ When("I open the all-entries page", async ({ page, serverUrl }) => {
   await page.goto(`${serverUrl}/entries`);
 });
 
+When("I open the feeds page", async ({ page, serverUrl }) => {
+  await page.goto(`${serverUrl}/feeds`);
+});
+
+When("I open the import page", async ({ page, serverUrl }) => {
+  await page.goto(`${serverUrl}/feeds/import`);
+});
+
+When("I open the edit page for feed {string}", async ({ page }, feedTitle) => {
+  await page
+    .getByTestId("feeds-table")
+    .locator("tr")
+    .filter({ hasText: feedTitle })
+    .getByRole("link", { name: "edit" })
+    .click();
+});
+
 When("I tap the hamburger", async ({ page }) => {
   await page.locator(".sidebar-toggle").click();
 });

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -1032,6 +1032,7 @@ td input[type="text"] {
     outline: 2px solid var(--color-accent);
     outline-offset: 2px;
 }
+.banner-dismiss .ico { width: 18px; height: 18px; }
 
 /* Tinted wash + border per level; border-left picks up the level colour
    via the theme-aware tokens. (Dark border-left values matched the dark

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -2055,6 +2055,50 @@ summary {
     .tab-bar {
         gap: var(--space-2);
     }
+
+    /* Sidebar chrome links: logo and sign-out link */
+    .sidebar-logo,
+    .sidebar-footer a {
+        display: inline-flex;
+        align-items: center;
+        min-height: var(--touch-min);
+        min-width: var(--touch-min);
+    }
+
+    /* Horizontal pills: ensure full 44px in both axes */
+    .tab-bar a,
+    .feed-filter-link,
+    .stats-period-btn,
+    .actions a {
+        min-width: var(--touch-min);
+        justify-content: center;
+    }
+
+    /* Checkbox + radio wrapped in label become a 44px tappable row */
+    label:has(> input[type="checkbox"]),
+    label:has(> input[type="radio"]) {
+        display: inline-flex;
+        align-items: center;
+        gap: var(--space-2);
+        min-height: var(--touch-min);
+    }
+    input[type="checkbox"],
+    input[type="radio"] {
+        width: 1.25rem;
+        height: 1.25rem;
+        accent-color: var(--color-accent);
+        flex-shrink: 0;
+    }
+
+    /* File input */
+    input[type="file"] { min-height: var(--touch-min); }
+
+    /* Disclosure summary — padding only to preserve native ▸/▾ marker */
+    summary {
+        min-height: var(--touch-min);
+        padding: var(--space-3) 0;
+        box-sizing: border-box;
+    }
 }
 
 /* ===== Responsive: Phone (card tables, compact spacing) ===== */

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -219,12 +219,12 @@ code {
     display: none;
     background: none;
     border: none;
-    font-size: var(--font-2xl);
     color: var(--color-text-muted);
     cursor: pointer;
     padding: var(--space-1);
     line-height: 1;
 }
+.sidebar-close .ico { width: 20px; height: 20px; }
 
 .sidebar-nav {
     flex: 1;
@@ -289,21 +289,13 @@ code {
 
 .sidebar-item-icon {
     width: var(--icon-md);
-    text-align: center;
-    font-size: 1rem;
-    line-height: 1;
+    height: var(--icon-md);
     flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
 }
-
-[data-theme="dark"] .sidebar-item-icon {
-    opacity: 0.85;
-}
-
-@media (prefers-color-scheme: dark) {
-    :root:not([data-theme]) .sidebar-item-icon {
-        opacity: 0.85;
-    }
-}
+.sidebar-item-icon .ico { width: var(--icon-md); height: var(--icon-md); }
 
 .sidebar-badge {
     margin-left: auto;
@@ -378,11 +370,11 @@ code {
     border-radius: var(--radius-md);
     padding: var(--space-2);
     cursor: pointer;
-    font-size: var(--font-xl);
     line-height: 1;
     color: var(--color-text);
     box-shadow: var(--shadow-sm);
 }
+.sidebar-toggle .ico { width: 22px; height: 22px; }
 
 /* ===== Main Content Area ===== */
 .main-content {

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -1051,15 +1051,8 @@ td input[type="text"] {
     border: 0;
 }
 
-/* ===== Entry Items (List) — editorial grid ===== */
+/* ===== Entry Items (List) — head / meta / actions ===== */
 .entry-item {
-    display: grid;
-    grid-template-columns: auto 1fr;
-    grid-template-areas:
-        "fav  head"
-        "fav  meta"
-        "foot foot";
-    column-gap: var(--space-3);
     padding: var(--space-4) var(--space-5);
     border-bottom: 1px solid var(--color-border-light);
     cursor: pointer;
@@ -1077,12 +1070,11 @@ td input[type="text"] {
 .entry-item.entry-read:hover,
 .entry-item.entry-read.selected { opacity: 1; }
 
-/* Favicon spans the title+meta rows only (no tall empty column). */
+/* Favicon inline in the meta row. */
 .entry-favicon {
-    grid-area: fav;
     width: 24px;
     height: 24px;
-    margin-top: 2px;
+    margin-top: 0;
     border-radius: var(--radius-control);
     flex: none;
     object-fit: cover;
@@ -1103,14 +1095,15 @@ td input[type="text"] {
 .fav-c4 { background: #A6563E; }
 .fav-c5 { background: #6E8B3D; }
 
-/* Head: serif title + summary badges + right-aligned time. */
+/* Head row: title + right-pinned status cluster (star, summary sparkle, time). */
 .entry-head {
-    grid-area: head;
     display: flex;
-    align-items: baseline;
+    align-items: flex-start;
     gap: var(--space-2);
 }
 .entry-item-title {
+    flex: 1;
+    min-width: 0;
     font-family: var(--font-ui);
     /* Desktop sits next to the 14px sidebar, so the title matches that UI
        scale; mobile bumps it to --font-base (see the media block). */
@@ -1118,16 +1111,24 @@ td input[type="text"] {
     font-weight: 600;
     line-height: 1.32;
     color: var(--color-text);
-    cursor: pointer;
     overflow-wrap: break-word;
     word-break: break-word;
 }
 .entry-item-title:hover { color: var(--color-accent); }
 .entry-title-bold { font-weight: 600; }
 .entry-title-normal { font-weight: 400; }
-.entry-item-badges { flex: none; }
+.entry-status {
+    flex: none;
+    align-self: flex-start;
+    height: 1.32em;
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    font-size: var(--font-sm);
+}
+.entry-status .ico { width: 1.15em; height: 1.15em; }
+.entry-status-star { color: var(--color-accent); display: inline-flex; }
 .entry-time {
-    margin-left: auto;
     flex: none;
     font-family: var(--font-ui);
     font-size: var(--font-xs);
@@ -1135,11 +1136,11 @@ td input[type="text"] {
     white-space: nowrap;
 }
 
-/* Meta: feed · category, flush-left with the title. */
+/* Meta row: inline favicon + feed · category. */
 .entry-item-meta {
-    grid-area: meta;
-    /* Inline text flow (not flex) so "feed · category" wraps naturally as one
-       run of text instead of two side-by-side blocks. */
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
     margin-top: var(--space-1);
     font-family: var(--font-ui);
     font-size: var(--font-sm);
@@ -1153,12 +1154,11 @@ td input[type="text"] {
 /* Actions: full-width strip. Desktop = quiet text links that brighten on
    row hover; mobile (below) = full-width icon buttons. */
 .entry-item-actions {
-    grid-area: foot;
     display: flex;
     gap: var(--space-5);
     margin-top: var(--space-2);
     font-family: var(--font-ui);
-    font-size: var(--font-xs);
+    font-size: var(--font-sm);
     opacity: 0.72;
     transition: opacity 0.1s;
 }
@@ -1577,11 +1577,6 @@ mark {
     background: #ffffff;
 }
 
-/* Summary badges — shared geometry, per-state colour. */
-.entry-item-badges {
-    white-space: nowrap;
-}
-
 /* Summary-status badges — one sparkle glyph, colour + fill carry meaning.
    Icon sizes via 1.15em of the status-cluster font (set on .entry-status). */
 .summary-badge,
@@ -1910,12 +1905,18 @@ summary {
     /* ===== Entry row (redesign) — mobile ===== */
     .entry-item { padding: var(--space-4); }
 
-    /* No sidebar visible on mobile, so the larger title reads fine here. */
-    .entry-item-title { font-size: var(--font-base); }
+    /* No sidebar visible on mobile, so the larger title reads fine here.
+       display:flex + min-height gives it a 44px tap target (WCAG 2.5.5). */
+    .entry-item-title {
+        font-size: var(--font-base);
+        display: flex;
+        align-items: center;
+        min-height: var(--touch-min);
+    }
+    .entry-status { font-size: var(--font-base); }
 
-    /* Feed/category stay inline so "feed · category" wraps naturally. Vertical
-       padding (not min-height/inline-flex, which would break the wrap) gives
-       each inline link a ~28px hit box — inline links are exempt from the 44px
+    /* Feed/category flex row with favicon. Vertical padding on the links
+       gives each one a ~28px hit box — inline links are exempt from the 44px
        rule. No horizontal padding so they stay flush with the title. */
     .entry-item-meta {
         margin-top: var(--space-2);

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -472,22 +472,28 @@ code {
     border-bottom: 1px solid var(--color-border-light);
 }
 
-/* Back-to-list button — mobile-only (the desktop split view never leaves
+/* Back button — mobile-only (the desktop split view never leaves
    the list). `margin-right: auto` pins it far left so the nav stays right.
    Revealed in the ≤1024px block. */
 .reading-pane-back-link {
     display: none;
     margin-right: auto;
+    align-items: center;
+    gap: var(--space-2);
+    min-height: var(--touch-min);
+    padding: 0 var(--space-3);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
     background: none;
-    border: 0;
-    padding: 0;
     font: inherit;
     color: var(--color-accent);
     cursor: pointer;
 }
+.reading-pane-back-link .action-icon .ico { width: 18px; height: 18px; }
 
 .reading-pane-back-link:hover {
     color: var(--color-accent-hover);
+    border-color: var(--color-accent);
 }
 
 /* Prev/Next navigation. Buttons render disabled and app.js enables whichever

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -2466,6 +2466,13 @@ summary {
     padding: 0 var(--space-5);
 }
 
+/* "Mark Above as Read" reads cramped at btn-sm on desktop; give it a
+   comfortable size. Mobile still gets 44px from the touch baseline. */
+#mark-above-read {
+    font-size: var(--font-sm);
+    padding: var(--space-2) var(--space-4);
+}
+
 /* SSR form-button actions inside `.entry-item-actions`. The read/star
    buttons are form-wrapped (to carry their POST target), so the form is the
    flex child of `.entry-item-actions`; it must `display: contents`-style

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -1582,33 +1582,24 @@ mark {
     white-space: nowrap;
 }
 
+/* Summary-status badges — one sparkle glyph, colour + fill carry meaning.
+   Icon sizes via 1.15em of the status-cluster font (set on .entry-status). */
 .summary-badge,
 .summary-badge-pending,
 .summary-badge-processing,
 .summary-badge-failed {
-    margin-left: var(--space-1);
-    font-size: var(--font-xs);
+    display: inline-flex;
+    align-items: center;
 }
-
-.summary-badge {
-    color: var(--color-accent);
-    font-weight: normal;
-}
-
-.summary-badge-pending {
-    color: var(--color-text-muted);
-}
-
+.summary-badge { color: var(--color-accent); }            /* completed, filled */
+.summary-badge-pending { color: var(--color-text-muted); } /* outline */
 .summary-badge-processing {
-    color: var(--color-accent);
-    animation: blink 1s infinite;
+    color: var(--color-accent);                            /* outline, pulsing */
+    animation: summary-pulse 1s ease-in-out infinite;
 }
+.summary-badge-failed { color: var(--color-error); }       /* failed, filled */
 
-.summary-badge-failed {
-    color: var(--color-error);
-}
-
-@keyframes blink {
+@keyframes summary-pulse {
     0%, 100% { opacity: 1; }
     50% { opacity: 0.3; }
 }

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -615,13 +615,8 @@ code {
     cursor: default;
 }
 
-/* Inline SVG icons (outline set) for action + nav controls. Scale with the
-   surrounding font-size; stroke uses currentColor so they inherit the control
-   colour. Star uses the same path filled (.is-filled) for the active state. */
-.action-icon .ico,
-.reading-pane-nav-btn .ico {
-    width: 1.15em;
-    height: 1.15em;
+/* Base inline-icon styling (stroke set; size per context). */
+.ico {
     display: block;
     fill: none;
     stroke: currentColor;
@@ -629,10 +624,10 @@ code {
     stroke-linecap: round;
     stroke-linejoin: round;
 }
-.action-icon .ico.is-filled {
-    fill: var(--color-accent);
-    stroke: none;
-}
+.ico.is-filled { fill: currentColor; stroke: none; }
+.action-icon .ico,
+.reading-pane-nav-btn .ico { width: 1.15em; height: 1.15em; }
+.action-icon .ico.is-filled { fill: var(--color-accent); }
 
 .reading-pane-article {
     font-family: var(--font-body);

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -468,9 +468,8 @@ code {
    the list). `margin-right: auto` pins it far left so the nav stays right.
    Revealed in the ≤1024px block. */
 .reading-pane-back-link {
-    display: none;
+    display: none;                       /* shown as inline-flex in the ≤1024px block */
     margin-right: auto;
-    align-items: center;
     gap: var(--space-2);
     min-height: var(--touch-min);
     padding: 0 var(--space-3);

--- a/static/js/components/rdrs-flash.js
+++ b/static/js/components/rdrs-flash.js
@@ -95,7 +95,7 @@ class RdrsFlash extends HTMLElement {
         dismiss.className = 'banner-dismiss';
         dismiss.setAttribute('aria-label', 'Dismiss notification');
         dismiss.setAttribute('data-testid', 'flash-close');
-        dismiss.textContent = '×';
+        dismiss.innerHTML = '<svg class="ico" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 6l12 12M18 6L6 18"/></svg>';
         dismiss.addEventListener('click', () => {
             banner.remove();
             // Return focus to the original trigger if still in the DOM and visible,

--- a/static/js/components/rdrs-sidebar.js
+++ b/static/js/components/rdrs-sidebar.js
@@ -19,6 +19,22 @@
 
 import { escapeHtml } from '/static/js/utils.js';
 
+const ICON = {
+  inbox: '<svg class="ico" viewBox="0 0 24 24" aria-hidden="true"><path d="M22 12h-6l-2 3h-4l-2-3H2"/><path d="M5.4 5.1 2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.4-6.9A2 2 0 0 0 16.8 4H7.2a2 2 0 0 0-1.8 1.1z"/></svg>',
+  star: '<svg class="ico is-filled" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3.5l2.7 5.5 6 .9-4.3 4.2 1 6L12 17.3 6.6 20l1-6L3.3 9.9l6-.9z"/></svg>',
+  sparkle: '<svg class="ico" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l1.7 4.6L18 9.3l-4.3 1.7L12 16l-1.7-4.9L6 9.3l4.3-1.7z"/><path d="M18 15l.7 1.8L20.5 17.5l-1.8.7L18 20l-.7-1.8L15.5 17.5l1.8-.7z"/></svg>',
+  list: '<svg class="ico" viewBox="0 0 24 24" aria-hidden="true"><path d="M8 6h13M8 12h13M8 18h13"/><path d="M3.5 6h.01M3.5 12h.01M3.5 18h.01"/></svg>',
+  rss: '<svg class="ico" viewBox="0 0 24 24" aria-hidden="true"><path d="M4 11a9 9 0 0 1 9 9"/><path d="M4 4a16 16 0 0 1 16 16"/><circle cx="5" cy="19" r="1.6" fill="currentColor" stroke="none"/></svg>',
+  folder: '<svg class="ico" viewBox="0 0 24 24" aria-hidden="true"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></svg>',
+  search: '<svg class="ico" viewBox="0 0 24 24" aria-hidden="true"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4.3-4.3"/></svg>',
+  barchart: '<svg class="ico" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 20v-6M12 20V4M18 20v-9"/><path d="M4 20h16"/></svg>',
+  user: '<svg class="ico" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="8" r="4"/><path d="M4.5 21a7.5 7.5 0 0 1 15 0"/></svg>',
+  cog: '<svg class="ico" viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>',
+  shield: '<svg class="ico" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l8 3v5c0 5-3.5 8-8 9.5C7.5 19 4 16 4 11V6z"/></svg>',
+  menu: '<svg class="ico" viewBox="0 0 24 24" aria-hidden="true"><path d="M3 6h18M3 12h18M3 18h18"/></svg>',
+  close: '<svg class="ico" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 6l12 12M18 6L6 18"/></svg>',
+};
+
 const SIDEBAR_CACHE_KEY = 'rdrs.sidebar.v1';
 
 function readBootstrap() {
@@ -164,66 +180,66 @@ class RdrsSidebar extends HTMLElement {
 
         const adminLink = isAdmin ? `
             <a href="/admin" class="sidebar-item${isActive('admin')}" data-testid="nav-admin">
-                <span class="sidebar-item-icon">&#x1F6E1;&#xFE0F;</span>
+                <span class="sidebar-item-icon">${ICON.shield}</span>
                 <span>Admin</span>
             </a>` : '';
 
         this.innerHTML = `
-<button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Open menu">&#9776;</button>
+<button class="sidebar-toggle" onclick="toggleSidebar()" aria-label="Open menu">${ICON.menu}</button>
 
 <aside class="sidebar" id="sidebar" data-testid="main-nav">
     ${masqBanner}
     <div class="sidebar-header">
         <a href="/" class="sidebar-logo">rdrs</a>
-        <button class="sidebar-close" onclick="closeSidebar()" aria-label="Close menu">&times;</button>
+        <button class="sidebar-close" onclick="closeSidebar()" aria-label="Close menu">${ICON.close}</button>
     </div>
     <nav class="sidebar-nav">
         <div class="sidebar-section">
             <a href="/" class="sidebar-item${isActive('unread')}" data-testid="nav-unread">
-                <span class="sidebar-item-icon">&#x1F4EC;&#xFE0F;</span>
+                <span class="sidebar-item-icon">${ICON.inbox}</span>
                 <span>Unread</span>
                 <span class="sidebar-badge" id="unread-count">${totalUnread > 0 ? totalUnread : ''}</span>
             </a>
             <a href="/entries/starred" class="sidebar-item${isActive('starred')}">
-                <span class="sidebar-item-icon">&#x2B50;&#xFE0F;</span>
+                <span class="sidebar-item-icon">${ICON.star}</span>
                 <span>Starred</span>
             </a>
             <a href="/entries/summarized" class="sidebar-item${isActive('summarized')}" data-testid="nav-summarized">
-                <span class="sidebar-item-icon">&#x2728;&#xFE0F;</span>
+                <span class="sidebar-item-icon">${ICON.sparkle}</span>
                 <span>Summarized</span>
                 <span class="sidebar-badge" id="summarized-count">${totalSummarized > 0 ? totalSummarized : ''}</span>
             </a>
             <a href="/entries" class="sidebar-item${['all', 'read', 'entries'].includes(active) ? ' active' : ''}" data-testid="nav-entries">
-                <span class="sidebar-item-icon">&#x1F4F0;&#xFE0F;</span>
+                <span class="sidebar-item-icon">${ICON.list}</span>
                 <span>All Entries</span>
             </a>
         </div>
         ${categoriesHtml}
         <div class="sidebar-section">
             <a href="/feeds" class="sidebar-item${isActive('feeds')}" data-testid="nav-feeds">
-                <span class="sidebar-item-icon">&#x1F4E1;&#xFE0F;</span>
+                <span class="sidebar-item-icon">${ICON.rss}</span>
                 <span>Feeds</span>
             </a>
             <a href="/categories" class="sidebar-item${isActive('categories')}" data-testid="nav-categories">
-                <span class="sidebar-item-icon">&#x1F5C2;&#xFE0F;</span>
+                <span class="sidebar-item-icon">${ICON.folder}</span>
                 <span>Categories</span>
             </a>
         </div>
         <div class="sidebar-section">
             <a href="/search" class="sidebar-item${isActive('search')}" data-testid="nav-search">
-                <span class="sidebar-item-icon">&#x1F50D;&#xFE0F;</span>
+                <span class="sidebar-item-icon">${ICON.search}</span>
                 <span>Search</span>
             </a>
             <a href="/statistics" class="sidebar-item${isActive('statistics')}" data-testid="nav-statistics">
-                <span class="sidebar-item-icon">&#x1F4CA;&#xFE0F;</span>
+                <span class="sidebar-item-icon">${ICON.barchart}</span>
                 <span>Statistics</span>
             </a>
             <a href="/user-settings" class="sidebar-item${isActive('user-settings')}" data-testid="nav-settings">
-                <span class="sidebar-item-icon">&#x1F464;&#xFE0F;</span>
+                <span class="sidebar-item-icon">${ICON.user}</span>
                 <span>Settings</span>
             </a>
             <a href="/settings" class="sidebar-item${isActive('settings')}">
-                <span class="sidebar-item-icon">&#x2699;&#xFE0F;</span>
+                <span class="sidebar-item-icon">${ICON.cog}</span>
                 <span>App</span>
             </a>
             ${adminLink}

--- a/templates/_entry_row.html
+++ b/templates/_entry_row.html
@@ -15,10 +15,10 @@
     <div class="entry-head">
         <a href="/entries/{{ r.id }}/fragment" data-swap="#reading-pane" class="entry-item-title {% if r.is_read %}entry-title-normal{% else %}entry-title-bold{% endif %}" data-testid="entry-title-link">{{ r.title }}</a>
         <span class="entry-item-badges">{% match r.summary_status_str() %}
-            {% when Some("completed") %}<span title="Has Summary" class="summary-badge">✅</span>
-            {% when Some("pending") %}<span title="Pending" class="summary-badge-pending">⏳</span>
-            {% when Some("processing") %}<span title="Processing" class="summary-badge-processing">🔄</span>
-            {% when Some("failed") %}<span title="Failed" class="summary-badge-failed">❌</span>
+            {% when Some("completed") %}<span title="Has Summary" class="summary-badge" aria-hidden="true">{% call icons::summary(true) %}{% endcall %}</span>
+            {% when Some("pending") %}<span title="Pending" class="summary-badge-pending" aria-hidden="true">{% call icons::summary(false) %}{% endcall %}</span>
+            {% when Some("processing") %}<span title="Processing" class="summary-badge-processing" aria-hidden="true">{% call icons::summary(false) %}{% endcall %}</span>
+            {% when Some("failed") %}<span title="Failed" class="summary-badge-failed" aria-hidden="true">{% call icons::summary(true) %}{% endcall %}</span>
             {% when _ %}
         {% endmatch %}</span>
         <time class="entry-time" datetime="{{ r.published_at_iso }}">{{ r.published_relative }}</time>

--- a/templates/_entry_row.html
+++ b/templates/_entry_row.html
@@ -1,30 +1,32 @@
 {%- import "_icons.html" as icons -%}
-{# Single entry row — editorial CSS-grid layout (see
-   docs/superpowers/specs/2026-06-13-entry-item-redesign-design.md).
-   Grid areas: "fav head" / "fav meta" / "foot foot". The form-wrapped
-   action buttons keep their data-testids and POST targets so triage and
-   responsive e2e keep working; on mobile the .action-label spans are
-   hidden (CSS) leaving icon-only 44px buttons. #}
+{# Single entry row — head row (title + right-pinned status cluster) + meta row
+   (inline favicon + feed · category) + action strip below.
+   Testids and POST action URLs are preserved so triage and responsive e2e
+   keep working; on mobile the .action-label spans are hidden (CSS) leaving
+   icon-only 44px buttons. The title is a 44px tap target on mobile via
+   display:flex + min-height:var(--touch-min). #}
 <div id="entry-row-{{ r.id }}" class="entry-item{% if r.is_read %} entry-read{% endif %}" data-entry-row data-entry-id="{{ r.id }}" data-testid="entry-item">
-    {% if r.feed_has_icon %}
-    <img class="entry-favicon" src="/api/feeds/{{ r.feed_id }}/icon" alt="" loading="lazy" width="24" height="24">
-    {% else %}
-    <span class="entry-favicon entry-favicon-chip fav-c{{ r.feed_color_index() }}" aria-hidden="true">{{ r.feed_initial() }}</span>
-    {% endif %}
-
     <div class="entry-head">
         <a href="/entries/{{ r.id }}/fragment" data-swap="#reading-pane" class="entry-item-title {% if r.is_read %}entry-title-normal{% else %}entry-title-bold{% endif %}" data-testid="entry-title-link">{{ r.title }}</a>
-        <span class="entry-item-badges">{% match r.summary_status_str() %}
+        <span class="entry-status">
+            {% if r.is_starred %}<span class="entry-status-star" title="Starred" aria-hidden="true">{% call icons::star(true) %}{% endcall %}</span>{% endif %}
+            {% match r.summary_status_str() %}
             {% when Some("completed") %}<span title="Has Summary" class="summary-badge" aria-hidden="true">{% call icons::summary(true) %}{% endcall %}</span>
             {% when Some("pending") %}<span title="Pending" class="summary-badge-pending" aria-hidden="true">{% call icons::summary(false) %}{% endcall %}</span>
             {% when Some("processing") %}<span title="Processing" class="summary-badge-processing" aria-hidden="true">{% call icons::summary(false) %}{% endcall %}</span>
             {% when Some("failed") %}<span title="Failed" class="summary-badge-failed" aria-hidden="true">{% call icons::summary(true) %}{% endcall %}</span>
             {% when _ %}
-        {% endmatch %}</span>
-        <time class="entry-time" datetime="{{ r.published_at_iso }}">{{ r.published_relative }}</time>
+            {% endmatch %}
+            <time class="entry-time" datetime="{{ r.published_at_iso }}">{{ r.published_relative }}</time>
+        </span>
     </div>
 
     <div class="muted entry-item-meta">
+        {% if r.feed_has_icon %}
+        <img class="entry-favicon" src="/api/feeds/{{ r.feed_id }}/icon" alt="" loading="lazy" width="24" height="24">
+        {% else %}
+        <span class="entry-favicon entry-favicon-chip fav-c{{ r.feed_color_index() }}" aria-hidden="true">{{ r.feed_initial() }}</span>
+        {% endif %}
         <a href="/feeds/{{ r.feed_id }}/entries">{{ r.feed_title }}</a>
         <span class="meta-sep">·</span>
         <a href="/categories/{{ r.category_id }}/entries">{{ r.category_name }}</a>

--- a/templates/_icons.html
+++ b/templates/_icons.html
@@ -10,3 +10,4 @@
 {% macro close() %}<svg class="ico" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 6l12 12M18 6L6 18"/></svg>{% endmacro %}
 {% macro chevron_left() %}<svg class="ico" viewBox="0 0 24 24" aria-hidden="true"><path d="M15 6l-6 6 6 6"/></svg>{% endmacro %}
 {% macro chevron_right() %}<svg class="ico" viewBox="0 0 24 24" aria-hidden="true"><path d="M9 6l6 6-6 6"/></svg>{% endmacro %}
+{% macro summary(filled) %}<svg class="ico{% if filled %} is-filled{% endif %}" viewBox="0 0 24 24" aria-hidden="true">{% if filled %}<path d="M12 3L14 10L21 12L14 14L12 21L10 14L3 12L10 10Z"/>{% else %}<g transform="translate(1.2 1.2) scale(0.9)"><path d="M12 3L14 10L21 12L14 14L12 21L10 14L3 12L10 10Z"/></g>{% endif %}</svg>{% endmacro %}

--- a/templates/_reading_pane.html
+++ b/templates/_reading_pane.html
@@ -12,7 +12,7 @@
     {# Pane toolbar. On mobile it also holds the Back affordance (left); the
        prev/next nav sits at the right on every viewport. #}
     <div class="reading-pane-back">
-        <button type="button" class="reading-pane-back-link" data-pane-back data-testid="reading-pane-back">← Back to list</button>
+        <button type="button" class="reading-pane-back-link" data-pane-back data-testid="reading-pane-back"><span class="action-icon" aria-hidden="true">{% call icons::chevron_left() %}{% endcall %}</span><span>Back</span></button>
         {# Prev/Next navigation across the current filtered list. Rendered
            disabled; app.js resolves neighbours via
            `GET /api/entries/{id}/neighbors` after the pane opens and enables

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -1,3 +1,4 @@
+{%- import "_icons.html" as icons -%}
 {% macro flash(messages) %}
 {% if !messages.is_empty() %}
 <div class="banner-stack" role="region" aria-label="Notifications" tabindex="-1">
@@ -6,7 +7,7 @@
         <span class="banner-icon" aria-hidden="true"></span>
         <div class="banner-body"><span class="sr-only">{{ msg.level_name() }}: </span><span class="banner-message">{{ msg.message }}</span></div>
         <time class="banner-time" datetime="{{ msg.timestamp_iso() }}" data-testid="flash-time">{{ msg.formatted_time() }}</time>
-        <button type="button" class="banner-dismiss" aria-label="Dismiss notification" data-testid="flash-close" onclick="this.closest('.banner').remove();">&times;</button>
+        <button type="button" class="banner-dismiss" aria-label="Dismiss notification" data-testid="flash-close" onclick="this.closest('.banner').remove();">{% call icons::close() %}{% endcall %}</button>
     </div>
     {% endfor %}
 </div>


### PR DESCRIPTION
## Summary

Replaces all remaining emoji/glyph icons with the inline SVG icon set, relays out the entry-list row to echo the reading pane, and closes every measured sub-44px touch-target gap.

### Icons (emoji/glyph → SVG)
- **Entry summary badge** — ✅⏳🔄❌ → one `summary()` sparkle macro; colour + fill carry state (gold filled = done, muted outline = pending, pulsing outline = processing, red filled = failed).
- **Reading-pane back button** — `←` text → bordered `chevron_left` + "Back" (consistent with prev/next nav).
- **Flash dismiss** — `×` → `close()` SVG, on **both** the SSR macro and the JS-generated toast banners.
- **Sidebar** — 11 nav emoji + hamburger ☰ + close × → inline SVG icon map (path-identical to the Askama macros); removed the dark-mode `opacity` hack that only existed to dim emoji.
- Promoted `.ico`/`.is-filled` to reusable base CSS so the JS sidebar can rely on it.

### Entry-row relayout
CSS grid → block flow echoing the reading pane:
- **Head row:** title + right-pinned status cluster (star · summary sparkle · published time).
- **Meta row:** inline favicon + feed · category.
- **Actions row:** read / star / original.
- Icon sizing matches the reading pane (`1.15em`).

### Touch targets (44px)
Empirically audited at 375px; extended the touch-area treatment from buttons to the remaining interactive controls:
- Sidebar logout link & logo, filter/feed/stats pills, feed-row edit link.
- Checkbox + its wrapping label (44px row), file input, `<summary>` disclosure (padding-based so the native ▸/▾ marker is preserved).
- Desktop "Mark Above as Read" enlarged (was cramped at `btn-sm`).
- Retained the 375px audit as a regression tool (`e2e/scripts/touch-audit.spec.js`).

## Testing
- `cargo fmt` / `cargo clippy --all-targets -- -D warnings` / `cargo build` — clean
- `cargo nextest run` — **902 passed**
- Playwright-BDD e2e — **119 passed**, 0 skipped
- Glyph-icon sweep — clean (only the allowed onboarding `→` remains)

## Notes / optional follow-up
- Sidebar "Starred" star renders in `currentColor` (muted) rather than gold, by design — all nav icons share one weight/colour. Can switch to accent if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)