### PR TITLE
Summarization: cancel, retry/clear failed state, and request timeout

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -293,6 +293,10 @@ RDRS integrates with Kagi AI for automatic article summarization:
 4. Worker calls Kagi API and stores result in `entry_summary` table
 5. Summary is cached and returned to client
 
+**Cancellation & Timeout:**
+- Each in-flight or queued job has a `CancellationToken` in a shared `CancelRegistry` keyed by `(user_id, entry_id)`. A `POST /entries/{id}/summarize/cancel` request cancels the token (aborting the in-flight HTTP request) and deletes the record.
+- Each Kagi request races against a 90-second hard timeout; on expiry the request is dropped and the summary is marked `failed`.
+
 **Status Tracking:**
 - Summaries track state: pending, processing, completed, failed
 - Failed requests include error messages for debugging

--- a/docs/superpowers/plans/2026-06-15-summarization-cancel-retry.md
+++ b/docs/superpowers/plans/2026-06-15-summarization-cancel-retry.md
@@ -1,0 +1,1018 @@
+# Summarization Cancel / Retry / Timeout Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let users cancel an in-flight/queued summarization and recover a failed one (Retry / Clear) from the reading pane, and add a Kagi request timeout so a hung call can't wedge the single worker.
+
+**Architecture:** A shared per-entry `CancellationToken` registry in `AppState` lets a new `POST /entries/{id}/summarize/cancel` handler abort a job; the worker races the Kagi call against that token and a 90 s timeout via an extracted `run_summary` helper. The reading pane gains a failed-state branch (error banner + Retry + Clear) and an in-flight Cancel button; Retry reuses the existing summarize endpoint, Cancel/Clear share the new cancel endpoint (which deletes the record).
+
+**Tech Stack:** Rust (Axum, Askama, rusqlite, tokio, `tokio_util::sync::CancellationToken`), vanilla CSS, Playwright BDD (e2e).
+
+**Spec:** `docs/superpowers/specs/2026-06-15-summarization-cancel-retry-design.md`
+
+**Before you start — environment:** This is a NixOS box; re-source `/tmp/rdrs-env.sh` before every `cargo`/`npm` command (OpenSSL env vars). Run Rust tests with `RDRS_FAST_HASH=1 cargo nextest run`. Always `cargo fmt` before committing and keep `cargo clippy -- -D warnings` clean.
+
+---
+
+## File Structure
+
+- `src/services/summary_worker.rs` — add `CancelRegistry` type alias, `SUMMARY_TIMEOUT` const, `SummaryOutcome` enum + `run_summary` helper, thread the registry through `start_summary_worker` / `process_summary_job`.
+- `src/services/mod.rs` — re-export `CancelRegistry`.
+- `src/lib.rs` — `AppState.summary_cancels` field; register the cancel route.
+- `src/main.rs` — create the registry, pass to worker + `AppState`.
+- `src/handlers/entries.rs` — `SummarizeCleared` response type, `summarize_cancel_form` handler, extend `resolve_summary` + `build_reading_pane_view` with `summary_error`.
+- `src/handlers/pages/mod.rs` — add `summary_error` field to `ReadingPaneView`.
+- `templates/_reading_pane.html` — Cancel button (in-flight) + failed branch.
+- `templates/_summarize_pending.html` — Cancel button.
+- `templates/_summary_cleared.html` — **new** empty-container fragment.
+- `templates/_icons.html` — `refresh` macro.
+- `static/css/app.css` — `.summary-error-banner`.
+- `e2e/support/seed.js`, `e2e/steps/*.steps.js`, `e2e/features/reading.feature` — failed-state coverage.
+- `ARCHITECTURE.md` + worker doc comments — note cancellation + timeout now exist.
+
+> **Note on `build_reading_pane_view`:** it is the *single* `pub(crate)` builder in `src/handlers/entries.rs` used by the fragment endpoints **and** by `maybe_build_reading_pane` in `src/handlers/pages/mod.rs` for full-page renders. Changing it once covers every reading-pane render path.
+
+---
+
+## Task 1: `run_summary` helper + timeout constant (pure, testable)
+
+**Files:**
+- Modify: `src/services/summary_worker.rs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the `#[cfg(test)] mod tests` block in `src/services/summary_worker.rs`:
+
+```rust
+    #[tokio::test]
+    async fn run_summary_completes() {
+        let token = CancellationToken::new();
+        let out = run_summary(&token, std::time::Duration::from_secs(1), async {
+            Ok::<String, String>("hello".to_string())
+        })
+        .await;
+        assert!(matches!(out, SummaryOutcome::Completed(s) if s == "hello"));
+    }
+
+    #[tokio::test]
+    async fn run_summary_propagates_failure() {
+        let token = CancellationToken::new();
+        let out = run_summary(&token, std::time::Duration::from_secs(1), async {
+            Err::<String, String>("boom".to_string())
+        })
+        .await;
+        assert!(matches!(out, SummaryOutcome::Failed(e) if e == "boom"));
+    }
+
+    #[tokio::test]
+    async fn run_summary_times_out() {
+        let token = CancellationToken::new();
+        let out = run_summary(&token, std::time::Duration::from_millis(20), async {
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+            Ok::<String, String>("late".to_string())
+        })
+        .await;
+        assert!(matches!(out, SummaryOutcome::Failed(e) if e == "Summarization timed out"));
+    }
+
+    #[tokio::test]
+    async fn run_summary_cancels_before_completion() {
+        let token = CancellationToken::new();
+        token.cancel();
+        let out = run_summary(&token, std::time::Duration::from_secs(1), async {
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+            Ok::<String, String>("never".to_string())
+        })
+        .await;
+        assert!(matches!(out, SummaryOutcome::Cancelled));
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `RDRS_FAST_HASH=1 cargo nextest run -p rdrs run_summary 2>&1 | tail -20`
+Expected: compile error — `run_summary` / `SummaryOutcome` not found.
+
+- [ ] **Step 3: Implement the helper + constant**
+
+Add near the top of `src/services/summary_worker.rs` (after the imports):
+
+```rust
+use std::time::Duration;
+
+/// Maximum wall-clock time for a single Kagi summarization request. A hung
+/// request would otherwise occupy the single worker indefinitely and block
+/// every user's queued summaries. NEVER lower this in production without
+/// confirming Kagi's worst-case latency.
+const SUMMARY_TIMEOUT: Duration = Duration::from_secs(90);
+
+/// Result of racing a summarization future against cancellation + timeout.
+pub(crate) enum SummaryOutcome {
+    Completed(String),
+    Failed(String),
+    Cancelled,
+}
+
+/// Race a summarization future against an external cancellation token and a
+/// hard timeout. `biased` makes cancellation win deterministically when the
+/// token is already cancelled. On timeout the future is dropped (the in-flight
+/// HTTP request is aborted) and a `Failed("Summarization timed out")` is
+/// returned.
+pub(crate) async fn run_summary<F>(
+    token: &CancellationToken,
+    timeout: Duration,
+    fut: F,
+) -> SummaryOutcome
+where
+    F: std::future::Future<Output = Result<String, String>>,
+{
+    tokio::select! {
+        biased;
+        _ = token.cancelled() => SummaryOutcome::Cancelled,
+        res = tokio::time::timeout(timeout, fut) => match res {
+            Ok(Ok(text)) => SummaryOutcome::Completed(text),
+            Ok(Err(e)) => SummaryOutcome::Failed(e),
+            Err(_elapsed) => SummaryOutcome::Failed("Summarization timed out".to_string()),
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `RDRS_FAST_HASH=1 cargo nextest run -p rdrs run_summary 2>&1 | tail -20`
+Expected: 4 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cargo fmt
+git add src/services/summary_worker.rs
+git commit -S -m "feat: add run_summary cancel/timeout race helper"
+```
+
+---
+
+## Task 2: Thread a cancellation registry through the worker
+
+**Files:**
+- Modify: `src/services/summary_worker.rs`
+- Modify: `src/services/mod.rs`
+- Modify: `src/lib.rs` (AppState field)
+- Modify: `src/main.rs` (create + wire registry)
+
+- [ ] **Step 1: Add the registry type and re-export**
+
+At the top of `src/services/summary_worker.rs`, extend the imports and add the alias:
+
+```rust
+use std::collections::HashMap;
+use std::sync::Mutex;
+```
+
+Add after the `SummaryJob` struct:
+
+```rust
+/// Per-entry cancellation tokens for in-flight / queued summary jobs, keyed by
+/// `(user_id, entry_id)`. The cancel handler cancels + removes the token; the
+/// worker creates one on dequeue (if absent) and removes it when the job ends.
+pub type CancelRegistry = Arc<Mutex<HashMap<(i64, i64), CancellationToken>>>;
+```
+
+In `src/services/mod.rs`, extend the `summary_worker` re-export (currently
+`pub use summary_worker::{create_summary_channel, recover_incomplete_jobs, start_summary_worker, SummaryJob, ...}`) to also export `CancelRegistry`:
+
+```rust
+pub use summary_worker::{
+    create_summary_channel, recover_incomplete_jobs, start_summary_worker, CancelRegistry,
+    SummaryJob,
+};
+```
+
+(Keep any other names already in that brace list; add `CancelRegistry` alphabetically.)
+
+- [ ] **Step 2: Add the `cancels` param to `start_summary_worker` and `process_summary_job`**
+
+Change the `start_summary_worker` signature to accept the registry and pass it into both `process_summary_job` call sites:
+
+```rust
+pub fn start_summary_worker(
+    mut rx: mpsc::Receiver<SummaryJob>,
+    cache: Arc<SummaryCache>,
+    sidebar_cache: Arc<SidebarCache>,
+    db: DbPool,
+    cancels: CancelRegistry,
+    cancel_token: CancellationToken,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        tracing::info!("Summary worker started");
+
+        loop {
+            let job = tokio::select! {
+                _ = cancel_token.cancelled() => {
+                    tracing::info!("Summary worker stopping, draining remaining jobs...");
+                    while let Ok(job) = rx.try_recv() {
+                        process_summary_job(&job, &cache, &sidebar_cache, &db, &cancels).await;
+                    }
+                    break;
+                }
+                job = rx.recv() => {
+                    match job {
+                        Some(job) => job,
+                        None => break,
+                    }
+                }
+            };
+
+            process_summary_job(&job, &cache, &sidebar_cache, &db, &cancels).await;
+        }
+
+        tracing::info!("Summary worker stopped");
+    })
+}
+```
+
+- [ ] **Step 3: Restructure `process_summary_job` to use the registry + `run_summary`**
+
+Replace the whole `process_summary_job` function with an outer (token lifecycle) + inner (work) split:
+
+```rust
+async fn process_summary_job(
+    job: &SummaryJob,
+    cache: &Arc<SummaryCache>,
+    sidebar_cache: &Arc<SidebarCache>,
+    db: &DbPool,
+    cancels: &CancelRegistry,
+) {
+    let key = (job.user_id, job.entry_id);
+
+    // Get-or-create this job's cancellation token. Covers startup-recovered
+    // jobs too (they never pass through the enqueue handler).
+    let token = {
+        let mut map = cancels.lock().unwrap();
+        map.entry(key)
+            .or_insert_with(CancellationToken::new)
+            .clone()
+    };
+
+    // Cancelled while still queued — the cancel handler already deleted the
+    // record. Drop the token and skip.
+    if token.is_cancelled() {
+        cancels.lock().unwrap().remove(&key);
+        return;
+    }
+
+    run_summary_job_body(job, cache, sidebar_cache, db, &token).await;
+
+    cancels.lock().unwrap().remove(&key);
+}
+
+async fn run_summary_job_body(
+    job: &SummaryJob,
+    cache: &Arc<SummaryCache>,
+    sidebar_cache: &Arc<SidebarCache>,
+    db: &DbPool,
+    token: &CancellationToken,
+) {
+    tracing::debug!(
+        "Processing summary job: user={}, entry={}, link={}",
+        job.user_id,
+        job.entry_id,
+        job.entry_link
+    );
+
+    // Mark as processing in both cache and DB
+    cache.set_processing(job.user_id, job.entry_id);
+    {
+        let user_id = job.user_id;
+        let entry_id = job.entry_id;
+        let _ = db
+            .background(move |conn| entry_summary::set_processing(conn, user_id, entry_id))
+            .await;
+    }
+
+    // Get Kagi config for the user
+    let user_id = job.user_id;
+    let entry_id = job.entry_id;
+    let kagi_config = match db
+        .background(move |conn| user_settings::get_save_services_config(conn, user_id))
+        .await
+    {
+        Ok(Ok(config)) => config.kagi,
+        Ok(Err(e)) => {
+            tracing::error!("Failed to get user settings: {}", e);
+            let error_msg = "Failed to load Kagi settings".to_string();
+            cache.set_failed(job.user_id, job.entry_id, error_msg.clone());
+            let _ = db
+                .background(move |conn| {
+                    entry_summary::set_failed(conn, user_id, entry_id, &error_msg)
+                })
+                .await;
+            return;
+        }
+        Err(e) => {
+            tracing::error!("Failed to access DB: {}", e);
+            let error_msg = "Internal error: DB access failed".to_string();
+            cache.set_failed(job.user_id, job.entry_id, error_msg);
+            return;
+        }
+    };
+
+    let kagi_config = match kagi_config {
+        Some(c) if c.is_configured() => c,
+        _ => {
+            let error_msg = "Kagi is not configured".to_string();
+            cache.set_failed(job.user_id, job.entry_id, error_msg.clone());
+            let user_id = job.user_id;
+            let entry_id = job.entry_id;
+            let _ = db
+                .background(move |conn| {
+                    entry_summary::set_failed(conn, user_id, entry_id, &error_msg)
+                })
+                .await;
+            return;
+        }
+    };
+
+    // Race the Kagi call against cancellation + timeout.
+    match run_summary(
+        token,
+        SUMMARY_TIMEOUT,
+        summarize_with_kagi(&kagi_config, &job.entry_link),
+    )
+    .await
+    {
+        SummaryOutcome::Completed(summary_text) => {
+            tracing::debug!(
+                "Summary completed for entry {}: {} chars",
+                job.entry_id,
+                summary_text.len()
+            );
+            cache.set_completed(job.user_id, job.entry_id, summary_text.clone());
+            let user_id = job.user_id;
+            let entry_id = job.entry_id;
+            let _ = db
+                .background(move |conn| {
+                    entry_summary::set_completed(conn, user_id, entry_id, &summary_text)
+                })
+                .await;
+            // A summary just completed — the sidebar "Summarized" badge must tick up.
+            sidebar_cache.bust(job.user_id);
+        }
+        SummaryOutcome::Failed(error) => {
+            tracing::warn!("Summary failed for entry {}: {}", job.entry_id, error);
+            cache.set_failed(job.user_id, job.entry_id, error.clone());
+            let user_id = job.user_id;
+            let entry_id = job.entry_id;
+            let _ = db
+                .background(move |conn| entry_summary::set_failed(conn, user_id, entry_id, &error))
+                .await;
+        }
+        SummaryOutcome::Cancelled => {
+            // The cancel handler owns cleanup (delete + cache remove + sidebar
+            // bust). Write nothing back.
+            tracing::debug!("Summary cancelled for entry {}", job.entry_id);
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Fix the existing worker test call sites**
+
+Every existing `start_summary_worker(...)` call in the test module now needs a
+`cancels` argument. Add this helper at the top of the `tests` module and pass
+`registry()` as the 5th argument (before `cancel_token`) in
+`test_worker_stops_on_cancellation`, `test_worker_stops_when_channel_closed`,
+and `test_worker_drains_jobs_on_cancellation`:
+
+```rust
+    fn registry() -> CancelRegistry {
+        Arc::new(Mutex::new(HashMap::new()))
+    }
+```
+
+Example edit (apply the same shape to all three call sites):
+
+```rust
+        let handle = start_summary_worker(
+            rx,
+            cache,
+            Arc::new(SidebarCache::default()),
+            db,
+            registry(),
+            cancel_token.clone(),
+        );
+```
+
+- [ ] **Step 5: Wire the registry into `AppState` and `main.rs`**
+
+In `src/lib.rs`, add the field to `AppState` (after `sidebar_cache`):
+
+```rust
+    pub summary_cancels: services::CancelRegistry,
+```
+
+In `src/main.rs`, create the registry before `start_summary_worker` and pass it
+in both places. After the `sidebar_cache` line (`let sidebar_cache = ...`):
+
+```rust
+    // Per-entry cancellation tokens for summary jobs (cancel/abort support)
+    let summary_cancels: rdrs::services::CancelRegistry =
+        std::sync::Arc::new(std::sync::Mutex::new(std::collections::HashMap::new()));
+```
+
+Update the worker start call to pass `summary_cancels.clone()` as the new 5th arg:
+
+```rust
+    let summary_worker_handle = services::start_summary_worker(
+        summary_rx,
+        summary_cache.clone(),
+        sidebar_cache.clone(),
+        db.clone(),
+        summary_cancels.clone(),
+        cancel_token.clone(),
+    );
+```
+
+Add the field to the `AppState { ... }` initializer (after `sidebar_cache`):
+
+```rust
+        summary_cancels,
+```
+
+- [ ] **Step 6: Build + run the worker tests**
+
+Run: `RDRS_FAST_HASH=1 cargo nextest run -p rdrs summary_worker 2>&1 | tail -25`
+Expected: all `summary_worker` tests PASS (existing + Task 1's).
+Run: `cargo clippy -- -D warnings 2>&1 | tail -15`
+Expected: no warnings.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cargo fmt
+git add src/services/summary_worker.rs src/services/mod.rs src/lib.rs src/main.rs
+git commit -S -m "feat: per-entry cancellation registry + timeout in summary worker"
+```
+
+---
+
+## Task 3: Cancel / Clear endpoint + cleared-container fragment
+
+**Files:**
+- Create: `templates/_summary_cleared.html`
+- Modify: `src/handlers/entries.rs` (new `SummarizeCleared` type + `summarize_cancel_form` handler)
+- Modify: `src/lib.rs` (route)
+- Test: `tests/summary_cancel.rs` (new integration test)
+
+- [ ] **Step 1: Create the cleared-container fragment template**
+
+Create `templates/_summary_cleared.html`:
+
+```html
+{# `POST /entries/{id}/summarize/cancel` response. Cancels any in-flight /
+   queued job and deletes the summary record, returning the summary container
+   to its empty (no-summary) state. Swaps ONLY `#rp-summary-container` so the
+   article body is untouched. #}
+<template data-swap-target="#rp-summary-container">
+    <div class="rp-summary-container" id="rp-summary-container" data-summary-container></div>
+</template>
+```
+
+- [ ] **Step 2: Add the `SummarizeCleared` response type**
+
+In `src/handlers/entries.rs`, directly after the `SummarizePending` `IntoResponse`
+impl (around line 81), add:
+
+```rust
+/// Response for `POST /entries/{id}/summarize/cancel`. Swaps
+/// `#rp-summary-container` back to its empty state after a cancel / clear.
+#[derive(Template)]
+#[template(path = "_summary_cleared.html")]
+pub struct SummarizeCleared;
+
+impl IntoResponse for SummarizeCleared {
+    fn into_response(self) -> Response {
+        match self.render() {
+            Ok(html) => Html(html).into_response(),
+            Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Add the `summarize_cancel_form` handler**
+
+In `src/handlers/entries.rs`, directly after `summarize_entry_form` (ends ~line
+639), add:
+
+```rust
+/// `POST /entries/{id}/summarize/cancel` — cancel an in-flight / queued
+/// summarization (or clear a failed one) and delete the record, returning the
+/// summary container to its empty state.
+///
+/// Cancel (in-flight) and Clear (failed) share this endpoint: both mean "stop
+/// and remove this summary". A failed record simply has no live token, so the
+/// registry lookup misses and we just delete. Ownership is enforced by
+/// `find_by_id_for_user`'s join constraint (404 otherwise).
+pub async fn summarize_cancel_form(
+    auth_user: PageAuthUser,
+    State(state): State<AppState>,
+    AxumPath(entry_id): AxumPath<i64>,
+) -> AppResult<SummarizeCleared> {
+    let user_id = auth_user.user.id;
+
+    // Validate ownership and delete the record in one write txn.
+    state
+        .db
+        .user(move |conn| {
+            entry::find_by_id_for_user(conn, user_id, entry_id)?
+                .ok_or(AppError::EntryNotFound)?;
+            entry_summary::delete(conn, user_id, entry_id)?;
+            Ok::<_, crate::error::AppError>(())
+        })
+        .await??;
+
+    // Cancel + drop any in-flight / queued token for this entry.
+    let token = {
+        let mut map = state.summary_cancels.lock().unwrap();
+        map.remove(&(user_id, entry_id))
+    };
+    if let Some(token) = token {
+        token.cancel();
+    }
+
+    state.summary_cache.remove(user_id, entry_id);
+    state.sidebar_cache.bust(user_id);
+
+    Ok(SummarizeCleared)
+}
+```
+
+> If `entry`, `entry_summary`, `PageAuthUser`, `AppError`, `AxumPath`, `State`,
+> `Template`, `Html`, `Response`, `StatusCode` are not already imported in this
+> file, they are — `summarize_entry_form` above uses all of them. No new `use`
+> lines needed.
+
+- [ ] **Step 4: Register the route**
+
+In `src/lib.rs`, directly after the existing `/entries/{id}/summarize` route
+(around line 207-209), add:
+
+```rust
+        .route(
+            "/entries/{id}/summarize/cancel",
+            post(handlers::entries::summarize_cancel_form),
+        )
+```
+
+- [ ] **Step 5: Write the failing integration test**
+
+Look at an existing integration test under `tests/` to copy the app/login
+harness (e.g. how a test boots `create_router(AppState{..})` and authenticates).
+Create `tests/summary_cancel.rs` mirroring that harness, with:
+
+```rust
+// Use the same test harness as the other tests/ files: build an AppState with
+// an in-memory DB + a real CancelRegistry, log in, seed an entry.
+//
+// Assertions (use the project's existing request helpers):
+// 1. Seed a `failed` summary for an owned entry, POST /entries/{id}/summarize/cancel,
+//    assert 200 and that entry_summary::find_by_user_and_entry returns None.
+// 2. POST /entries/{id}/summarize/cancel for an entry the user does NOT own
+//    returns 404.
+// 3. Insert a CancellationToken into state.summary_cancels for (user, entry),
+//    POST cancel, assert the token is now cancelled() and removed from the map.
+```
+
+Implement these three `#[tokio::test]` cases concretely against the harness you
+copied. The key assertions in code:
+
+```rust
+    // (1) record deleted
+    let gone = state
+        .db
+        .read_user(move |c| rdrs::models::entry_summary::find_by_user_and_entry(c, uid, eid))
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(gone.is_none());
+
+    // (3) token cancelled + removed
+    assert!(token.is_cancelled());
+    assert!(state.summary_cancels.lock().unwrap().get(&(uid, eid)).is_none());
+```
+
+- [ ] **Step 6: Run the test to verify it fails, then passes after wiring**
+
+Run: `RDRS_FAST_HASH=1 cargo nextest run -p rdrs --test summary_cancel 2>&1 | tail -25`
+Expected: FAIL first (route/handler missing) → after Steps 1-4, PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cargo fmt
+git add templates/_summary_cleared.html src/handlers/entries.rs src/lib.rs tests/summary_cancel.rs
+git commit -S -m "feat: POST /entries/{id}/summarize/cancel (cancel + clear)"
+```
+
+---
+
+## Task 4: Surface `summary_error` through the reading-pane builder
+
+**Files:**
+- Modify: `src/handlers/pages/mod.rs` (`ReadingPaneView` struct)
+- Modify: `src/handlers/entries.rs` (`resolve_summary` + `build_reading_pane_view`)
+
+- [ ] **Step 1: Add the field to `ReadingPaneView`**
+
+In `src/handlers/pages/mod.rs`, add to the `ReadingPaneView` struct after
+`pub summary_in_flight: bool,`:
+
+```rust
+    /// `Some(error_message)` when the latest summary attempt failed. Lets the
+    /// reading pane render the failed branch (error banner + Retry / Clear) and
+    /// distinguishes `failed` from "no summary" (both leave `summary_text` None
+    /// and `summary_in_flight` false).
+    pub summary_error: Option<String>,
+```
+
+- [ ] **Step 2: Extend `resolve_summary` to return the error**
+
+In `src/handlers/entries.rs`, change `resolve_summary`'s return type to a
+3-tuple and populate the failed branch:
+
+```rust
+async fn resolve_summary(
+    state: &AppState,
+    user_id: i64,
+    entry_id: i64,
+) -> AppResult<(Option<String>, bool, Option<String>)> {
+    if let Some(cached) = state.summary_cache.get(user_id, entry_id) {
+        match cached.status {
+            SummaryStatus::Completed => return Ok((cached.summary_text, false, None)),
+            SummaryStatus::Pending | SummaryStatus::Processing => return Ok((None, true, None)),
+            SummaryStatus::Failed => {
+                // Fall through to DB — a retry may have refreshed the row
+                // without yet updating the cache.
+            }
+        }
+    }
+    let db_entry = state
+        .db
+        .read_user(move |conn| entry_summary::find_by_user_and_entry(conn, user_id, entry_id))
+        .await??;
+    match db_entry {
+        Some(s) => match s.status {
+            SummaryStatus::Completed => Ok((s.summary_text, false, None)),
+            SummaryStatus::Pending | SummaryStatus::Processing => Ok((None, true, None)),
+            SummaryStatus::Failed => Ok((None, false, s.error_message)),
+        },
+        None => Ok((None, false, None)),
+    }
+}
+```
+
+- [ ] **Step 3: Pass `summary_error` into the `ReadingPaneView`**
+
+In `build_reading_pane_view` (the `ReadingPaneView { ... }` construction around
+line 223-253), update the `resolve_summary` destructuring and add the field:
+
+```rust
+    let (summary_text, summary_in_flight, summary_error) =
+        resolve_summary(state, user_id, entry_id).await?;
+```
+
+and in the struct initializer, after `summary_in_flight,`:
+
+```rust
+        summary_error,
+```
+
+- [ ] **Step 4: Build to verify it compiles**
+
+Run: `RDRS_FAST_HASH=1 cargo nextest run -p rdrs build_reading_pane 2>&1 | tail -15; cargo build 2>&1 | tail -15`
+Expected: compiles. (Template not yet using the field — that's Task 5; the
+field is simply unused-but-present, which is fine for a struct field.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+cargo fmt
+git add src/handlers/pages/mod.rs src/handlers/entries.rs
+git commit -S -m "feat: carry summary_error into ReadingPaneView"
+```
+
+---
+
+## Task 5: Reading-pane UI — Cancel button, failed branch, icon, CSS
+
+**Files:**
+- Modify: `templates/_icons.html`
+- Modify: `static/css/app.css`
+- Modify: `templates/_summarize_pending.html`
+- Modify: `templates/_reading_pane.html`
+
+- [ ] **Step 1: Add a `refresh` (retry) icon macro**
+
+In `templates/_icons.html`, add a new macro line (after the `revert` macro):
+
+```html
+{% macro refresh() %}<svg class="ico" viewBox="0 0 24 24" aria-hidden="true"><path d="M21 12a9 9 0 1 1-2.6-6.4"/><path d="M21 3v5h-5"/></svg>{% endmacro %}
+```
+
+- [ ] **Step 2: Add the `.summary-error-banner` CSS**
+
+In `static/css/app.css`, directly after the `.summary-box blockquote { ... }`
+rule (ends ~line 1735), add:
+
+```css
+/* Failed-summary banner — mirrors .banner--error's tinted wash + error
+   left-border, sized to sit inside the summary box. */
+.summary-error-banner {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--space-2);
+    font-size: var(--font-sm);
+    line-height: 1.5;
+    color: var(--color-text);
+    background: light-dark(rgba(185, 28, 28, 0.06), rgba(248, 113, 113, 0.08));
+    border: 1px solid light-dark(rgba(185, 28, 28, 0.20), rgba(248, 113, 113, 0.25));
+    border-left: var(--border-accent-width) solid var(--color-error);
+    border-radius: var(--radius-md);
+    padding: var(--space-3) var(--space-4);
+}
+.summary-error-banner .action-icon {
+    flex: none;
+    color: var(--color-error);
+    display: inline-flex;
+}
+```
+
+- [ ] **Step 3: Add the Cancel button to the in-flight fragment**
+
+Replace the body of `templates/_summarize_pending.html` with (keep the leading
+comment), adding the Cancel form inside the box:
+
+```html
+{# `POST /entries/{id}/summarize` response. Swaps ONLY the summary
+   container so a Fetch-Full-Content view stays put — the reading
+   pane's `<article>` is not touched. The full reading-pane render
+   on next page load will surface the completed summary once the
+   background worker finishes. #}
+{%- import "_icons.html" as icons -%}
+<template data-swap-target="#rp-summary-container">
+    <div class="rp-summary-container" id="rp-summary-container" data-summary-container>
+        <div class="summary-box">
+            <div class="summary-actions">
+                <form method="post" action="/entries/{{ id }}/summarize/cancel" data-swap="#rp-summary-container">
+                    <button type="submit" class="rp-action" aria-label="Cancel summarization"><span class="action-icon" aria-hidden="true">{% call icons::close() %}{% endcall %}</span><span class="action-label">Cancel</span></button>
+                </form>
+            </div>
+            <p class="muted">Summarizing… (refresh to see the result)</p>
+        </div>
+    </div>
+</template>
+```
+
+> `SummarizePending` is a unit struct with no fields, so `{{ id }}` is not
+> available. Add an `id` field to it. In `src/handlers/entries.rs` change
+> `pub struct SummarizePending;` to `pub struct SummarizePending { pub id: i64 }`
+> and update the two construction sites in `summarize_entry_form`
+> (`Ok(SummarizePending)` → `Ok(SummarizePending { id: entry_id })`). Build to
+> confirm.
+
+- [ ] **Step 4: Add the in-flight Cancel button + failed branch to the reading pane**
+
+In `templates/_reading_pane.html`, replace the `#rp-summary-container` block
+(lines 80-102) with the three-branch version (in-flight gets a Cancel button;
+new failed branch with Retry + Clear + error banner):
+
+```html
+        <div class="rp-summary-container" id="rp-summary-container" data-summary-container>
+            {% if pane.summary_in_flight %}
+            <div class="summary-box">
+                <div class="summary-actions">
+                    <form method="post" action="/entries/{{ pane.id }}/summarize/cancel" data-swap="#rp-summary-container">
+                        <button type="submit" class="rp-action" aria-label="Cancel summarization"><span class="action-icon" aria-hidden="true">{% call icons::close() %}{% endcall %}</span><span class="action-label">Cancel</span></button>
+                    </form>
+                </div>
+                <p class="muted">Summarizing… (refresh to see the result)</p>
+            </div>
+            {% else if let Some(summary) = pane.summary_text.as_ref() %}
+            <div class="summary-box">
+                <div class="summary-actions">
+                    <button type="button" class="rp-action" data-summary-copy aria-label="Copy summary"><span class="action-icon" aria-hidden="true">{% call icons::copy() %}{% endcall %}</span><span class="action-label">Copy</span></button>
+                    <button type="button" class="rp-action" data-summary-dismiss data-entry-id="{{ pane.id }}" aria-label="Dismiss summary"><span class="action-icon" aria-hidden="true">{% call icons::close() %}{% endcall %}</span><span class="action-label">Dismiss</span></button>
+                </div>
+                <div class="summary-header">
+                    <div class="summary-title" data-summary-title>{{ pane.title }}</div>
+                    {% if let Some(link) = pane.link.as_ref() %}
+                    <a class="summary-link" href="{{ link }}" target="_blank" rel="noopener noreferrer" data-summary-link>{{ link }}</a>
+                    {% endif %}
+                </div>
+                <blockquote class="rp-summary-content">{{ summary|safe }}</blockquote>
+            </div>
+            {% else if let Some(error) = pane.summary_error.as_ref() %}
+            <div class="summary-box">
+                <div class="summary-actions">
+                    <form method="post" action="/entries/{{ pane.id }}/summarize" data-swap="#rp-summary-container">
+                        <button type="submit" class="rp-action" aria-label="Retry summarization"><span class="action-icon" aria-hidden="true">{% call icons::refresh() %}{% endcall %}</span><span class="action-label">Retry</span></button>
+                    </form>
+                    <form method="post" action="/entries/{{ pane.id }}/summarize/cancel" data-swap="#rp-summary-container">
+                        <button type="submit" class="rp-action" aria-label="Clear failed summary"><span class="action-icon" aria-hidden="true">{% call icons::close() %}{% endcall %}</span><span class="action-label">Clear</span></button>
+                    </form>
+                </div>
+                <div class="summary-error-banner" data-summary-error><span class="action-icon" aria-hidden="true">{% call icons::close() %}{% endcall %}</span><span>Summarization failed: {{ error }}</span></div>
+            </div>
+            {% endif %}
+        </div>
+```
+
+> The error banner reuses the `close` icon as a generic marker tinted by
+> `.summary-error-banner .action-icon { color: var(--color-error) }`. The
+> `data-summary-error` hook is for the e2e selector in Task 6.
+
+- [ ] **Step 5: Rebuild assets (mandatory before any E2E / visual check)**
+
+Run: `cargo build 2>&1 | tail -15`
+Expected: compiles (Askama validates the templates at build time — a typo'd
+field or macro fails here).
+
+- [ ] **Step 6: Commit**
+
+```bash
+cargo fmt
+git add templates/_icons.html static/css/app.css templates/_summarize_pending.html templates/_reading_pane.html src/handlers/entries.rs
+git commit -S -m "feat: reading-pane Cancel button + failed-state banner with Retry/Clear"
+```
+
+---
+
+## Task 6: E2E coverage for the failed state
+
+**Files:**
+- Modify: `e2e/support/seed.js` (failed-summary seeder)
+- Modify: `e2e/steps/entries.steps.js` (or the steps file backing `reading.feature`)
+- Modify: `e2e/features/reading.feature`
+
+> Only the **failed** state is e2e-tested: `find_incomplete` re-queues only
+> `pending`/`processing` rows on startup, so a seeded `failed` row is stable
+> (the worker won't touch it and flip it). The in-flight Cancel button is
+> covered by the Rust handler test (Task 3); seeding a `pending` row for e2e
+> would race the recovery worker.
+
+- [ ] **Step 1: Add a failed-summary seeder**
+
+In `e2e/support/seed.js`, next to `insertSummary` (~line 117), add:
+
+```javascript
+  insertFailedSummary(entryId, userId, errorMessage = "Kagi API returned 503.") {
+    this.db
+      .prepare(
+        `INSERT OR IGNORE INTO entry_summary (user_id, entry_id, status, error_message)
+         VALUES (?, ?, 'failed', ?)`,
+      )
+      .run(userId, entryId, errorMessage);
+  }
+```
+
+- [ ] **Step 2: Add the Given step**
+
+In the steps file that defines `the entry titled "X" has a summary` (find it:
+`rg -n "has a summary" e2e/steps`), add a sibling step. Mirror the existing
+step's lookup of the entry id + user id, then call the new seeder:
+
+```javascript
+Given('the entry titled {string} has a failed summary', async function (title) {
+  const entryId = this.seed.entryIdByTitle(title); // reuse however the sibling step resolves it
+  this.seed.insertFailedSummary(entryId, this.userId);
+});
+```
+
+> Match the exact helper names the sibling `has a summary` step uses to resolve
+> `entryId` / `userId` in this codebase — copy that line verbatim, only swapping
+> `insertSummary` for `insertFailedSummary`.
+
+- [ ] **Step 3: Add the scenario**
+
+In `e2e/features/reading.feature`, add after the existing summary scenarios
+(~line 46):
+
+```gherkin
+  Scenario: Failed summary shows an error with Retry and Clear
+    Given Kagi is configured
+    And the entry titled "Test Entry 3" has a failed summary
+    When I open the entry titled "Test Entry 3"
+    Then I see the summary error banner
+    And I see a "Retry" summary action
+    And I see a "Clear" summary action
+    When I click the "Clear" summary action
+    Then I do not see the summary error banner
+```
+
+> Reuse existing steps where they already exist (`Kagi is configured` →
+> `configureKagi`; "open the entry titled" likely exists for the reading pane).
+> For the assertion steps, add thin steps keyed off selectors:
+> `[data-summary-error]` for the banner, and button text for the actions
+> (`page.getByRole('button', { name })`). The "click ... summary action" step
+> submits the form and waits for the `#rp-summary-container` swap.
+
+- [ ] **Step 4: Add the missing assertion/click steps**
+
+In the same steps file, add (adjust the `World`/`page` accessor to match the
+file's convention):
+
+```javascript
+Then('I see the summary error banner', async function () {
+  await expect(this.page.locator('[data-summary-error]')).toBeVisible();
+});
+
+Then('I do not see the summary error banner', async function () {
+  await expect(this.page.locator('[data-summary-error]')).toHaveCount(0);
+});
+
+Then('I see a {string} summary action', async function (label) {
+  await expect(
+    this.page.locator('#rp-summary-container').getByRole('button', { name: label }),
+  ).toBeVisible();
+});
+
+When('I click the {string} summary action', async function (label) {
+  await this.page
+    .locator('#rp-summary-container')
+    .getByRole('button', { name: label })
+    .click();
+  await this.page.waitForLoadState('networkidle');
+});
+```
+
+- [ ] **Step 5: Rebuild + regenerate specs + run the scenario**
+
+```bash
+cargo build                       # embed the new templates/CSS
+cd e2e && npx bddgen
+npx playwright test --grep "Failed summary shows an error"
+```
+Expected: the scenario passes. If a step is reported undefined, align its text
+with the existing step file's phrasing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd .. && git add e2e/support/seed.js e2e/features/reading.feature e2e/steps
+git commit -S -m "test(e2e): failed-summary banner with Retry/Clear"
+```
+
+---
+
+## Task 7: Docs + screenshots check
+
+**Files:**
+- Modify: `ARCHITECTURE.md` (and/or the `summary_worker.rs` module doc comment)
+- Possibly: `screenshots/` (only if a default capture changed)
+
+- [ ] **Step 1: Update prose that claims no cancellation/timeout**
+
+Run: `rg -n -i "no (cancel|timeout)|cannot be (cancel|abort)|无|無取消" ARCHITECTURE.md src/services/summary_worker.rs`
+Update any sentence stating the summary worker has no cancellation or no
+timeout to reflect: per-entry cancellation via the registry + a 90 s Kagi
+timeout (timeout → `failed`). Keep edits to the affected sentences only.
+
+- [ ] **Step 2: Regenerate screenshots and check for diffs**
+
+```bash
+cargo build
+cd e2e && npm run screenshots && cd ..
+git status --porcelain screenshots/
+```
+Expected: likely **no** change — the default captures are the unread list +
+reading pane (completed/empty) and the keyboard-help overlay, none of which show
+the in-flight Cancel or failed states. If `git status` shows modified images,
+include them in the commit; otherwise skip.
+
+- [ ] **Step 3: Final full verification**
+
+```bash
+cargo fmt --all -- --check
+cargo clippy -- -D warnings 2>&1 | tail -15
+RDRS_FAST_HASH=1 cargo nextest run 2>&1 | tail -25
+cd e2e && npx playwright test --grep-invert "@skip" 2>&1 | tail -25; cd ..
+```
+Expected: fmt clean, no clippy warnings, all Rust tests pass, e2e green.
+
+- [ ] **Step 4: Commit any doc/screenshot changes**
+
+```bash
+git add ARCHITECTURE.md src/services/summary_worker.rs
+# add screenshots/ only if Step 2 produced diffs
+git commit -S -m "docs: note summary worker cancellation + timeout"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** cancel pending+processing (Tasks 2-3 + `run_summary` Cancelled path), delete-on-cancel (Task 3), 90 s timeout→failed (Task 1-2), reading-pane-only controls (Task 5), failed banner = `.banner--error` palette (Task 5), Retry reuses `/summarize` (Task 5 form action), Cancel/Clear share `/summarize/cancel` (Tasks 3,5), `summary_error` field (Task 4), tests + e2e (Tasks 1,3,6), docs/screenshots (Task 7). All covered.
+- **Type consistency:** `CancelRegistry = Arc<Mutex<HashMap<(i64,i64), CancellationToken>>>` used identically in worker, `AppState`, `main.rs`, and handler. `SummaryOutcome { Completed, Failed, Cancelled }` matches the worker `match`. `resolve_summary` returns a 3-tuple consumed by the single destructuring in `build_reading_pane_view`. `SummarizePending { id }` updated at both construction sites.
+- **Race safety:** `run_summary` uses `biased` + `token.cancelled()` first, so a cancelled job never writes `completed`/`failed`; the handler's `delete` serializes after `set_processing` on the single write connection.

--- a/docs/superpowers/specs/2026-06-15-summarization-cancel-retry-design.md
+++ b/docs/superpowers/specs/2026-06-15-summarization-cancel-retry-design.md
@@ -1,0 +1,212 @@
+# Summarization: Cancel, Timeout & Failed-State Recovery
+
+**Date:** 2026-06-15
+**Status:** Approved (design)
+
+## Problem
+
+AI summarization currently cannot be stopped once requested, and a failed
+summary has no recovery path in the UI:
+
+- The summary worker is a single Tokio task draining an MPSC channel one job at
+  a time. There is **no per-job cancellation handle** — only a global
+  graceful-shutdown `CancellationToken`. A job that is queued or in-flight
+  cannot be aborted.
+- `summarize_with_kagi` has **no timeout**. A hung Kagi request occupies the one
+  worker indefinitely, blocking every user's subsequent summaries.
+- In the reading pane, the `failed` status renders **nothing** — the
+  `#rp-summary-container` only handles `summary_in_flight` and the
+  completed-`summary_text` branches. Users cannot see the error, retry, or clear
+  it from the UI. (A `DELETE /api/entries/{id}/summary` JSON endpoint exists, but
+  it is only wired to the completed-summary "Dismiss" button via JS.)
+
+## Goals
+
+1. Allow an in-progress or queued summarization to be **cancelled** from the UI.
+2. Give the **failed** state a visible error message plus **Retry** and
+   **Clear** actions in the UI.
+3. Add a request **timeout** so a hung Kagi call cannot wedge the worker.
+
+## Non-Goals
+
+- No `cancelled` status / no schema migration — cancelling deletes the record.
+- No controls in the list view; the list `summary-badge-*` stays indicator-only.
+- No change to the completed-summary "Dismiss" path (existing JS + DELETE API).
+- No parallelism / priority changes to the worker.
+
+## Behavioural Decisions
+
+| Item | Decision |
+|---|---|
+| Cancel scope | Both `pending` (queued) and `processing` (in-flight) |
+| State after cancel | Record deleted → back to "no summary" (no badge) |
+| Timeout | Kagi request times out at **90 s** → `failed` with message `Summarization timed out` |
+| Control placement | Reading pane only |
+| Failed presentation | Banner-style error box reusing the app's `--color-error` palette (mirrors `.banner--error`) |
+
+## Architecture
+
+### Backend — cancellation registry
+
+Add a shared, per-entry token registry to `AppState`:
+
+```rust
+// (user_id, entry_id) -> CancellationToken
+summary_cancels: Arc<Mutex<HashMap<(i64, i64), CancellationToken>>>
+```
+
+Reuses `tokio_util::sync::CancellationToken` (already used for worker shutdown).
+The registry is created in `main.rs` and cloned into both the worker and
+`AppState`. A `std::sync::Mutex` is sufficient — critical sections are a single
+insert / remove / clone.
+
+Because processing is sequential there is at most one in-flight job, but the
+channel can hold up to 100 queued jobs, so a per-key registry (not a single
+"current job" slot) is required to cancel a *specific* queued entry.
+
+### Backend — worker changes (`services/summary_worker.rs`)
+
+`process_summary_job` becomes:
+
+1. Get-or-insert the `CancellationToken` for `(user_id, entry_id)` from the
+   registry. (Startup-restored jobs from `find_incomplete` flow through here
+   too — no special-casing needed.)
+2. If `token.is_cancelled()` → the cancel handler already cleaned up; remove the
+   token and skip to the next job.
+3. `entry_summary::set_processing` + `cache.set_processing`.
+4. Race cancellation against the timed Kagi call:
+
+   ```rust
+   tokio::select! {
+       _ = token.cancelled() => {
+           // Handler owns cleanup (delete + cache remove + sidebar bust).
+           // Just drop the Kagi future; never write a result back.
+       }
+       res = tokio::time::timeout(SUMMARY_TIMEOUT, summarize_with_kagi(...)) => {
+           match res {
+               Ok(Ok(text)) => /* set_completed + cache + sidebar bust */,
+               Ok(Err(e))   => /* set_failed(e) */,
+               Err(_elapsed) => /* set_failed("Summarization timed out") */,
+           }
+       }
+   }
+   ```
+
+   `SUMMARY_TIMEOUT` = `Duration::from_secs(90)`, a module constant.
+5. Remove the token from the registry on completion / failure.
+
+**Race safety:** once `token.cancelled()` is ready, `tokio::select!` drops the
+Kagi branch, so `set_completed`/`set_failed` never run for a cancelled job. DB
+writes serialize on the single write connection, so the handler's `delete` lands
+after any in-flight `set_processing`; the net result is a deleted record.
+
+### Backend — endpoints (`handlers/entries.rs`)
+
+| Action | Endpoint | Behaviour |
+|---|---|---|
+| **Retry** | reuse `POST /entries/{id}/summarize` | Existing `upsert_pending` resets `failed` → `pending`, clears `summary_text`/`error_message`, re-enqueues. No new code. |
+| **Cancel / Clear** | **new** `POST /entries/{id}/summarize/cancel` | Validate ownership (`find_by_id_for_user` → 404). If a token exists, `token.cancel()` and remove it. `entry_summary::delete` + `summary_cache.remove` + `sidebar_cache.bust`. Return the empty `#rp-summary-container` fragment. |
+
+Cancel and Clear share one endpoint: both mean "stop and remove this summary." A
+`failed` record simply has no live token, so the token lookup misses and the
+handler just deletes. SSR form-POST; no new JS.
+
+### Frontend
+
+**`ReadingPaneView` (`handlers/pages/mod.rs`)** — add:
+
+```rust
+pub summary_error: Option<String>,  // Some(error_message) ⟹ failed
+```
+
+`Some` distinguishes `failed` from "no summary" (both currently
+`summary_text = None`, `summary_in_flight = false`). The builder populates it
+with `entry_summary.error_message` when status is `Failed`.
+
+**`templates/_reading_pane.html`** — `#rp-summary-container` becomes three
+branches (priority order):
+
+1. `summary_in_flight` → `summary-box` with `Summarizing… (refresh to see the
+   result)` **plus a Cancel button** (`rp-action`, form `POST
+   /entries/{id}/summarize/cancel`, `data-swap="#rp-summary-container"`).
+2. `summary_text` (completed) → **unchanged** (Copy / Dismiss).
+3. `summary_error` (failed) → `summary-box` containing:
+   - `summary-actions` with **Retry** (form `POST /entries/{id}/summarize`) and
+     **Clear** (form `POST /entries/{id}/summarize/cancel`), both `rp-action`,
+     buttons left-aligned, each `data-swap="#rp-summary-container"`.
+   - a **`.summary-error-banner`** element showing the error message.
+
+**`templates/_summarize_pending.html`** — add the Cancel button to the in-flight
+fragment so a freshly-queued summary is immediately cancellable.
+
+**New fragment** — the cancel/clear response: an empty `#rp-summary-container`
+(`<template data-swap-target="#rp-summary-container">` wrapping the empty
+container) so the swap helper returns the pane to the no-summary state.
+
+**`static/css/app.css`** — add `.summary-error-banner`, mirroring
+`.banner--error`:
+
+```css
+.summary-error-banner {
+    display: flex; align-items: flex-start; gap: var(--space-2);
+    font-size: var(--font-sm); color: var(--color-text); line-height: 1.5;
+    background: light-dark(rgba(185,28,28,0.06), rgba(248,113,113,0.08));
+    border: 1px solid light-dark(rgba(185,28,28,0.20), rgba(248,113,113,0.25));
+    border-left: var(--border-accent-width) solid var(--color-error);
+    border-radius: var(--radius-md);
+    padding: var(--space-3) var(--space-4);
+}
+.summary-error-banner .action-icon { color: var(--color-error); flex: none; }
+```
+
+**`templates/_icons.html`** — add a `refresh`/`retry` SVG icon for the Retry
+button (Cancel/Clear reuse the existing `close` icon; the in-flight Cancel and
+failed Clear both use `close`).
+
+## Testing
+
+**Rust (`cargo nextest run`, `RDRS_FAST_HASH=1` locally):**
+
+- `POST /entries/{id}/summarize/cancel`:
+  - pending path — record deleted, cache cleared, returns empty container.
+  - processing path — token cancelled, record deleted, no result written.
+  - failed path (Clear) — record deleted.
+  - non-owner → 404.
+- Worker: a cancelled token causes the job to be skipped / aborted with no
+  `completed`/`failed` write.
+- Worker: a Kagi call exceeding the timeout transitions the record to `failed`
+  with the timeout message. (Inject a slow/stub summarizer or a small test-only
+  timeout.)
+- Retry: re-`POST /summarize` on a `failed` record resets it to `pending`.
+
+**E2E (Playwright BDD, `e2e/`):**
+
+- Failed summary renders the error banner with Retry + Clear; Clear removes the
+  box; Retry returns it to the in-flight state.
+- In-flight summary shows a Cancel button; cancelling returns the pane to the
+  no-summary state.
+
+## Build & Docs
+
+- UI changes → `cargo build` then `cd e2e && npm run screenshots`; refresh the
+  four `screenshots/` images **only if** a default screenshot scenario is
+  affected (the generator captures the unread list + reading pane and the
+  keyboard-help overlay — the summary states are not in the default capture, so
+  screenshots likely do **not** change; verify and update only if they do).
+- Update doc comments / `ARCHITECTURE.md` text that states the summary worker
+  has no cancellation and no timeout.
+
+## Files Touched (summary)
+
+- `src/main.rs` — create the cancel registry; pass it to the worker.
+- `src/lib.rs` — `AppState.summary_cancels` field; register `POST
+  /entries/{id}/summarize/cancel` next to the existing `summarize_entry_form`
+  route (line ~208).
+- `src/services/summary_worker.rs` — get-or-insert token, `select!` with
+  timeout + cancellation, token cleanup, `SUMMARY_TIMEOUT` const.
+- `src/handlers/entries.rs` — new `summarize_cancel_form` handler.
+- `src/handlers/pages/mod.rs` — `ReadingPaneView.summary_error` + builder fill.
+- `templates/_reading_pane.html`, `templates/_summarize_pending.html`,
+  new cancel-response fragment, `templates/_icons.html`.
+- `static/css/app.css` — `.summary-error-banner`.
+- Tests under `tests/` + `e2e/features/`.

--- a/e2e/features/reading.feature
+++ b/e2e/features/reading.feature
@@ -45,6 +45,17 @@ Feature: Reading entries
     When I open the inbox
     Then the sidebar Summarized item shows a count of "1"
 
+  Scenario: Failed summary shows an error with Retry and Clear
+    Given the user has Kagi configured
+    And the entry titled "Test Entry 3" has a failed summary
+    When I open the inbox
+    And I click the entry titled "Test Entry 3"
+    Then I see the summary error banner
+    And I see a "Retry" summary action
+    And I see a "Clear" summary action
+    When I click the "Clear" summary action
+    Then I do not see the summary error banner
+
   Scenario: Single-feed view filters by that feed
     When I open the entries page for feed "Reading Feed"
     Then I see 5 entries in the entry list

--- a/e2e/steps/entries.steps.js
+++ b/e2e/steps/entries.steps.js
@@ -43,6 +43,11 @@ Given("the entry titled {string} has a summary", async ({ seed, currentUser }, t
   seed.insertSummary(seed.findEntryIdByTitle(userId, title), userId);
 });
 
+Given("the entry titled {string} has a failed summary", async ({ seed, currentUser }, title) => {
+  const userId = seed.getUserId(currentUser.username);
+  seed.insertFailedSummary(seed.findEntryIdByTitle(userId, title), userId);
+});
+
 Given("all entries in category {string} are marked read", async ({ seed, currentUser }, name) => {
   const userId = seed.getUserId(currentUser.username);
   seed.markCategoryRead(userId, name);
@@ -445,4 +450,26 @@ Then("the help overlay descriptions are aligned", async ({ page }) => {
     const { x } = await descs.nth(i).boundingBox();
     expect(Math.abs(x - x0)).toBeLessThan(1);
   }
+});
+
+Then("I see the summary error banner", async ({ page }) => {
+  await expect(page.locator("[data-summary-error]")).toBeVisible();
+});
+
+Then("I do not see the summary error banner", async ({ page }) => {
+  await expect(page.locator("[data-summary-error]")).toHaveCount(0);
+});
+
+Then("I see a {string} summary action", async ({ page }, label) => {
+  await expect(
+    page.locator("#rp-summary-container").getByRole("button", { name: label }),
+  ).toBeVisible();
+});
+
+When("I click the {string} summary action", async ({ page }, label) => {
+  await page
+    .locator("#rp-summary-container")
+    .getByRole("button", { name: label })
+    .click();
+  await page.waitForLoadState("networkidle");
 });

--- a/e2e/steps/entries.steps.js
+++ b/e2e/steps/entries.steps.js
@@ -471,5 +471,7 @@ When("I click the {string} summary action", async ({ page }, label) => {
     .locator("#rp-summary-container")
     .getByRole("button", { name: label })
     .click();
-  await page.waitForLoadState("networkidle");
+  // Wait for the #rp-summary-container swap to settle rather than using
+  // networkidle (flaky with the app's background sidebar polling).
+  await page.locator("[data-summary-error]").waitFor({ state: "detached" });
 });

--- a/e2e/support/seed.js
+++ b/e2e/support/seed.js
@@ -126,6 +126,18 @@ export class SeedHelper {
     }
   }
 
+  insertFailedSummary(entryId, userId, errorMessage = "Kagi API returned 503.") {
+    const db = new Database(this.dbPath);
+    try {
+      db.prepare(
+        `INSERT OR IGNORE INTO entry_summary (user_id, entry_id, status, error_message)
+         VALUES (?, ?, 'failed', ?)`
+      ).run(userId, entryId, errorMessage);
+    } finally {
+      db.close();
+    }
+  }
+
   configureKagi(userId, sessionToken = "e2e-test-token") {
     // Seeds a fake Kagi config so the reading-pane Summarize button is rendered.
     // The token is bogus — actual Kagi calls will fail at request time, which

--- a/src/handlers/entries.rs
+++ b/src/handlers/entries.rs
@@ -69,7 +69,9 @@ impl IntoResponse for ReadingPaneWithFlash {
 /// stays put.
 #[derive(Template)]
 #[template(path = "_summarize_pending.html")]
-pub struct SummarizePending;
+pub struct SummarizePending {
+    pub id: i64,
+}
 
 impl IntoResponse for SummarizePending {
     fn into_response(self) -> Response {
@@ -652,7 +654,7 @@ pub async fn summarize_entry_form(
         })
         .await;
 
-    Ok(SummarizePending)
+    Ok(SummarizePending { id: entry_id })
 }
 
 /// `POST /entries/{id}/summarize/cancel` — cancel an in-flight / queued

--- a/src/handlers/entries.rs
+++ b/src/handlers/entries.rs
@@ -80,6 +80,21 @@ impl IntoResponse for SummarizePending {
     }
 }
 
+/// Response for `POST /entries/{id}/summarize/cancel`. Swaps
+/// `#rp-summary-container` back to its empty state after a cancel / clear.
+#[derive(Template)]
+#[template(path = "_summary_cleared.html")]
+pub struct SummarizeCleared;
+
+impl IntoResponse for SummarizeCleared {
+    fn into_response(self) -> Response {
+        match self.render() {
+            Ok(html) => Html(html).into_response(),
+            Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+        }
+    }
+}
+
 /// `GET /entries/{id}/fragment` — returns the reading-pane HTML fragment for
 /// the given entry. The entry must belong to the authenticated user; otherwise
 /// a 404 is returned (same semantics as the JSON `/api/entries/{id}` endpoint
@@ -636,6 +651,46 @@ pub async fn summarize_entry_form(
         .await;
 
     Ok(SummarizePending)
+}
+
+/// `POST /entries/{id}/summarize/cancel` — cancel an in-flight / queued
+/// summarization (or clear a failed one) and delete the record, returning the
+/// summary container to its empty state.
+///
+/// Cancel (in-flight) and Clear (failed) share this endpoint: both mean "stop
+/// and remove this summary". A failed record simply has no live token, so the
+/// registry lookup misses and we just delete. Ownership is enforced by
+/// `find_by_id_for_user`'s join constraint (404 otherwise).
+pub async fn summarize_cancel_form(
+    auth_user: PageAuthUser,
+    State(state): State<AppState>,
+    AxumPath(entry_id): AxumPath<i64>,
+) -> AppResult<SummarizeCleared> {
+    let user_id = auth_user.user.id;
+
+    // Validate ownership and delete the record in one write txn.
+    state
+        .db
+        .user(move |conn| {
+            entry::find_by_id_for_user(conn, user_id, entry_id)?.ok_or(AppError::EntryNotFound)?;
+            entry_summary::delete(conn, user_id, entry_id)?;
+            Ok::<_, crate::error::AppError>(())
+        })
+        .await??;
+
+    // Cancel + drop any in-flight / queued token for this entry.
+    let token = {
+        let mut map = state.summary_cancels.lock().unwrap();
+        map.remove(&(user_id, entry_id))
+    };
+    if let Some(token) = token {
+        token.cancel();
+    }
+
+    state.summary_cache.remove(user_id, entry_id);
+    state.sidebar_cache.bust(user_id);
+
+    Ok(SummarizeCleared)
 }
 
 /// `POST /entries/{id}/fetch-full-content` — fetch the source article from

--- a/src/handlers/entries.rs
+++ b/src/handlers/entries.rs
@@ -235,7 +235,8 @@ pub(crate) async fn build_reading_pane_view(
         proxy_base_url,
     );
 
-    let (summary_text, summary_in_flight) = resolve_summary(state, user_id, entry_id).await?;
+    let (summary_text, summary_in_flight, summary_error) =
+        resolve_summary(state, user_id, entry_id).await?;
 
     let published_at = ewf.entry.published_at;
     Ok(ReadingPaneView {
@@ -262,28 +263,29 @@ pub(crate) async fn build_reading_pane_view(
         is_starred: ewf.entry.starred_at.is_some(),
         summary_text,
         summary_in_flight,
+        summary_error,
         has_kagi,
         has_save,
         is_full_content: false,
     })
 }
 
-/// Resolve `(summary_text, summary_in_flight)` for an entry. Reads the
-/// in-memory cache first; on miss or terminal-failed state falls back to
-/// the `entry_summary` table so a completed summary persisted in a
-/// previous session is still surfaced.
+/// Resolve `(summary_text, summary_in_flight, summary_error)` for an entry.
+/// Reads the in-memory cache first; on miss or terminal-failed state falls back
+/// to the `entry_summary` table so a completed summary persisted in a previous
+/// session is still surfaced.
 async fn resolve_summary(
     state: &AppState,
     user_id: i64,
     entry_id: i64,
-) -> AppResult<(Option<String>, bool)> {
+) -> AppResult<(Option<String>, bool, Option<String>)> {
     if let Some(cached) = state.summary_cache.get(user_id, entry_id) {
         match cached.status {
-            SummaryStatus::Completed => return Ok((cached.summary_text, false)),
-            SummaryStatus::Pending | SummaryStatus::Processing => return Ok((None, true)),
+            SummaryStatus::Completed => return Ok((cached.summary_text, false, None)),
+            SummaryStatus::Pending | SummaryStatus::Processing => return Ok((None, true, None)),
             SummaryStatus::Failed => {
-                // Fall through to DB — the DB row may have been refreshed
-                // by a retry that hasn't been written into the cache yet.
+                // Fall through to DB — a retry may have refreshed the row
+                // without yet updating the cache.
             }
         }
     }
@@ -293,11 +295,11 @@ async fn resolve_summary(
         .await??;
     match db_entry {
         Some(s) => match s.status {
-            SummaryStatus::Completed => Ok((s.summary_text, false)),
-            SummaryStatus::Pending | SummaryStatus::Processing => Ok((None, true)),
-            SummaryStatus::Failed => Ok((None, false)),
+            SummaryStatus::Completed => Ok((s.summary_text, false, None)),
+            SummaryStatus::Pending | SummaryStatus::Processing => Ok((None, true, None)),
+            SummaryStatus::Failed => Ok((None, false, s.error_message)),
         },
-        None => Ok((None, false)),
+        None => Ok((None, false, None)),
     }
 }
 

--- a/src/handlers/pages/mod.rs
+++ b/src/handlers/pages/mod.rs
@@ -104,6 +104,11 @@ pub struct ReadingPaneView {
     pub is_starred: bool,
     pub summary_text: Option<String>,
     pub summary_in_flight: bool,
+    /// `Some(error_message)` when the latest summary attempt failed. Lets the
+    /// reading pane render the failed branch (error banner + Retry / Clear) and
+    /// distinguishes `failed` from "no summary" (both leave `summary_text` None
+    /// and `summary_in_flight` false).
+    pub summary_error: Option<String>,
     pub has_kagi: bool,
     pub has_save: bool,
     /// `true` after `POST /entries/{id}/fetch-full-content` succeeds —

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,6 +209,10 @@ pub fn create_router(state: AppState) -> Router {
             post(handlers::entries::summarize_entry_form),
         )
         .route(
+            "/entries/{id}/summarize/cancel",
+            post(handlers::entries::summarize_cancel_form),
+        )
+        .route(
             "/entries/{id}/fetch-full-content",
             post(handlers::entries::fetch_full_content_form),
         )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@ pub struct AppState {
     pub summary_cache: Arc<SummaryCache>,
     pub summary_tx: mpsc::Sender<SummaryJob>,
     pub sidebar_cache: Arc<SidebarCache>,
+    pub summary_cancels: services::CancelRegistry,
 }
 
 pub fn create_router(state: AppState) -> Router {

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,12 +53,17 @@ async fn main() {
     // Create sidebar cache
     let sidebar_cache = Arc::new(services::SidebarCache::default());
 
+    // Per-entry cancellation tokens for summary jobs (cancel/abort support)
+    let summary_cancels: rdrs::services::CancelRegistry =
+        std::sync::Arc::new(std::sync::Mutex::new(std::collections::HashMap::new()));
+
     // Start summary worker
     let summary_worker_handle = services::start_summary_worker(
         summary_rx,
         summary_cache.clone(),
         sidebar_cache.clone(),
         db.clone(),
+        summary_cancels.clone(),
         cancel_token.clone(),
     );
 
@@ -86,6 +91,7 @@ async fn main() {
         summary_cache,
         summary_tx,
         sidebar_cache,
+        summary_cancels,
     };
 
     // Start background sync task

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -35,5 +35,6 @@ pub use summarize::KagiConfig;
 pub use summary_cache::{create_summary_cache, SummaryCache, SummaryCacheEntry, SummaryStatus};
 pub use summary_cleanup::start_cleanup_worker;
 pub use summary_worker::{
-    create_summary_channel, recover_incomplete_jobs, start_summary_worker, SummaryJob,
+    create_summary_channel, recover_incomplete_jobs, start_summary_worker, CancelRegistry,
+    SummaryJob,
 };

--- a/src/services/summary_worker.rs
+++ b/src/services/summary_worker.rs
@@ -1,4 +1,5 @@
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use tokio::sync::mpsc;
@@ -9,13 +10,9 @@ use tokio_util::sync::CancellationToken;
 /// request would otherwise occupy the single worker indefinitely and block
 /// every user's queued summaries. NEVER lower this in production without
 /// confirming Kagi's worst-case latency.
-// allow(dead_code): wired into the worker loop in the next task
-#[allow(dead_code)]
 const SUMMARY_TIMEOUT: Duration = Duration::from_secs(90);
 
 /// Result of racing a summarization future against cancellation + timeout.
-// allow(dead_code): variants consumed by the worker loop wired up in the next task
-#[allow(dead_code)]
 pub(crate) enum SummaryOutcome {
     Completed(String),
     Failed(String),
@@ -27,8 +24,6 @@ pub(crate) enum SummaryOutcome {
 /// token is already cancelled. On timeout the future is dropped (the in-flight
 /// HTTP request is aborted) and a `Failed("Summarization timed out")` is
 /// returned.
-// allow(dead_code): called from the worker loop wired up in the next task
-#[allow(dead_code)]
 pub(crate) async fn run_summary<F>(
     token: &CancellationToken,
     timeout: Duration,
@@ -62,12 +57,18 @@ pub struct SummaryJob {
     pub entry_link: String,
 }
 
+/// Per-entry cancellation tokens for in-flight / queued summary jobs, keyed by
+/// `(user_id, entry_id)`. The cancel handler cancels + removes the token; the
+/// worker creates one on dequeue (if absent) and removes it when the job ends.
+pub type CancelRegistry = Arc<Mutex<HashMap<(i64, i64), CancellationToken>>>;
+
 /// Start the summary worker that processes jobs from the queue
 pub fn start_summary_worker(
     mut rx: mpsc::Receiver<SummaryJob>,
     cache: Arc<SummaryCache>,
     sidebar_cache: Arc<SidebarCache>,
     db: DbPool,
+    cancels: CancelRegistry,
     cancel_token: CancellationToken,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
@@ -79,7 +80,7 @@ pub fn start_summary_worker(
                     tracing::info!("Summary worker stopping, draining remaining jobs...");
                     // Drain remaining jobs before exiting
                     while let Ok(job) = rx.try_recv() {
-                        process_summary_job(&job, &cache, &sidebar_cache, &db).await;
+                        process_summary_job(&job, &cache, &sidebar_cache, &db, &cancels).await;
                     }
                     break;
                 }
@@ -91,7 +92,7 @@ pub fn start_summary_worker(
                 }
             };
 
-            process_summary_job(&job, &cache, &sidebar_cache, &db).await;
+            process_summary_job(&job, &cache, &sidebar_cache, &db, &cancels).await;
         }
 
         tracing::info!("Summary worker stopped");
@@ -103,6 +104,35 @@ async fn process_summary_job(
     cache: &Arc<SummaryCache>,
     sidebar_cache: &Arc<SidebarCache>,
     db: &DbPool,
+    cancels: &CancelRegistry,
+) {
+    let key = (job.user_id, job.entry_id);
+
+    // Get-or-create this job's cancellation token. Covers startup-recovered
+    // jobs too (they never pass through the enqueue handler).
+    let token = {
+        let mut map = cancels.lock().unwrap();
+        map.entry(key).or_default().clone()
+    };
+
+    // Cancelled while still queued — the cancel handler already deleted the
+    // record. Drop the token and skip.
+    if token.is_cancelled() {
+        cancels.lock().unwrap().remove(&key);
+        return;
+    }
+
+    run_summary_job_body(job, cache, sidebar_cache, db, &token).await;
+
+    cancels.lock().unwrap().remove(&key);
+}
+
+async fn run_summary_job_body(
+    job: &SummaryJob,
+    cache: &Arc<SummaryCache>,
+    sidebar_cache: &Arc<SidebarCache>,
+    db: &DbPool,
+    token: &CancellationToken,
 ) {
     tracing::debug!(
         "Processing summary job: user={}, entry={}, link={}",
@@ -164,17 +194,21 @@ async fn process_summary_job(
         }
     };
 
-    // Call Kagi API
-    match summarize_with_kagi(&kagi_config, &job.entry_link).await {
-        Ok(summary_text) => {
+    // Race the Kagi call against cancellation + timeout.
+    match run_summary(
+        token,
+        SUMMARY_TIMEOUT,
+        summarize_with_kagi(&kagi_config, &job.entry_link),
+    )
+    .await
+    {
+        SummaryOutcome::Completed(summary_text) => {
             tracing::debug!(
                 "Summary completed for entry {}: {} chars",
                 job.entry_id,
                 summary_text.len()
             );
-            // Update cache
             cache.set_completed(job.user_id, job.entry_id, summary_text.clone());
-            // Update DB
             let user_id = job.user_id;
             let entry_id = job.entry_id;
             let _ = db
@@ -185,15 +219,19 @@ async fn process_summary_job(
             // A summary just completed — the sidebar "Summarized" badge must tick up.
             sidebar_cache.bust(job.user_id);
         }
-        Err(error) => {
+        SummaryOutcome::Failed(error) => {
             tracing::warn!("Summary failed for entry {}: {}", job.entry_id, error);
             cache.set_failed(job.user_id, job.entry_id, error.clone());
-            // Update DB
             let user_id = job.user_id;
             let entry_id = job.entry_id;
             let _ = db
                 .background(move |conn| entry_summary::set_failed(conn, user_id, entry_id, &error))
                 .await;
+        }
+        SummaryOutcome::Cancelled => {
+            // The cancel handler owns cleanup (delete + cache remove + sidebar
+            // bust). Write nothing back.
+            tracing::debug!("Summary cancelled for entry {}", job.entry_id);
         }
     }
 }
@@ -270,6 +308,10 @@ mod tests {
     use crate::models::user::Role;
     use crate::models::{category, entry, feed, user};
     use rusqlite::Connection;
+
+    fn registry() -> CancelRegistry {
+        Arc::new(Mutex::new(HashMap::new()))
+    }
 
     fn open_shared_memory(name: &str) -> Connection {
         let uri = format!("file:{}?mode=memory&cache=shared", name);
@@ -366,6 +408,7 @@ mod tests {
             cache,
             Arc::new(SidebarCache::default()),
             db,
+            registry(),
             cancel_token.clone(),
         );
 
@@ -398,6 +441,7 @@ mod tests {
             cache,
             Arc::new(SidebarCache::default()),
             db,
+            registry(),
             cancel_token,
         );
 
@@ -599,6 +643,7 @@ mod tests {
             cache.clone(),
             Arc::new(SidebarCache::default()),
             db,
+            registry(),
             cancel_token.clone(),
         );
 

--- a/src/services/summary_worker.rs
+++ b/src/services/summary_worker.rs
@@ -141,15 +141,22 @@ async fn run_summary_job_body(
         job.entry_link
     );
 
-    // Mark as processing in both cache and DB
-    cache.set_processing(job.user_id, job.entry_id);
+    // Mark as processing in the DB first. If the row no longer exists, the job
+    // was cancelled (its record deleted) while it sat in the queue — abort
+    // without repopulating the cache, or the cancelled summary would be
+    // resurrected from the cache on the next render.
     {
         let user_id = job.user_id;
         let entry_id = job.entry_id;
-        let _ = db
+        if let Ok(Err(crate::error::AppError::NotFound(_))) = db
             .background(move |conn| entry_summary::set_processing(conn, user_id, entry_id))
-            .await;
+            .await
+        {
+            cache.remove(job.user_id, job.entry_id);
+            return;
+        }
     }
+    cache.set_processing(job.user_id, job.entry_id);
 
     // Get Kagi config for the user
     let user_id = job.user_id;
@@ -208,25 +215,37 @@ async fn run_summary_job_body(
                 job.entry_id,
                 summary_text.len()
             );
-            cache.set_completed(job.user_id, job.entry_id, summary_text.clone());
             let user_id = job.user_id;
             let entry_id = job.entry_id;
-            let _ = db
+            let text = summary_text.clone();
+            let db_res = db
                 .background(move |conn| {
-                    entry_summary::set_completed(conn, user_id, entry_id, &summary_text)
+                    entry_summary::set_completed(conn, user_id, entry_id, &text)
                 })
                 .await;
-            // A summary just completed — the sidebar "Summarized" badge must tick up.
-            sidebar_cache.bust(job.user_id);
+            if let Ok(Err(crate::error::AppError::NotFound(_))) = db_res {
+                // Cancelled mid-flight (row deleted) — do not repopulate the cache.
+                cache.remove(job.user_id, job.entry_id);
+            } else {
+                cache.set_completed(job.user_id, job.entry_id, summary_text.clone());
+                // A summary just completed — the sidebar "Summarized" badge must tick up.
+                sidebar_cache.bust(job.user_id);
+            }
         }
         SummaryOutcome::Failed(error) => {
             tracing::warn!("Summary failed for entry {}: {}", job.entry_id, error);
-            cache.set_failed(job.user_id, job.entry_id, error.clone());
             let user_id = job.user_id;
             let entry_id = job.entry_id;
-            let _ = db
-                .background(move |conn| entry_summary::set_failed(conn, user_id, entry_id, &error))
+            let err = error.clone();
+            let db_res = db
+                .background(move |conn| entry_summary::set_failed(conn, user_id, entry_id, &err))
                 .await;
+            if let Ok(Err(crate::error::AppError::NotFound(_))) = db_res {
+                // Cancelled mid-flight (row deleted) — do not repopulate the cache.
+                cache.remove(job.user_id, job.entry_id);
+            } else {
+                cache.set_failed(job.user_id, job.entry_id, error.clone());
+            }
         }
         SummaryOutcome::Cancelled => {
             // The cancel handler owns cleanup (delete + cache remove + sidebar
@@ -622,6 +641,87 @@ mod tests {
         })
         .await;
         assert!(matches!(out, SummaryOutcome::Cancelled));
+    }
+
+    #[tokio::test]
+    async fn cancelled_while_queued_does_not_repopulate_cache() {
+        let db = setup_test_db();
+
+        let (user_id, entry_id) = db
+            .user(|conn| {
+                let u = user::create_user(conn, "canceluser", "hash", Role::User)
+                    .unwrap()
+                    .id;
+                let cat = category::create_category(conn, u, "Tech").unwrap().id;
+                let feed_id = feed::create_feed(
+                    conn,
+                    &feed::CreateFeedParams {
+                        category_id: cat,
+                        url: "https://example.com/feed.xml",
+                        title: Some("Feed"),
+                        description: None,
+                        site_url: None,
+                        custom_user_agent: None,
+                        http2_disabled: None,
+                        custom_referrer: None,
+                    },
+                )
+                .unwrap()
+                .id;
+                let (entry_obj, _) = entry::upsert_entry(
+                    conn,
+                    feed_id,
+                    "guid-cancelled",
+                    Some("Cancelled Entry"),
+                    Some("https://example.com/x"),
+                    None,
+                    None,
+                    None,
+                    None,
+                )
+                .unwrap();
+                // Intentionally do NOT create an entry_summary row — this
+                // simulates the cancel handler having already deleted it while
+                // the job was still sitting in the queue.
+                (u, entry_obj.id)
+            })
+            .await
+            .unwrap();
+
+        let cache = Arc::new(SummaryCache::new(100, 24));
+        let sidebar = Arc::new(SidebarCache::default());
+        let cancels = registry();
+
+        // Pre-seed the cache as if enqueue set it to pending, to prove the
+        // worker removes the stale cache entry rather than promoting it.
+        cache.set_pending(user_id, entry_id);
+
+        let job = SummaryJob {
+            user_id,
+            entry_id,
+            entry_link: "https://example.com/x".to_string(),
+        };
+
+        process_summary_job(&job, &cache, &sidebar, &db, &cancels).await;
+
+        // The set_processing UPDATE hits 0 rows (no summary row exists) ->
+        // AppError::NotFound -> worker removes the stale cache entry instead
+        // of repopulating it.
+        assert!(
+            cache.get(user_id, entry_id).is_none(),
+            "cache must not be repopulated for a cancelled (row-deleted) job"
+        );
+
+        // Confirm no row was resurrected in the DB either.
+        let row = db
+            .read_user(move |c| entry_summary::find_by_user_and_entry(c, user_id, entry_id))
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(
+            row.is_none(),
+            "no entry_summary row must exist after a cancelled job"
+        );
     }
 
     #[tokio::test]

--- a/src/services/summary_worker.rs
+++ b/src/services/summary_worker.rs
@@ -1,8 +1,52 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
+
+/// Maximum wall-clock time for a single Kagi summarization request. A hung
+/// request would otherwise occupy the single worker indefinitely and block
+/// every user's queued summaries. NEVER lower this in production without
+/// confirming Kagi's worst-case latency.
+// allow(dead_code): wired into the worker loop in the next task
+#[allow(dead_code)]
+const SUMMARY_TIMEOUT: Duration = Duration::from_secs(90);
+
+/// Result of racing a summarization future against cancellation + timeout.
+// allow(dead_code): variants consumed by the worker loop wired up in the next task
+#[allow(dead_code)]
+pub(crate) enum SummaryOutcome {
+    Completed(String),
+    Failed(String),
+    Cancelled,
+}
+
+/// Race a summarization future against an external cancellation token and a
+/// hard timeout. `biased` makes cancellation win deterministically when the
+/// token is already cancelled. On timeout the future is dropped (the in-flight
+/// HTTP request is aborted) and a `Failed("Summarization timed out")` is
+/// returned.
+// allow(dead_code): called from the worker loop wired up in the next task
+#[allow(dead_code)]
+pub(crate) async fn run_summary<F>(
+    token: &CancellationToken,
+    timeout: Duration,
+    fut: F,
+) -> SummaryOutcome
+where
+    F: std::future::Future<Output = Result<String, String>>,
+{
+    tokio::select! {
+        biased;
+        _ = token.cancelled() => SummaryOutcome::Cancelled,
+        res = tokio::time::timeout(timeout, fut) => match res {
+            Ok(Ok(text)) => SummaryOutcome::Completed(text),
+            Ok(Err(e)) => SummaryOutcome::Failed(e),
+            Err(_elapsed) => SummaryOutcome::Failed("Summarization timed out".to_string()),
+        }
+    }
+}
 
 use super::sidebar_cache::SidebarCache;
 use super::summarize::kagi::{self, KagiConfig};
@@ -491,6 +535,49 @@ mod tests {
         // Verify job was queued
         let job = rx.try_recv().unwrap();
         assert_eq!(job.entry_link, "https://example.com/article2");
+    }
+
+    #[tokio::test]
+    async fn run_summary_completes() {
+        let token = CancellationToken::new();
+        let out = run_summary(&token, std::time::Duration::from_secs(1), async {
+            Ok::<String, String>("hello".to_string())
+        })
+        .await;
+        assert!(matches!(out, SummaryOutcome::Completed(s) if s == "hello"));
+    }
+
+    #[tokio::test]
+    async fn run_summary_propagates_failure() {
+        let token = CancellationToken::new();
+        let out = run_summary(&token, std::time::Duration::from_secs(1), async {
+            Err::<String, String>("boom".to_string())
+        })
+        .await;
+        assert!(matches!(out, SummaryOutcome::Failed(e) if e == "boom"));
+    }
+
+    #[tokio::test]
+    async fn run_summary_times_out() {
+        let token = CancellationToken::new();
+        let out = run_summary(&token, std::time::Duration::from_millis(20), async {
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+            Ok::<String, String>("late".to_string())
+        })
+        .await;
+        assert!(matches!(out, SummaryOutcome::Failed(e) if e == "Summarization timed out"));
+    }
+
+    #[tokio::test]
+    async fn run_summary_cancels_before_completion() {
+        let token = CancellationToken::new();
+        token.cancel();
+        let out = run_summary(&token, std::time::Duration::from_secs(1), async {
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+            Ok::<String, String>("never".to_string())
+        })
+        .await;
+        assert!(matches!(out, SummaryOutcome::Cancelled));
     }
 
     #[tokio::test]

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -1734,6 +1734,27 @@ summary {
     white-space: pre-wrap;
 }
 
+/* Failed-summary banner — mirrors .banner--error's tinted wash + error
+   left-border, sized to sit inside the summary box. */
+.summary-error-banner {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--space-2);
+    font-size: var(--font-sm);
+    line-height: 1.5;
+    color: var(--color-text);
+    background: light-dark(rgba(185, 28, 28, 0.06), rgba(248, 113, 113, 0.08));
+    border: 1px solid light-dark(rgba(185, 28, 28, 0.20), rgba(248, 113, 113, 0.25));
+    border-left: var(--border-accent-width) solid var(--color-error);
+    border-radius: var(--radius-md);
+    padding: var(--space-3) var(--space-4);
+}
+.summary-error-banner .action-icon {
+    flex: none;
+    color: var(--color-error);
+    display: inline-flex;
+}
+
 /* ===== Responsive: Wide screens ===== */
 @media (min-width: 1600px) {
     :root {

--- a/templates/_icons.html
+++ b/templates/_icons.html
@@ -4,6 +4,7 @@
 {% macro external() %}<svg class="ico" viewBox="0 0 24 24" aria-hidden="true"><path d="M14 4h6v6"/><path d="M20 4l-8.5 8.5"/><path d="M19 14v5H5V5h5"/></svg>{% endmacro %}
 {% macro document() %}<svg class="ico" viewBox="0 0 24 24" aria-hidden="true"><path d="M7 3h7l4 4v14H7z"/><path d="M14 3v4h4"/><path d="M9.5 12h6M9.5 16h6"/></svg>{% endmacro %}
 {% macro revert() %}<svg class="ico" viewBox="0 0 24 24" aria-hidden="true"><path d="M9 14L4 9l5-5"/><path d="M4 9h11a5 5 0 0 1 0 10h-4"/></svg>{% endmacro %}
+{% macro refresh() %}<svg class="ico" viewBox="0 0 24 24" aria-hidden="true"><path d="M21 12a9 9 0 1 1-2.6-6.4"/><path d="M21 3v5h-5"/></svg>{% endmacro %}
 {% macro sparkle() %}<svg class="ico" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3l1.7 4.6L18 9.3l-4.3 1.7L12 16l-1.7-4.9L6 9.3l4.3-1.7z"/><path d="M18 15l.7 1.8L20.5 17.5l-1.8.7L18 20l-.7-1.8L15.5 17.5l1.8-.7z"/></svg>{% endmacro %}
 {% macro bookmark() %}<svg class="ico" viewBox="0 0 24 24" aria-hidden="true"><path d="M6 4h12v17l-6-4-6 4z"/></svg>{% endmacro %}
 {% macro copy() %}<svg class="ico" viewBox="0 0 24 24" aria-hidden="true"><rect x="9" y="9" width="11" height="11" rx="2"/><path d="M5 15V6a2 2 0 0 1 2-2h8"/></svg>{% endmacro %}

--- a/templates/_reading_pane.html
+++ b/templates/_reading_pane.html
@@ -80,6 +80,11 @@
         <div class="rp-summary-container" id="rp-summary-container" data-summary-container>
             {% if pane.summary_in_flight %}
             <div class="summary-box">
+                <div class="summary-actions">
+                    <form method="post" action="/entries/{{ pane.id }}/summarize/cancel" data-swap="#rp-summary-container">
+                        <button type="submit" class="rp-action" aria-label="Cancel summarization"><span class="action-icon" aria-hidden="true">{% call icons::close() %}{% endcall %}</span><span class="action-label">Cancel</span></button>
+                    </form>
+                </div>
                 <p class="muted">Summarizing… (refresh to see the result)</p>
             </div>
             {% else if let Some(summary) = pane.summary_text.as_ref() %}
@@ -88,8 +93,6 @@
                     <button type="button" class="rp-action" data-summary-copy aria-label="Copy summary"><span class="action-icon" aria-hidden="true">{% call icons::copy() %}{% endcall %}</span><span class="action-label">Copy</span></button>
                     <button type="button" class="rp-action" data-summary-dismiss data-entry-id="{{ pane.id }}" aria-label="Dismiss summary"><span class="action-icon" aria-hidden="true">{% call icons::close() %}{% endcall %}</span><span class="action-label">Dismiss</span></button>
                 </div>
-                {# Title + link rendered inside the box so what users see
-                   matches what the Copy button writes to the clipboard. #}
                 <div class="summary-header">
                     <div class="summary-title" data-summary-title>{{ pane.title }}</div>
                     {% if let Some(link) = pane.link.as_ref() %}
@@ -97,6 +100,18 @@
                     {% endif %}
                 </div>
                 <blockquote class="rp-summary-content">{{ summary|safe }}</blockquote>
+            </div>
+            {% else if let Some(error) = pane.summary_error.as_ref() %}
+            <div class="summary-box">
+                <div class="summary-actions">
+                    <form method="post" action="/entries/{{ pane.id }}/summarize" data-swap="#rp-summary-container">
+                        <button type="submit" class="rp-action" aria-label="Retry summarization"><span class="action-icon" aria-hidden="true">{% call icons::refresh() %}{% endcall %}</span><span class="action-label">Retry</span></button>
+                    </form>
+                    <form method="post" action="/entries/{{ pane.id }}/summarize/cancel" data-swap="#rp-summary-container">
+                        <button type="submit" class="rp-action" aria-label="Clear failed summary"><span class="action-icon" aria-hidden="true">{% call icons::close() %}{% endcall %}</span><span class="action-label">Clear</span></button>
+                    </form>
+                </div>
+                <div class="summary-error-banner" data-summary-error><span class="action-icon" aria-hidden="true">{% call icons::close() %}{% endcall %}</span><span>Summarization failed: {{ error }}</span></div>
             </div>
             {% endif %}
         </div>

--- a/templates/_summarize_pending.html
+++ b/templates/_summarize_pending.html
@@ -3,9 +3,15 @@
    pane's `<article>` is not touched. The full reading-pane render
    on next page load will surface the completed summary once the
    background worker finishes. #}
+{%- import "_icons.html" as icons -%}
 <template data-swap-target="#rp-summary-container">
     <div class="rp-summary-container" id="rp-summary-container" data-summary-container>
         <div class="summary-box">
+            <div class="summary-actions">
+                <form method="post" action="/entries/{{ id }}/summarize/cancel" data-swap="#rp-summary-container">
+                    <button type="submit" class="rp-action" aria-label="Cancel summarization"><span class="action-icon" aria-hidden="true">{% call icons::close() %}{% endcall %}</span><span class="action-label">Cancel</span></button>
+                </form>
+            </div>
             <p class="muted">Summarizing… (refresh to see the result)</p>
         </div>
     </div>

--- a/templates/_summary_cleared.html
+++ b/templates/_summary_cleared.html
@@ -1,0 +1,7 @@
+{# `POST /entries/{id}/summarize/cancel` response. Cancels any in-flight /
+   queued job and deletes the summary record, returning the summary container
+   to its empty (no-summary) state. Swaps ONLY `#rp-summary-container` so the
+   article body is untouched. #}
+<template data-swap-target="#rp-summary-container">
+    <div class="rp-summary-container" id="rp-summary-container" data-summary-container></div>
+</template>

--- a/tests/auth_test.rs
+++ b/tests/auth_test.rs
@@ -36,6 +36,7 @@ fn create_test_server(config: Config) -> TestServer {
         summary_cache,
         summary_tx,
         sidebar_cache: Arc::new(services::SidebarCache::default()),
+        summary_cancels: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
     };
 
     let app = create_router(state);

--- a/tests/compression_test.rs
+++ b/tests/compression_test.rs
@@ -39,6 +39,7 @@ fn create_test_server(config: Config) -> TestServer {
         summary_cache,
         summary_tx,
         sidebar_cache: Arc::new(services::SidebarCache::default()),
+        summary_cancels: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
     };
 
     TestServer::builder().build(create_router(state))

--- a/tests/entry_handlers_test.rs
+++ b/tests/entry_handlers_test.rs
@@ -57,6 +57,7 @@ fn create_test_app(config: Config) -> TestApp {
         summary_cache,
         summary_tx,
         sidebar_cache: Arc::new(services::SidebarCache::default()),
+        summary_cancels: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
     };
 
     let app = create_router(state);

--- a/tests/etag_test.rs
+++ b/tests/etag_test.rs
@@ -41,6 +41,7 @@ fn create_test_server(name: &str, config: Config) -> TestServer {
         summary_cache,
         summary_tx,
         sidebar_cache: Arc::new(services::SidebarCache::default()),
+        summary_cancels: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
     };
 
     TestServer::builder().build(create_router(state))

--- a/tests/greader_test.rs
+++ b/tests/greader_test.rs
@@ -57,6 +57,7 @@ fn create_test_app(config: Config) -> TestApp {
         summary_cache,
         summary_tx,
         sidebar_cache: Arc::new(services::SidebarCache::default()),
+        summary_cancels: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
     };
 
     let app = create_router(state);
@@ -774,6 +775,7 @@ async fn test_unauthenticated_access_denied() {
         summary_cache,
         summary_tx,
         sidebar_cache: Arc::new(services::SidebarCache::default()),
+        summary_cancels: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
     };
 
     let app = create_router(state);

--- a/tests/handlers_test.rs
+++ b/tests/handlers_test.rs
@@ -64,6 +64,7 @@ fn create_test_server(config: Config) -> TestServer {
         summary_cache,
         summary_tx,
         sidebar_cache: Arc::new(services::SidebarCache::default()),
+        summary_cancels: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
     };
 
     let app = create_router(state);
@@ -87,6 +88,7 @@ fn create_test_app(config: Config) -> TestApp {
         summary_cache,
         summary_tx,
         sidebar_cache: Arc::new(services::SidebarCache::default()),
+        summary_cancels: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
     };
 
     let app = create_router(state);
@@ -3543,6 +3545,7 @@ fn create_test_app_named(config: Config, name: &str) -> TestApp {
         summary_cache,
         summary_tx,
         sidebar_cache: Arc::new(services::SidebarCache::default()),
+        summary_cancels: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
     };
 
     let app = create_router(state);

--- a/tests/pages_test.rs
+++ b/tests/pages_test.rs
@@ -50,6 +50,7 @@ fn create_test_app_named(config: Config, name: &str) -> TestApp {
         summary_cache,
         summary_tx,
         sidebar_cache: Arc::new(services::SidebarCache::default()),
+        summary_cancels: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
     };
 
     let app = create_router(state);

--- a/tests/statistics_test.rs
+++ b/tests/statistics_test.rs
@@ -55,6 +55,7 @@ fn create_test_app(name: &str) -> TestApp {
         summary_cache,
         summary_tx,
         sidebar_cache: Arc::new(services::SidebarCache::default()),
+        summary_cancels: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
     };
 
     let app = create_router(state);

--- a/tests/summary_cancel.rs
+++ b/tests/summary_cancel.rs
@@ -1,0 +1,250 @@
+//! Integration tests for `POST /entries/{id}/summarize/cancel`.
+//!
+//! Tests cover:
+//! - Failed-summary clear deletes the record
+//! - Non-owner returns 404
+//! - In-flight token is cancelled and removed from the registry
+
+mod common;
+use common::default_test_config;
+
+use std::sync::Arc;
+
+use axum_test::TestServer;
+use rdrs::{auth, create_router, db, services, AppState, Config, DbPool, Role};
+use rusqlite::Connection;
+use serde_json::json;
+use tokio_util::sync::CancellationToken;
+
+struct TestApp {
+    server: TestServer,
+    db: DbPool,
+    state: AppState,
+}
+
+fn open_shared_memory(name: &str) -> Connection {
+    let uri = format!("file:{}?mode=memory&cache=shared", name);
+    Connection::open_with_flags(
+        uri,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_WRITE
+            | rusqlite::OpenFlags::SQLITE_OPEN_CREATE
+            | rusqlite::OpenFlags::SQLITE_OPEN_URI,
+    )
+    .unwrap()
+}
+
+fn create_test_app(config: Config, db_name: &str) -> TestApp {
+    let write_conn = open_shared_memory(db_name);
+    db::init_db(&write_conn).unwrap();
+    let read_conn = open_shared_memory(db_name);
+
+    let (db, _handle) = DbPool::new(write_conn, read_conn);
+    let webauthn = auth::create_webauthn(&config).unwrap();
+    let summary_cache = services::create_summary_cache(100, 24);
+    let (summary_tx, _summary_rx) = services::create_summary_channel(10);
+
+    let state = AppState {
+        db: db.clone(),
+        config: Arc::new(config),
+        webauthn: Arc::new(webauthn),
+        summary_cache,
+        summary_tx,
+        sidebar_cache: Arc::new(services::SidebarCache::default()),
+        summary_cancels: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+    };
+
+    let app = create_router(state.clone());
+    let server = TestServer::builder().save_cookies().build(app);
+
+    TestApp { server, db, state }
+}
+
+/// Seed a user, category, feed, and one entry. Returns (user_id, entry_id).
+async fn setup_user_with_entry(db: &DbPool, username: &str, password: &str) -> (i64, i64) {
+    let username = username.to_owned();
+    let password = password.to_owned();
+    db.user(move |conn| {
+        let password_hash = auth::hash_password(&password).unwrap();
+        conn.execute(
+            "INSERT INTO user (username, password_hash, role) VALUES (?1, ?2, ?3)",
+            rusqlite::params![username, password_hash, Role::Admin.as_str()],
+        )
+        .unwrap();
+        let user_id = conn.last_insert_rowid();
+
+        conn.execute(
+            "INSERT INTO category (user_id, name) VALUES (?1, ?2)",
+            rusqlite::params![user_id, "Test Category"],
+        )
+        .unwrap();
+        let category_id = conn.last_insert_rowid();
+
+        conn.execute(
+            "INSERT INTO feed (category_id, url, title) VALUES (?1, ?2, ?3)",
+            rusqlite::params![
+                category_id,
+                format!("https://example.com/{}/feed.xml", username),
+                "Test Feed"
+            ],
+        )
+        .unwrap();
+        let feed_id = conn.last_insert_rowid();
+
+        conn.execute(
+            "INSERT INTO entry (feed_id, guid, title, link, content, published_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, datetime('now'))",
+            rusqlite::params![
+                feed_id,
+                format!("{}-guid-1", username),
+                "Test Entry",
+                "https://example.com/entry/1",
+                "<p>Content</p>"
+            ],
+        )
+        .unwrap();
+        let entry_id = conn.last_insert_rowid();
+
+        (user_id, entry_id)
+    })
+    .await
+    .unwrap()
+}
+
+async fn login(server: &TestServer, username: &str, password: &str) {
+    server
+        .post("/api/session")
+        .json(&json!({
+            "username": username,
+            "password": password
+        }))
+        .await
+        .assert_status_ok();
+}
+
+// ============================================================================
+// Case 1: Failed-summary clear deletes the record
+// ============================================================================
+
+#[tokio::test]
+async fn test_cancel_clears_failed_summary() {
+    let app = create_test_app(default_test_config(), "test_cancel_clears_failed");
+    let (uid, eid) = setup_user_with_entry(&app.db, "user1", "password123").await;
+    login(&app.server, "user1", "password123").await;
+
+    // Seed a failed summary record
+    app.db
+        .user(move |conn| {
+            rdrs::models::entry_summary::upsert_pending(conn, uid, eid).unwrap();
+            rdrs::models::entry_summary::set_failed(conn, uid, eid, "API error").unwrap();
+            Ok::<_, rdrs::error::AppError>(())
+        })
+        .await
+        .unwrap()
+        .unwrap();
+
+    // POST cancel
+    let response = app
+        .server
+        .post(&format!("/entries/{}/summarize/cancel", eid))
+        .await;
+    response.assert_status_ok();
+
+    // Assert the summary record is gone
+    let gone = app
+        .db
+        .read_user(move |c| rdrs::models::entry_summary::find_by_user_and_entry(c, uid, eid))
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(gone.is_none(), "expected summary record to be deleted");
+}
+
+// ============================================================================
+// Case 2: Non-owner returns 404
+// ============================================================================
+
+#[tokio::test]
+async fn test_cancel_non_owner_returns_404() {
+    let app = create_test_app(default_test_config(), "test_cancel_non_owner");
+
+    // Create owner user with an entry
+    let (_uid1, eid) = setup_user_with_entry(&app.db, "owner", "password123").await;
+
+    // Create a second user who does NOT own that entry
+    app.db
+        .user(move |conn| {
+            let password_hash = auth::hash_password("password456").unwrap();
+            conn.execute(
+                "INSERT INTO user (username, password_hash, role) VALUES (?1, ?2, ?3)",
+                rusqlite::params!["attacker", password_hash, "user"],
+            )
+            .unwrap();
+            Ok::<_, rdrs::error::AppError>(())
+        })
+        .await
+        .unwrap()
+        .unwrap();
+
+    // Login as attacker
+    login(&app.server, "attacker", "password456").await;
+
+    // Try to cancel the owner's entry
+    let response = app
+        .server
+        .post(&format!("/entries/{}/summarize/cancel", eid))
+        .await;
+    response.assert_status_not_found();
+}
+
+// ============================================================================
+// Case 3: In-flight token is cancelled and removed from the registry
+// ============================================================================
+
+#[tokio::test]
+async fn test_cancel_removes_inflight_token() {
+    let app = create_test_app(default_test_config(), "test_cancel_inflight_token");
+    let (uid, eid) = setup_user_with_entry(&app.db, "tokenuser", "password123").await;
+    login(&app.server, "tokenuser", "password123").await;
+
+    // Seed a pending summary record so delete has a row
+    app.db
+        .user(move |conn| {
+            rdrs::models::entry_summary::upsert_pending(conn, uid, eid).unwrap();
+            Ok::<_, rdrs::error::AppError>(())
+        })
+        .await
+        .unwrap()
+        .unwrap();
+
+    // Insert a CancellationToken into the registry
+    let cancel_token = CancellationToken::new();
+    let cloned_token = cancel_token.clone();
+    {
+        let mut map = app.state.summary_cancels.lock().unwrap();
+        map.insert((uid, eid), cancel_token);
+    }
+
+    // POST cancel
+    let response = app
+        .server
+        .post(&format!("/entries/{}/summarize/cancel", eid))
+        .await;
+    response.assert_status_ok();
+
+    // Assert the cloned token is now cancelled
+    assert!(
+        cloned_token.is_cancelled(),
+        "expected token to be cancelled"
+    );
+
+    // Assert the token has been removed from the registry
+    assert!(
+        app.state
+            .summary_cancels
+            .lock()
+            .unwrap()
+            .get(&(uid, eid))
+            .is_none(),
+        "expected token to be removed from registry"
+    );
+}


### PR DESCRIPTION
## Summary

Make AI summarization controllable from the UI and resilient to hung requests:

- **Cancel in-flight or queued summaries.** A per-entry `CancelRegistry` of `CancellationToken`s (keyed by `(user_id, entry_id)`) lives in `AppState`. The worker routes the Kagi call through a `run_summary` helper that races the request against its token and a hard timeout. A new `POST /entries/{id}/summarize/cancel` endpoint cancels the token (aborting the in-flight HTTP request), deletes the `entry_summary` record, clears the cache, and busts the sidebar count.
- **Request timeout.** Each Kagi request is bounded by a 90s timeout; on expiry the summary is marked `failed` ("Summarization timed out"), so a hung request can no longer wedge the single sequential worker.
- **Recover a failed summary from the reading pane.** The reading pane now renders a failed-state branch — an error banner (reusing the app's `--color-error` palette) plus **Retry** (re-submits `POST /entries/{id}/summarize`) and **Clear** (shares the cancel endpoint). The in-flight state gained a **Cancel** button. A new `summary_error` field on `ReadingPaneView` distinguishes `failed` from "no summary".
- **Cache-consistency fix.** The worker gates its cache writes on the DB write result (`set_processing`/`set_completed`/`set_failed` are `UPDATE ... WHERE` and return `NotFound` on 0 rows), so a summary cancelled while queued — or in the narrow completion window — is no longer resurrected from the moka cache.

Controls are reading-pane only; the list-view badges remain indicators. The completed-summary Copy/Dismiss path is unchanged.

Design spec and implementation plan are under `docs/superpowers/`.

## Test Plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `RDRS_FAST_HASH=1 cargo nextest run` — 910 passed (incl. cancel endpoint ownership/clear/token tests, `run_summary` cancel/timeout unit tests, and a cancel-while-queued cache regression test)
- [x] E2E `npx playwright test --grep-invert "@skip"` — 120 passed (incl. failed-summary banner with Retry/Clear)
- [x] README screenshots regenerated — no diff (failed/in-flight states are not in the default captures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)