### PR TITLE
Entry row: emphasize title + inline-wrap feed·category

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -1098,9 +1098,9 @@ td input[type="text"] {
     flex: 1;
     min-width: 0;
     font-family: var(--font-ui);
-    /* Desktop sits next to the 14px sidebar, so the title matches that UI
-       scale; mobile bumps it to --font-base (see the media block). */
-    font-size: var(--font-sm);
+    /* Title is the row's focal point: bumped to --font-base on desktop for
+       emphasis (was --font-sm); mobile goes one step further (see media block). */
+    font-size: var(--font-base);
     font-weight: 600;
     line-height: 1.32;
     color: var(--color-text);
@@ -1132,13 +1132,20 @@ td input[type="text"] {
 /* Meta row: inline favicon + feed · category. */
 .entry-item-meta {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     gap: var(--space-2);
-    margin-top: var(--space-1);
+    /* Bigger gap below the title to let the emphasized headline breathe. */
+    margin-top: var(--space-2);
     font-family: var(--font-ui);
     font-size: var(--font-sm);
     line-height: 1.5;
     color: var(--color-text-secondary);
+}
+/* feed · category as a single inline text run that wraps as a unit, rather
+   than two side-by-side flex blocks that get squeezed. */
+.entry-meta-text {
+    flex: 1;
+    min-width: 0;
 }
 .entry-item-meta a { color: var(--color-text-secondary); }
 .entry-item-meta a:hover { color: var(--color-accent); }
@@ -1901,7 +1908,7 @@ summary {
     /* No sidebar visible on mobile, so the larger title reads fine here.
        display:flex + min-height gives it a 44px tap target (WCAG 2.5.5). */
     .entry-item-title {
-        font-size: var(--font-base);
+        font-size: var(--font-lg);
         display: flex;
         align-items: center;
         min-height: var(--touch-min);

--- a/templates/_entry_row.html
+++ b/templates/_entry_row.html
@@ -27,9 +27,11 @@
         {% else %}
         <span class="entry-favicon entry-favicon-chip fav-c{{ r.feed_color_index() }}" aria-hidden="true">{{ r.feed_initial() }}</span>
         {% endif %}
-        <a href="/feeds/{{ r.feed_id }}/entries">{{ r.feed_title }}</a>
-        <span class="meta-sep">·</span>
-        <a href="/categories/{{ r.category_id }}/entries">{{ r.category_name }}</a>
+        <span class="entry-meta-text">
+            <a href="/feeds/{{ r.feed_id }}/entries">{{ r.feed_title }}</a>
+            <span class="meta-sep">·</span>
+            <a href="/categories/{{ r.category_id }}/entries">{{ r.category_name }}</a>
+        </span>
     </div>
 
     <div class="entry-item-actions">


### PR DESCRIPTION
## Summary

Strengthen the entry title as the row's focal point and let the meta line flow as a single inline run instead of two side-by-side flex blocks that get squeezed on the narrow (340px) list pane.

- **Title font-size** — desktop `--font-sm` → `--font-base`; mobile `--font-base` → `--font-lg`
- **Bottom spacing** — meta `margin-top` `--space-1` → `--space-2`, giving the larger title room to breathe
- **feed · category** — wrapped in `.entry-meta-text` (inline, `flex:1`) so the pair wraps as one unit; meta row `align-items` `center` → `flex-start` to top-align the favicon when the text wraps

## Before / After

On the 340px desktop list pane, a long publication + category previously split into two side-by-side blocks (the `·` separator squeezed out). Now `feed · category` flows as inline text that wraps naturally, favicon aligned to the first line.

## Testing

- `cargo build` (CSS is `include_str!`'d into the binary)
- Responsive e2e: **22/22 pass**, including the entry-row redesign scenario, `.entry-item-meta a` 24px and `entry-title-link` 44px touch-target checks

Testids and POST action URLs are unchanged.