### PR TITLE
refactor(datetime): extract try_parse_datetime for safe timestamp aggregates

### DIFF
--- a/src/models/statistics.rs
+++ b/src/models/statistics.rs
@@ -351,14 +351,19 @@ pub fn get_admin_database_stats(conn: &Connection) -> AppResult<AdminDatabaseSta
     let tombstone_count: i64 =
         conn.query_row("SELECT COUNT(*) FROM entry_tombstone", [], |row| row.get(0))?;
 
-    let parse = |s: &str| chrono::NaiveDateTime::parse_from_str(s, "%Y-%m-%d %H:%M:%S").ok();
+    // Use the fallible parser (not parse_datetime, whose Utc::now() fallback
+    // would silently corrupt these aggregates on an unparseable timestamp).
     let (coverage_days, avg_new_entries_per_day) = match (
-        min_created.as_deref().and_then(parse),
-        max_created.as_deref().and_then(parse),
+        min_created
+            .as_deref()
+            .and_then(crate::utils::datetime::try_parse_datetime),
+        max_created
+            .as_deref()
+            .and_then(crate::utils::datetime::try_parse_datetime),
     ) {
         (Some(min), Some(max)) => {
             let coverage = (max - min).num_seconds() as f64 / 86_400.0;
-            let now = chrono::Utc::now().naive_utc();
+            let now = chrono::Utc::now();
             let age_days = (now - min).num_seconds() as f64 / 86_400.0;
             let avg = if age_days > 0.0 {
                 total_entries as f64 / age_days
@@ -689,6 +694,28 @@ mod tests {
             s.coverage_days
         );
         // created_at is in the past, so age > 0 and avg is positive & finite.
+        assert!(s.avg_new_entries_per_day > 0.0 && s.avg_new_entries_per_day.is_finite());
+    }
+
+    #[test]
+    fn test_admin_database_stats_parses_rfc3339_created_at() {
+        let conn = setup_db();
+        let user_id = create_user_with_data(&conn);
+        let feed_id = get_feed_id(&conn, user_id);
+
+        // RFC 3339 timestamps spanning exactly 2 days. The previous SQL-only
+        // parser would have failed these and collapsed coverage to 0.0.
+        insert_entry_created_at(&conn, feed_id, "a", "2024-01-01T00:00:00Z");
+        insert_entry_created_at(&conn, feed_id, "b", "2024-01-03T00:00:00Z");
+
+        let s = get_admin_database_stats(&conn).unwrap();
+
+        assert_eq!(s.total_entries, 2);
+        assert!(
+            (s.coverage_days - 2.0).abs() < 1e-6,
+            "coverage was {}",
+            s.coverage_days
+        );
         assert!(s.avg_new_entries_per_day > 0.0 && s.avg_new_entries_per_day.is_finite());
     }
 }

--- a/src/utils/datetime.rs
+++ b/src/utils/datetime.rs
@@ -108,9 +108,15 @@ pub fn normalize_timezone_format(text: &str) -> String {
     text.to_string()
 }
 
-/// Parse a datetime string from the database (stored as SQL datetime or RFC 3339).
-/// Falls back to `Utc::now()` if parsing fails.
-pub fn parse_datetime(s: &str) -> DateTime<Utc> {
+/// Parse a datetime string from the database, returning `None` if every
+/// supported format fails. Tries, in order: RFC 3339, SQL datetime
+/// (`%Y-%m-%d %H:%M:%S`), dateparser (RFC 2822 and other localized formats),
+/// then the Chinese date format.
+///
+/// Prefer this over [`parse_datetime`] when an unparseable value must be
+/// distinguished from a valid one (e.g. aggregates over timestamps, where the
+/// `Utc::now()` fallback would silently corrupt the result).
+pub fn try_parse_datetime(s: &str) -> Option<DateTime<Utc>> {
     // Try RFC 3339 first (standard format)
     DateTime::parse_from_rfc3339(s)
         .map(|dt| dt.with_timezone(&Utc))
@@ -120,9 +126,15 @@ pub fn parse_datetime(s: &str) -> DateTime<Utc> {
         })
         // Then try dateparser for various formats (RFC 2822, localized dates, etc.)
         .or_else(|_| dateparser::parse(s).map(|dt| dt.with_timezone(&Utc)))
+        .ok()
         // Then try Chinese date format
-        .or_else(|_| parse_chinese_datetime(s).ok_or(()))
-        .unwrap_or_else(|_| Utc::now())
+        .or_else(|| parse_chinese_datetime(s))
+}
+
+/// Parse a datetime string from the database (stored as SQL datetime or RFC 3339).
+/// Falls back to `Utc::now()` if parsing fails.
+pub fn parse_datetime(s: &str) -> DateTime<Utc> {
+    try_parse_datetime(s).unwrap_or_else(Utc::now)
 }
 
 /// Custom timestamp parser for feed-rs that handles:
@@ -164,6 +176,23 @@ mod tests {
         assert_eq!(dt.day(), 6);
         assert_eq!(dt.hour(), 14);
         assert_eq!(dt.minute(), 28);
+    }
+
+    #[test]
+    fn test_try_parse_datetime_supported_formats() {
+        // SQL datetime and RFC 3339 both parse to the same instant.
+        assert!(try_parse_datetime("2026-01-06 14:28:00").is_some());
+        assert!(try_parse_datetime("2026-01-06T14:28:00Z").is_some());
+        let a = try_parse_datetime("2026-01-06 14:28:00").unwrap();
+        let b = try_parse_datetime("2026-01-06T14:28:00Z").unwrap();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn test_try_parse_datetime_garbage_is_none() {
+        // Unparseable input returns None (no Utc::now() fallback).
+        assert!(try_parse_datetime("not a date").is_none());
+        assert!(try_parse_datetime("").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Follow-up to #314. `get_admin_database_stats` parsed `entry.created_at` with an inline SQL-only closure. The code-review flagged reusing the shared `parse_datetime`, but that helper **falls back to `Utc::now()` on parse failure** — which would silently corrupt the `MIN`/`MAX(created_at)` aggregates (a malformed `MIN` resolving to *now* would make `coverage_days` ≈ 0 / negative and skew `avg_new_entries_per_day`), strictly worse than the previous clean "→ 0.0".

This extracts the parse chain so we get the consolidation **without** the hazard:

- Add `try_parse_datetime(s) -> Option<DateTime<Utc>>` in `utils/datetime.rs` (RFC 3339 → SQL datetime → dateparser → Chinese), returning `None` on total failure.
- `parse_datetime` now delegates: `try_parse_datetime(s).unwrap_or_else(Utc::now)` — behavior-preserving (the existing `test_parse_datetime_falls_back_to_utc_now` still passes).
- `get_admin_database_stats` uses the fallible variant, so an unparseable timestamp cleanly yields `0` instead of a now-based value.

Side benefit: the stats query now also accepts RFC 3339 / RFC 2822 / Chinese `created_at` values, not just the SQL format.

## Testing

- New `try_parse_datetime` unit tests (SQL & RFC 3339 parse to the same instant; garbage / empty → `None`).
- New stats test: RFC 3339 `created_at` now yields correct `coverage_days` (would have collapsed to 0 before).
- Existing `parse_datetime` tests unchanged and green.
- Full suite: 923/923; `cargo fmt --check` and `cargo clippy -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
