### PR TITLE
feat(stats): make Daily Read Articles chart interactive and touch-friendly

### DIFF
--- a/docs/superpowers/plans/2026-06-18-interactive-daily-read-chart.md
+++ b/docs/superpowers/plans/2026-06-18-interactive-daily-read-chart.md
@@ -1,0 +1,678 @@
+# Interactive Daily Read Articles Chart Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn the `/statistics` "Daily Read Articles" pure-CSS bar chart into an
+interactive, touch-friendly chart that always shows a numeric Y-axis and reveals
+a day's exact count when a bar is tapped/clicked.
+
+**Architecture:** Keep the server-rendered `div`-bar model. The handler computes a
+"nice-max" scale + Y-axis ticks; the template renders gridlines, axis labels, and
+per-bar `data-*`; a new vanilla `<rdrs-reading-chart>` custom element (light DOM,
+Pointer/click events) highlights a tapped bar and positions an info card.
+
+**Tech Stack:** Rust (Axum + Askama), vanilla ES module custom element, CSS custom
+properties, Playwright BDD for E2E.
+
+## Global Constraints
+
+- SSR-first; no bundler/transpiler; vanilla ES module served via `include_str!`. (verbatim project rule)
+- No charting library; vanilla ES modules + `include_str!` is the ceiling.
+- `cargo fmt --all -- --check` and `cargo clippy -- -D warnings` must pass.
+- Tests run with `cargo nextest run` (never `cargo test`); local runs use `RDRS_FAST_HASH=1`.
+- Rebuild (`cargo build`) before any E2E run, because assets are embedded at compile time.
+- All commits GPG-signed; stage files explicitly by name (never `git add -A`/`.`).
+- Work happens on branch `feat/interactive-daily-read-chart` (already created).
+
+## File Structure
+
+| File | Responsibility | Action |
+|------|----------------|--------|
+| `src/handlers/pages/mod.rs` | `nice_step` / `compute_y_axis` helpers, `TickView`, handler wiring, `StatisticsTemplate.y_ticks` | Modify |
+| `templates/statistics.html` | Render Y-axis + gridlines + bar `data-*` + info card, wrap in `<rdrs-reading-chart>`, load page script | Modify |
+| `static/css/app.css` | Chart wrap/axis/gridline/active-bar/info-card styles | Modify |
+| `static/js/components/rdrs-reading-chart.js` | Tap-to-highlight custom element | Create |
+| `src/handlers/static_assets.rs` | Register the new JS asset | Modify |
+| `e2e/features/statistics.feature` | BDD scenario for tap interaction | Create |
+| `e2e/steps/statistics.steps.js` | Step defs for the scenario | Create |
+
+**Note on screenshots:** The four README screenshots (`e2e/scripts/screenshots.js`)
+only capture the unread list and the keyboard-help overlay — never `/statistics`.
+This change therefore affects **no** README screenshot; do not regenerate them.
+
+---
+
+### Task 1: Y-axis scale computation (handler)
+
+Compute a nice-max ceiling and tick list server-side, scale bars against it, and
+expose `y_ticks` to the template.
+
+**Files:**
+- Modify: `src/handlers/pages/mod.rs` (add `TickView` near `DailyReadView` ~line 2135; add helpers near `format_db_bytes` ~line 2157; wire handler ~lines 2638-2663 and struct ~line 2196-2215)
+- Test: `src/handlers/pages/mod.rs` `#[cfg(test)] mod tests` (~line 2785)
+
+**Interfaces:**
+- Produces:
+  - `pub struct TickView { pub value: i64, pub percent: f64 }`
+  - `fn nice_step(max: i64) -> i64`
+  - `fn compute_y_axis(max: i64) -> (i64, Vec<TickView>)` — returns `(nice_max, ticks)`; `max` must be `> 0`.
+  - `StatisticsTemplate.y_ticks: Vec<TickView>`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the `tests` module (and extend its `use super::{…}` import to include
+`compute_y_axis, nice_step`):
+
+```rust
+    #[test]
+    fn nice_step_small_maxes_are_one() {
+        assert_eq!(super::nice_step(1), 1);
+        assert_eq!(super::nice_step(3), 1);
+        assert_eq!(super::nice_step(4), 1);
+    }
+
+    #[test]
+    fn nice_step_uses_one_two_five_progression() {
+        assert_eq!(super::nice_step(8), 2);
+        assert_eq!(super::nice_step(11), 5);
+        assert_eq!(super::nice_step(50), 20);
+    }
+
+    #[test]
+    fn compute_y_axis_single_day() {
+        let (nice_max, ticks) = super::compute_y_axis(1);
+        assert_eq!(nice_max, 1);
+        assert_eq!(ticks.len(), 1);
+        assert_eq!(ticks[0].value, 1);
+        assert!((ticks[0].percent - 100.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn compute_y_axis_rounds_up_to_nice_max() {
+        let (nice_max, ticks) = super::compute_y_axis(11);
+        assert_eq!(nice_max, 15);
+        let values: Vec<i64> = ticks.iter().map(|t| t.value).collect();
+        assert_eq!(values, vec![5, 10, 15]);
+        assert!((ticks[1].percent - (10.0 * 100.0 / 15.0)).abs() < 1e-9);
+    }
+
+    #[test]
+    fn compute_y_axis_exact_small_range() {
+        let (nice_max, ticks) = super::compute_y_axis(4);
+        assert_eq!(nice_max, 4);
+        let values: Vec<i64> = ticks.iter().map(|t| t.value).collect();
+        assert_eq!(values, vec![1, 2, 3, 4]);
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo nextest run -E 'test(compute_y_axis) or test(nice_step)'`
+Expected: FAIL — `nice_step` / `compute_y_axis` not found.
+
+- [ ] **Step 3: Add `TickView`**
+
+Insert after the `DailyReadView` struct (~line 2141):
+
+```rust
+/// One Y-axis gridline + label on the daily-read chart. `percent` is the
+/// distance from the chart bottom, against the nice-max scale.
+pub struct TickView {
+    pub value: i64,
+    pub percent: f64,
+}
+```
+
+- [ ] **Step 4: Add the helpers**
+
+Insert just above `fn format_db_bytes` (~line 2157):
+
+```rust
+/// Pick a "nice" tick step (1-2-5 × 10ⁿ) targeting ~4 ticks for the given max.
+fn nice_step(max: i64) -> i64 {
+    if max <= 4 {
+        return 1;
+    }
+    let raw = max as f64 / 4.0;
+    let mag = 10f64.powf(raw.log10().floor());
+    let norm = raw / mag;
+    let nice = if norm <= 1.0 {
+        1.0
+    } else if norm <= 2.0 {
+        2.0
+    } else if norm <= 5.0 {
+        5.0
+    } else {
+        10.0
+    };
+    ((nice * mag).round() as i64).max(1)
+}
+
+/// Nice-max ceiling + Y-axis ticks for a chart whose largest value is `max`
+/// (`max > 0`). Bars are scaled against the returned `nice_max` so their tops
+/// align with the gridlines.
+fn compute_y_axis(max: i64) -> (i64, Vec<TickView>) {
+    let step = nice_step(max);
+    let nice_max = ((max + step - 1) / step) * step;
+    let mut ticks = Vec::new();
+    let mut v = step;
+    while v <= nice_max {
+        ticks.push(TickView {
+            value: v,
+            percent: (v as f64 * 100.0) / nice_max as f64,
+        });
+        v += step;
+    }
+    (nice_max, ticks)
+}
+```
+
+- [ ] **Step 5: Add the struct field**
+
+In `StatisticsTemplate` (after `pub daily_read_counts: Vec<DailyReadView>,`, ~line 2210):
+
+```rust
+    pub y_ticks: Vec<TickView>,
+```
+
+- [ ] **Step 6: Wire the handler**
+
+Replace the `let daily_max = …` line (~line 2638) and the `height_percent`
+computation inside the `daily_read_counts` map (~lines 2651-2655):
+
+```rust
+    let daily_max = daily.iter().map(|d| d.count).max().unwrap_or(0);
+    let (daily_scale_max, y_ticks) = if daily_max > 0 {
+        compute_y_axis(daily_max)
+    } else {
+        (0, Vec::new())
+    };
+```
+
+Change the `height_percent` denominator from `daily_max` to `daily_scale_max`:
+
+```rust
+            let height_percent = if daily_scale_max > 0 {
+                (d.count as f64 * 100.0) / daily_scale_max as f64
+            } else {
+                0.0
+            };
+```
+
+Add `y_ticks,` to the `StatisticsTemplate { … }` literal, right after
+`daily_read_counts,` (~line 2727):
+
+```rust
+            daily_read_counts,
+            y_ticks,
+```
+
+- [ ] **Step 7: Run tests + build to verify they pass**
+
+Run: `cargo nextest run -E 'test(compute_y_axis) or test(nice_step)' && cargo build`
+Expected: PASS, and the binary builds (Askama still compiles the template — `y_ticks` is rendered in Task 2, an unused field is fine for now).
+
+- [ ] **Step 8: Format + commit**
+
+```bash
+cargo fmt
+git add src/handlers/pages/mod.rs
+git commit -m "feat(stats): compute Y-axis nice-max scale and ticks for daily-read chart"
+```
+
+---
+
+### Task 2: Template + CSS rendering
+
+Render the Y-axis labels, gridlines, per-bar `data-*`/a11y attributes, and the
+info-card element; restyle bars to a low-key default with an active state.
+
+**Files:**
+- Modify: `templates/statistics.html:52-66` (the `Daily Read Articles` section)
+- Modify: `static/css/app.css:2388-2426` (chart styles)
+
+**Interfaces:**
+- Consumes: `StatisticsTemplate.y_ticks` (Task 1), `daily_read_counts[].short_label`, `.count`, `.date`, `.height_percent`.
+- Produces (for Task 3's JS): DOM `rdrs-reading-chart` containing `.stats-bar-col[data-date][data-count]` and a `.stats-chart-card[data-chart-card]`.
+
+- [ ] **Step 1: Replace the chart markup**
+
+Replace `templates/statistics.html` lines 52-66 (the whole `Daily Read Articles`
+`stats-section`) with:
+
+```html
+                <div class="stats-section">
+                    <h2>Daily Read Articles</h2>
+                    {% if daily_max == 0 %}
+                        <p class="muted">No read activity in this period</p>
+                    {% else %}
+                        <rdrs-reading-chart class="stats-chart-wrap">
+                            <div class="stats-y-axis" aria-hidden="true">
+                                {% for t in y_ticks %}
+                                    <span class="stats-y-tick" style="bottom: {{ t.percent }}%">{{ t.value }}</span>
+                                {% endfor %}
+                            </div>
+                            <div class="stats-chart">
+                                {% for t in y_ticks %}
+                                    <div class="stats-gridline" style="bottom: {{ t.percent }}%" aria-hidden="true"></div>
+                                {% endfor %}
+                                {% for d in daily_read_counts %}
+                                    <div class="stats-bar-col" data-date="{{ d.short_label }}" data-count="{{ d.count }}"
+                                         title="{{ d.date }}: {{ d.count }}" tabindex="0" role="button"
+                                         aria-label="{{ d.date }}: {{ d.count }} read">
+                                        <div class="stats-bar" style="height: {{ d.height_percent }}%"></div>
+                                        <div class="stats-bar-label">{{ d.short_label }}</div>
+                                    </div>
+                                {% endfor %}
+                            </div>
+                            <div class="stats-chart-card" data-chart-card hidden></div>
+                        </rdrs-reading-chart>
+                    {% endif %}
+                </div>
+```
+
+- [ ] **Step 2: Replace the chart CSS**
+
+Replace `static/css/app.css` lines 2388-2426 (`.stats-chart` through
+`.stats-bar-label`) with:
+
+```css
+.stats-chart-wrap {
+    position: relative;
+    display: flex;
+    align-items: stretch;
+    gap: var(--space-2);
+    margin-bottom: var(--space-6);
+    touch-action: manipulation;
+}
+.stats-y-axis {
+    position: relative;
+    width: 1.75rem;
+    height: 160px;
+    flex-shrink: 0;
+}
+.stats-y-tick {
+    position: absolute;
+    right: 0;
+    transform: translateY(50%);
+    font-family: var(--font-ui);
+    font-size: 10px;
+    color: var(--color-text-muted);
+    line-height: 1;
+}
+.stats-chart {
+    flex: 1;
+    display: flex;
+    align-items: flex-end;
+    gap: 2px;
+    height: 160px;
+    margin-bottom: var(--space-6);
+    position: relative;
+    min-width: 0;
+}
+.stats-gridline {
+    position: absolute;
+    left: 0;
+    right: 0;
+    height: 1px;
+    background: var(--color-border-light);
+    z-index: 0;
+}
+.stats-bar-col {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-end;
+    height: 100%;
+    min-width: 0;
+    position: relative;
+    z-index: 1;
+    cursor: pointer;
+}
+.stats-bar-col:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 2px;
+}
+.stats-bar {
+    width: 100%;
+    background: var(--color-accent-subtle);
+    border-radius: var(--radius-sm) var(--radius-sm) 0 0;
+    min-height: 2px;
+    transition: height 0.2s, background 0.15s;
+}
+.stats-bar-col.is-active .stats-bar,
+.stats-bar-col:hover .stats-bar {
+    background: var(--color-accent);
+}
+.stats-bar-label {
+    font-family: var(--font-ui);
+    font-size: 10px;
+    color: var(--color-text-muted);
+    margin-top: var(--space-1);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    text-align: center;
+}
+.stats-chart-card {
+    position: absolute;
+    top: 0;
+    transform: translate(-50%, -100%);
+    background: var(--color-text);
+    color: var(--color-bg);
+    font-family: var(--font-ui);
+    font-size: 11px;
+    line-height: 1;
+    padding: 0.3rem 0.5rem;
+    border-radius: var(--radius-sm);
+    white-space: nowrap;
+    pointer-events: none;
+    z-index: 2;
+}
+.stats-chart-card[hidden] {
+    display: none;
+}
+```
+
+- [ ] **Step 3: Build to verify the template compiles**
+
+Run: `cargo build`
+Expected: PASS — Askama compiles the new `y_ticks` loop and `daily_read_counts` access; no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cargo fmt
+git add templates/statistics.html static/css/app.css
+git commit -m "feat(stats): render Y-axis, gridlines, and tap target markup for daily-read chart"
+```
+
+---
+
+### Task 3: `<rdrs-reading-chart>` custom element + registration
+
+Add the vanilla custom element that highlights a tapped bar and positions the
+info card, register it as a served asset, and load it only on `/statistics`.
+
+**Files:**
+- Create: `static/js/components/rdrs-reading-chart.js`
+- Modify: `src/handlers/static_assets.rs:8-25` (the `FILES` array)
+- Modify: `templates/statistics.html` (add a `{% block page_script %}` at end of the `page` block content)
+
+**Interfaces:**
+- Consumes: DOM from Task 2 (`.stats-bar-col[data-date][data-count]`, `.stats-chart-card[data-chart-card]`).
+- Produces: registered element `rdrs-reading-chart`; served at `/static/js/components/rdrs-reading-chart.js`.
+
+- [ ] **Step 1: Create the custom element**
+
+Create `static/js/components/rdrs-reading-chart.js`:
+
+```js
+// <rdrs-reading-chart> — tap/click a bar to highlight it and show an info card.
+// Light DOM: enhances the server-rendered bars on /statistics. Pointer/click
+// events cover mouse, touch, and pen with one code path; bars are focusable so
+// Enter/Space work too. With JS disabled the static chart + native title remain.
+
+class RdrsReadingChart extends HTMLElement {
+    connectedCallback() {
+        this.card = this.querySelector('[data-chart-card]');
+        this.cols = Array.from(this.querySelectorAll('.stats-bar-col'));
+        this._active = null;
+
+        this.cols.forEach((col) => {
+            col.addEventListener('click', () => this._toggle(col));
+            col.addEventListener('keydown', (e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    this._toggle(col);
+                }
+            });
+        });
+
+        // Tap the chart's empty area to dismiss.
+        this.addEventListener('click', (e) => {
+            if (e.target === this) this._clear();
+        });
+        this.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape') this._clear();
+        });
+    }
+
+    _toggle(col) {
+        if (this._active === col) {
+            this._clear();
+        } else {
+            this._show(col);
+        }
+    }
+
+    _show(col) {
+        if (this._active) this._active.classList.remove('is-active');
+        this._active = col;
+        col.classList.add('is-active');
+
+        this.card.textContent = `${col.dataset.date} · ${col.dataset.count}`;
+        const wrapRect = this.getBoundingClientRect();
+        const colRect = col.getBoundingClientRect();
+        const left = colRect.left - wrapRect.left + colRect.width / 2;
+        this.card.style.left = `${left}px`;
+        this.card.hidden = false;
+    }
+
+    _clear() {
+        if (this._active) this._active.classList.remove('is-active');
+        this._active = null;
+        this.card.hidden = true;
+    }
+}
+
+customElements.define('rdrs-reading-chart', RdrsReadingChart);
+```
+
+- [ ] **Step 2: Register the asset**
+
+In `src/handlers/static_assets.rs`, add to the `FILES` array (after the
+`rdrs-sidebar.js` entry, ~line 24):
+
+```rust
+    (
+        "js/components/rdrs-reading-chart.js",
+        include_str!("../../static/js/components/rdrs-reading-chart.js"),
+    ),
+```
+
+- [ ] **Step 3: Load the script on the statistics page**
+
+In `templates/statistics.html`, add a `page_script` block immediately before the
+final `{% endblock %}` (the one closing `{% block page %}`, line 164):
+
+```html
+    {% block page_script %}
+    <link rel="modulepreload" href="/static/js/components/rdrs-reading-chart.js?v={{ layout.git_version }}">
+    <script type="module" src="/static/js/components/rdrs-reading-chart.js?v={{ layout.git_version }}"></script>
+    {% endblock %}
+```
+
+(The base `app_layout.html` already declares `{% block page_script %}{% endblock %}` at line 14.)
+
+- [ ] **Step 4: Build to verify everything compiles + embeds**
+
+Run: `cargo build`
+Expected: PASS — `include_str!` finds the new file; template compiles.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cargo fmt
+git add static/js/components/rdrs-reading-chart.js src/handlers/static_assets.rs templates/statistics.html
+git commit -m "feat(stats): add rdrs-reading-chart element for tap-to-inspect bars"
+```
+
+---
+
+### Task 4: E2E scenario (tap a bar shows its count)
+
+Seed read entries across two days, open `/statistics`, tap a bar, and assert the
+info card shows the count.
+
+**Files:**
+- Create: `e2e/features/statistics.feature`
+- Create: `e2e/steps/statistics.steps.js`
+
+**Interfaces:**
+- Consumes: existing fixtures `page`, `api`, `serverUrl`, `currentUser`, `seed`; `seed.getUserId`, `seed.createCategory`, `seed.createFeed`, `seed.insertEntries`, `seed.markRead`.
+- Produces: a passing tagged scenario covering the tap interaction.
+
+- [ ] **Step 1: Write the feature**
+
+Create `e2e/features/statistics.feature`:
+
+```gherkin
+Feature: Daily Read Articles chart
+
+  Background:
+    Given I am signed in
+    And I have read articles over several days
+
+  Scenario: Tapping a bar reveals that day's count
+    When I open the statistics page
+    And I tap the tallest read-activity bar
+    Then the chart info card shows a read count
+```
+
+- [ ] **Step 2: Write the step definitions**
+
+Create `e2e/steps/statistics.steps.js`. Reuse the existing `I am signed in` and
+`I open the statistics page` steps if present; the two new steps are below.
+(Confirm the signed-in/open steps already exist in `auth.steps.js` /
+`admin.steps.js`; if `I am signed in` is not already defined, use the inline sign-in
+shown here.)
+
+```js
+import { createBdd } from "playwright-bdd";
+import { test, expect } from "../support/fixtures.js";
+
+const { Given, When, Then } = createBdd(test);
+
+Given("I have read articles over several days", async ({ api, currentUser, seed }) => {
+  await api.register(currentUser.username, currentUser.password);
+  const userId = seed.getUserId(currentUser.username);
+  const categoryId = seed.createCategory(userId, "News");
+  const feedId = seed.createFeed(categoryId, "https://example.com/feed.xml", "Example");
+  const ids = seed.insertEntries(
+    Array.from({ length: 5 }, (_, i) => ({
+      feedId,
+      guid: `stats-${i}`,
+      title: `Stats Entry ${i}`,
+      link: `https://example.com/e/${i}`,
+      content: "<p>x</p>",
+    }))
+  );
+  // Three reads today, one yesterday — today's bar is the tallest.
+  seed.markRead(ids[0], "0 seconds");
+  seed.markRead(ids[1], "-1 hours");
+  seed.markRead(ids[2], "-2 hours");
+  seed.markRead(ids[3], "-1 days");
+});
+
+When("I tap the tallest read-activity bar", async ({ page }) => {
+  // The last column is "today" (chart is ordered oldest → newest), which has the
+  // most reads in the seed above.
+  const bars = page.locator("rdrs-reading-chart .stats-bar-col");
+  await bars.last().click();
+});
+
+Then("the chart info card shows a read count", async ({ page }) => {
+  const card = page.locator("rdrs-reading-chart .stats-chart-card");
+  await expect(card).toBeVisible();
+  // Format is "MM/DD · N"; assert it ends with the count 3.
+  await expect(card).toContainText(/·\s*3$/);
+});
+```
+
+If `I am signed in` is **not** already a shared step, prepend this to the file:
+
+```js
+Given("I am signed in", async ({ page, api, currentUser, serverUrl }) => {
+  await page.goto(`${serverUrl}/login`);
+  await page.getByTestId("username-input").fill(currentUser.username);
+  await page.getByTestId("password-input").fill(currentUser.password);
+  await page.getByTestId("login-submit").click();
+  await page.waitForURL(`${serverUrl}/`);
+});
+```
+
+(Note: `Given("I have read articles over several days")` already calls
+`api.register`; if a shared `I am signed in` also registers, drop the register call
+from one of them to avoid a duplicate-username error. Verify against the existing
+`auth.steps.js` during implementation and keep exactly one `api.register`.)
+
+- [ ] **Step 3: Rebuild the binary so E2E sees the new assets**
+
+Run: `cargo build`
+Expected: PASS (E2E global-setup skips building if a binary exists, so build first).
+
+- [ ] **Step 4: Regenerate BDD specs and run the scenario**
+
+Run (from `e2e/`): `npx bddgen && npx playwright test --grep "Daily Read Articles chart"`
+Expected: PASS — the info card becomes visible and contains the count `3`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add e2e/features/statistics.feature e2e/steps/statistics.steps.js
+git commit -m "test(e2e): cover tap-to-inspect on the daily-read chart"
+```
+
+---
+
+### Task 5: Full verification
+
+Confirm the whole suite, lints, and format are green before handing off.
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Format check + clippy**
+
+Run: `cargo fmt --all -- --check && cargo clippy -- -D warnings`
+Expected: PASS — no diff, no warnings.
+
+- [ ] **Step 2: Full Rust test suite**
+
+Run: `RDRS_FAST_HASH=1 cargo nextest run`
+Expected: PASS — including the Task 1 `nice_step`/`compute_y_axis` tests.
+
+- [ ] **Step 3: Confirm no README screenshot is affected**
+
+Run: `rg -n "/statistics" e2e/scripts/screenshots.js`
+Expected: NO MATCH — confirming the four README screenshots don't include the chart, so none need regeneration.
+
+- [ ] **Step 4: Manual sanity (optional, recommended)**
+
+Build + run the app, sign in to a user with read history, open `/statistics`,
+and verify: Y-axis numbers show, tapping a bar highlights it + shows the card,
+tapping empty space / `Esc` dismisses, and it works under a touch emulation.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Always-visible numeric Y-axis → Task 1 (ticks) + Task 2 (axis/gridline render). ✓
+- Tap a bar → highlight + info card → Task 2 (markup/active style) + Task 3 (JS). ✓
+- Touch support (Pointer/click + `touch-action: manipulation`) → Task 2 CSS + Task 3 JS. ✓
+- No build tooling / vanilla ES module via `include_str!` → Task 3 (asset registration). ✓
+- Info card = date + count only → Task 3 `_show` (`MM/DD · N`). ✓
+- No-JS fallback (native `title`) → Task 2 markup keeps `title`. ✓
+- Unit tests for nice-max → Task 1. ✓
+- E2E tap test → Task 4. ✓
+- Screenshots: confirmed not affected → Task 5 Step 3. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows full code. ✓
+
+**Type consistency:** `compute_y_axis` returns `(i64, Vec<TickView>)`; `TickView { value, percent }` used identically in template (`t.value`, `t.percent`). `data-date`/`data-count` set in Task 2 and read in Task 3 match. ✓

--- a/docs/superpowers/specs/2026-06-18-interactive-daily-read-chart-design.md
+++ b/docs/superpowers/specs/2026-06-18-interactive-daily-read-chart-design.md
@@ -1,0 +1,104 @@
+# Interactive Daily Read Articles Chart — Design
+
+Date: 2026-06-18
+Status: Approved (pending spec review)
+
+## Problem
+
+The "Daily Read Articles" chart on `/statistics` is a pure-CSS bar chart that
+renders shape only — it shows no numbers and has no interactivity. Exact values
+are reachable solely through the browser-native `title` tooltip on hover, which
+is invisible on touch screens. We want an interactive chart that surfaces the
+numbers and works on touch devices.
+
+## Goals
+
+- Always-visible numeric Y-axis scale (no longer "shape only").
+- Tap/click a bar to highlight it and show an info card with that day's value.
+- First-class touch support (Pointer Events; no double-tap-zoom interference).
+- Stay within project constraints: SSR-first, no frontend build tooling, vanilla
+  ES modules embedded via `include_str!`, no charting library.
+
+## Non-Goals
+
+- No line/area chart, no drag-scrub. (Considered and rejected during design:
+  user chose "C. bars + tap-to-focus" and "tap single bar only".)
+- No trend/delta comparison in the info card (date + count only).
+- No changes to the data query or the other two charts on the page.
+
+## Chosen Direction (from visual brainstorming)
+
+- **Chart type:** bars with a low-key base color; tapping a bar promotes it to the
+  accent color and reveals an info card. Y-axis scale + gridlines always visible.
+- **Interaction:** tap a single bar to show; tap another to switch; tap empty
+  space / the same bar again / `Esc` to dismiss.
+- **Info card contents:** `MM/DD · count` (date + count).
+
+## Architecture
+
+Keep the existing server-rendered `div`-bar model (consistent with the page's
+other `.stats-progress` charts). No SVG rewrite. Changes are localized:
+
+| Layer | File | Change |
+|-------|------|--------|
+| Handler | `src/handlers/pages/mod.rs` | Compute `y_ticks` (nice-max tick values) alongside existing `daily_read_counts` / `daily_max`; add to `StatisticsTemplate`. |
+| View model | `src/handlers/pages/mod.rs` | Add `y_ticks: Vec<i64>` (or a small tick struct with value + position%) to the template struct. |
+| Template | `templates/statistics.html` | Render Y-axis scale labels + gridlines; add `data-date` / `data-count` and `tabindex`/`role` to each bar column; wrap chart in `<reading-chart>`; keep `title` as no-JS fallback. |
+| CSS | `static/css/app.css` | Styles for axis labels, gridlines, `.stats-bar` highlighted state, info card, `touch-action: manipulation`. |
+| JS | `static/js/reading-chart.js` (new) | Custom element `<reading-chart>` using Pointer Events for tap highlight + info card. |
+| JS registration | wherever chrome custom elements are registered / served | Register/serve the new module via the existing static allowlist + `include_str!` pattern. |
+
+### Y-axis ticks (nice-max)
+
+Handler computes a "nice" maximum ≥ `daily_max` and a small set of evenly spaced
+tick values (e.g. 0, ¼, ½, ¾, max). Each bar's existing `height_percent` stays
+relative to the same nice-max so bars and gridlines align. Edge cases:
+
+- `daily_max == 0` → keep the existing "No read activity" message; no ticks.
+- single non-zero day → ticks still produce a sane scale (e.g. max rounded up).
+
+### `<reading-chart>` custom element (vanilla)
+
+- Attaches `pointerdown` listeners (covers mouse / touch / pen) to bar columns.
+- On activate: clear any previously highlighted bar, add highlighted class to the
+  target, position an info card (absolutely positioned within the chart) above the
+  bar showing `MM/DD · count` read from `data-*`.
+- Dismiss on: tapping empty chart area, re-tapping the active bar, or `Esc`.
+- Keyboard: bars are focusable; `Enter`/`Space` activates the focused bar.
+- `touch-action: manipulation` on the chart to suppress double-tap zoom.
+- Progressive enhancement: with JS disabled, bars + axis + native `title` still
+  render and are readable.
+
+## Data Flow
+
+```
+get_daily_read_counts (unchanged SQL)
+  -> daily_max
+  -> nice_max + y_ticks            (new, handler-side)
+  -> DailyReadView { date, count, height_percent, short_label }  (unchanged)
+  -> StatisticsTemplate { ..., y_ticks }
+  -> Askama renders bars (+ data-*) + axis + gridlines
+  -> <reading-chart> JS enhances tap interaction
+```
+
+## Error / Edge Handling
+
+- No data in period: existing empty-state message; chart + JS not rendered.
+- JS fails to load / disabled: static chart with axis numbers + native `title`.
+- Very many days (wide range): bars already flex to fit; tap targets remain the
+  full column width, not just the bar, so thin bars stay tappable.
+
+## Testing
+
+- **Unit (Rust):** `y_ticks` / nice-max computation — typical range, empty data,
+  single-day, and a max that is already "nice".
+- **E2E (Playwright BDD):** tap a bar → info card appears with the correct
+  `MM/DD · count`; tap empty area → dismissed. Use pointer/touch interaction.
+- **Screenshots:** UI changed, so rebuild (`cargo build`) and regenerate the four
+  `screenshots/` images referenced by `README.md`.
+
+## Constraints Recap
+
+- No bundler/transpiler; vanilla ES module served via `include_str!`.
+- `cargo fmt` + `cargo clippy -D warnings` must pass; tests via `cargo nextest`.
+- Rebuild before E2E/screenshots so embedded assets are fresh.

--- a/e2e/features/statistics.feature
+++ b/e2e/features/statistics.feature
@@ -8,3 +8,8 @@ Feature: Daily Read Articles chart
     When I open the statistics page
     And I tap the tallest read-activity bar
     Then the chart info card shows a read count
+
+  Scenario: The info card appears just above the tapped bar
+    When I open the statistics page
+    And I tap the single-read bar
+    Then the info card sits just above that bar

--- a/e2e/features/statistics.feature
+++ b/e2e/features/statistics.feature
@@ -1,0 +1,10 @@
+Feature: Daily Read Articles chart
+
+  Background:
+    Given I am signed in
+    And I have read articles over several days
+
+  Scenario: Tapping a bar reveals that day's count
+    When I open the statistics page
+    And I tap the tallest read-activity bar
+    Then the chart info card shows a read count

--- a/e2e/steps/statistics.steps.js
+++ b/e2e/steps/statistics.steps.js
@@ -31,7 +31,9 @@ Given("I have read articles over several days", async ({ currentUser, seed }) =>
 
 When("I tap the tallest read-activity bar", async ({ page }) => {
   // The chart renders oldest → newest; the last column is today, which has count 3.
-  await page.locator("rdrs-reading-chart .stats-bar-col").last().click();
+  const bar = page.locator("rdrs-reading-chart .stats-bar-col").last();
+  await bar.waitFor();
+  await bar.click();
 });
 
 Then("the chart info card shows a read count", async ({ page }) => {

--- a/e2e/steps/statistics.steps.js
+++ b/e2e/steps/statistics.steps.js
@@ -1,0 +1,42 @@
+import { createBdd } from "playwright-bdd";
+import { test, expect } from "../support/fixtures.js";
+
+const { Given, When, Then } = createBdd(test);
+
+// NOTE: "I am signed in" (auth.steps.js) already calls api.register and logs in.
+// NOTE: "I open the statistics page" is defined in admin.steps.js.
+// This file defines only the three steps unique to the chart interaction.
+
+Given("I have read articles over several days", async ({ currentUser, seed }) => {
+  // User is already registered by "I am signed in". Just seed data.
+  const userId = seed.getUserId(currentUser.username);
+  const categoryId = seed.createCategory(userId, "News");
+  const feedId = seed.createFeed(categoryId, "https://example.com/feed.xml", "Example");
+  const ids = seed.insertEntries(
+    Array.from({ length: 4 }, (_, i) => ({
+      feedId,
+      guid: `stats-${i}`,
+      title: `Stats Entry ${i}`,
+      link: `https://example.com/e/${i}`,
+      content: "<p>x</p>",
+    }))
+  );
+  // Three reads today → today's bar is the tallest (count = 3).
+  seed.markRead(ids[0], "0 seconds");
+  seed.markRead(ids[1], "-1 hours");
+  seed.markRead(ids[2], "-2 hours");
+  // One read yesterday → yesterday's bar has count = 1.
+  seed.markRead(ids[3], "-1 days");
+});
+
+When("I tap the tallest read-activity bar", async ({ page }) => {
+  // The chart renders oldest → newest; the last column is today, which has count 3.
+  await page.locator("rdrs-reading-chart .stats-bar-col").last().click();
+});
+
+Then("the chart info card shows a read count", async ({ page }) => {
+  const card = page.locator("rdrs-reading-chart .stats-chart-card");
+  await expect(card).toBeVisible();
+  // Format is "MM/DD · N"; assert it ends with the count 3.
+  await expect(card).toContainText(/·\s*3$/);
+});

--- a/e2e/steps/statistics.steps.js
+++ b/e2e/steps/statistics.steps.js
@@ -42,3 +42,24 @@ Then("the chart info card shows a read count", async ({ page }) => {
   // Format is "MM/DD · N"; assert it ends with the count 3.
   await expect(card).toContainText(/·\s*3$/);
 });
+
+When("I tap the single-read bar", async ({ page }) => {
+  // The "yesterday" column has count 1 — a short bar, well below the chart top.
+  const bar = page.locator('rdrs-reading-chart .stats-bar-col[data-count="1"]').first();
+  await bar.waitFor();
+  await bar.click();
+});
+
+Then("the info card sits just above that bar", async ({ page }) => {
+  const card = page.locator("rdrs-reading-chart .stats-chart-card");
+  // Measure the visible coloured fill (.stats-bar), not the full-height column.
+  const barFill = page.locator('rdrs-reading-chart .stats-bar-col[data-count="1"] .stats-bar').first();
+  await expect(card).toBeVisible();
+  const cardBox = await card.boundingBox();
+  const barBox = await barFill.boundingBox();
+  // The card's bottom edge should hover just above the bar fill's top edge — a
+  // small gap, NOT floating at the chart's top edge regardless of bar height.
+  const gap = barBox.y - (cardBox.y + cardBox.height);
+  expect(gap).toBeGreaterThanOrEqual(0);
+  expect(gap).toBeLessThanOrEqual(12);
+});

--- a/src/handlers/pages/mod.rs
+++ b/src/handlers/pages/mod.rs
@@ -2140,6 +2140,13 @@ pub struct DailyReadView {
     pub short_label: String,
 }
 
+/// One Y-axis gridline + label on the daily-read chart. `percent` is the
+/// distance from the chart bottom, against the nice-max scale.
+pub struct TickView {
+    pub value: i64,
+    pub percent: f64,
+}
+
 /// One row in the "Entries by Category" list, with pre-computed bar width.
 pub struct CategoryStatsView {
     pub name: String,
@@ -2152,6 +2159,44 @@ pub struct FeedStatsView {
     pub title: String,
     pub count: i64,
     pub width_percent: f64,
+}
+
+/// Pick a "nice" tick step (1-2-5 × 10ⁿ) targeting ~4 ticks for the given max.
+fn nice_step(max: i64) -> i64 {
+    if max <= 4 {
+        return 1;
+    }
+    let raw = max as f64 / 4.0;
+    let mag = 10f64.powf(raw.log10().floor());
+    let norm = raw / mag;
+    let nice = if norm <= 1.0 {
+        1.0
+    } else if norm <= 2.0 {
+        2.0
+    } else if norm <= 5.0 {
+        5.0
+    } else {
+        10.0
+    };
+    ((nice * mag).round() as i64).max(1)
+}
+
+/// Nice-max ceiling + Y-axis ticks for a chart whose largest value is `max`
+/// (`max > 0`). Bars are scaled against the returned `nice_max` so their tops
+/// align with the gridlines.
+fn compute_y_axis(max: i64) -> (i64, Vec<TickView>) {
+    let step = nice_step(max);
+    let nice_max = ((max + step - 1) / step) * step;
+    let mut ticks = Vec::new();
+    let mut v = step;
+    while v <= nice_max {
+        ticks.push(TickView {
+            value: v,
+            percent: (v as f64 * 100.0) / nice_max as f64,
+        });
+        v += step;
+    }
+    (nice_max, ticks)
 }
 
 /// Format a byte count for display (binary units, one decimal above 1 KB).
@@ -2208,6 +2253,7 @@ pub struct StatisticsTemplate {
     pub read_rate_fmt: String,
     pub daily_max: i64,
     pub daily_read_counts: Vec<DailyReadView>,
+    pub y_ticks: Vec<TickView>,
     pub categories: Vec<CategoryStatsView>,
     pub top_feeds: Vec<FeedStatsView>,
     pub admin: Option<AdminStatsView>,
@@ -2636,6 +2682,11 @@ pub async fn statistics_page(
     };
 
     let daily_max = daily.iter().map(|d| d.count).max().unwrap_or(0);
+    let (daily_scale_max, y_ticks) = if daily_max > 0 {
+        compute_y_axis(daily_max)
+    } else {
+        (0, Vec::new())
+    };
     let cat_max = cats.iter().map(|c| c.count).max().unwrap_or(0);
     let feed_max = feeds.iter().map(|f| f.count).max().unwrap_or(0);
 
@@ -2648,8 +2699,8 @@ pub async fn statistics_page(
             } else {
                 date_str.clone()
             };
-            let height_percent = if daily_max > 0 {
-                (d.count as f64 * 100.0) / daily_max as f64
+            let height_percent = if daily_scale_max > 0 {
+                (d.count as f64 * 100.0) / daily_scale_max as f64
             } else {
                 0.0
             };
@@ -2725,6 +2776,7 @@ pub async fn statistics_page(
             read_rate_fmt: format!("{:.1}", overview.read_rate()),
             daily_max,
             daily_read_counts,
+            y_ticks,
             categories,
             top_feeds,
             admin,
@@ -2972,5 +3024,45 @@ mod tests {
         assert_eq!(super::format_db_bytes(1536), "1.5 KB");
         assert_eq!(super::format_db_bytes(5 * 1024 * 1024), "5.0 MB");
         assert_eq!(super::format_db_bytes(3 * 1024 * 1024 * 1024), "3.0 GB");
+    }
+
+    #[test]
+    fn nice_step_small_maxes_are_one() {
+        assert_eq!(super::nice_step(1), 1);
+        assert_eq!(super::nice_step(3), 1);
+        assert_eq!(super::nice_step(4), 1);
+    }
+
+    #[test]
+    fn nice_step_uses_one_two_five_progression() {
+        assert_eq!(super::nice_step(8), 2);
+        assert_eq!(super::nice_step(11), 5);
+        assert_eq!(super::nice_step(50), 20);
+    }
+
+    #[test]
+    fn compute_y_axis_single_day() {
+        let (nice_max, ticks) = super::compute_y_axis(1);
+        assert_eq!(nice_max, 1);
+        assert_eq!(ticks.len(), 1);
+        assert_eq!(ticks[0].value, 1);
+        assert!((ticks[0].percent - 100.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn compute_y_axis_rounds_up_to_nice_max() {
+        let (nice_max, ticks) = super::compute_y_axis(11);
+        assert_eq!(nice_max, 15);
+        let values: Vec<i64> = ticks.iter().map(|t| t.value).collect();
+        assert_eq!(values, vec![5, 10, 15]);
+        assert!((ticks[1].percent - (10.0 * 100.0 / 15.0)).abs() < 1e-9);
+    }
+
+    #[test]
+    fn compute_y_axis_exact_small_range() {
+        let (nice_max, ticks) = super::compute_y_axis(4);
+        assert_eq!(nice_max, 4);
+        let values: Vec<i64> = ticks.iter().map(|t| t.value).collect();
+        assert_eq!(values, vec![1, 2, 3, 4]);
     }
 }

--- a/src/handlers/static_assets.rs
+++ b/src/handlers/static_assets.rs
@@ -22,6 +22,10 @@ const FILES: &[(&str, &str)] = &[
         "js/components/rdrs-sidebar.js",
         include_str!("../../static/js/components/rdrs-sidebar.js"),
     ),
+    (
+        "js/components/rdrs-reading-chart.js",
+        include_str!("../../static/js/components/rdrs-reading-chart.js"),
+    ),
 ];
 
 fn content_type_for(path: &str) -> &'static str {

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -2385,13 +2385,46 @@ summary {
     margin-bottom: var(--space-3);
 }
 
+.stats-chart-wrap {
+    position: relative;
+    display: flex;
+    align-items: stretch;
+    gap: var(--space-2);
+    margin-bottom: var(--space-6);
+    touch-action: manipulation;
+}
+.stats-y-axis {
+    position: relative;
+    width: 1.75rem;
+    height: 160px;
+    flex-shrink: 0;
+}
+.stats-y-tick {
+    position: absolute;
+    right: 0;
+    transform: translateY(50%);
+    font-family: var(--font-ui);
+    font-size: 10px;
+    color: var(--color-text-muted);
+    line-height: 1;
+}
 .stats-chart {
+    flex: 1;
     display: flex;
     align-items: flex-end;
     gap: 2px;
     height: 160px;
-    padding-bottom: var(--space-6);
+    margin-bottom: var(--space-6);
     position: relative;
+    min-width: 0;
+}
+.stats-gridline {
+    position: absolute;
+    left: 0;
+    right: 0;
+    height: 1px;
+    background: var(--color-border-light);
+    z-index: 0;
 }
 .stats-bar-col {
     flex: 1;
@@ -2402,13 +2435,23 @@ summary {
     height: 100%;
     min-width: 0;
     position: relative;
+    z-index: 1;
+    cursor: pointer;
+}
+.stats-bar-col:focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 2px;
 }
 .stats-bar {
     width: 100%;
-    background: var(--color-accent);
+    background: var(--color-accent-subtle);
     border-radius: var(--radius-sm) var(--radius-sm) 0 0;
     min-height: 2px;
-    transition: height 0.2s;
+    transition: height 0.2s, background 0.15s;
+}
+.stats-bar-col.is-active .stats-bar,
+.stats-bar-col:hover .stats-bar {
+    background: var(--color-accent);
 }
 .stats-bar-label {
     font-family: var(--font-ui);
@@ -2423,6 +2466,24 @@ summary {
     left: 0;
     right: 0;
     text-align: center;
+}
+.stats-chart-card {
+    position: absolute;
+    top: 0;
+    transform: translate(-50%, -100%);
+    background: var(--color-text);
+    color: var(--color-bg);
+    font-family: var(--font-ui);
+    font-size: 11px;
+    line-height: 1;
+    padding: 0.3rem 0.5rem;
+    border-radius: var(--radius-sm);
+    white-space: nowrap;
+    pointer-events: none;
+    z-index: 2;
+}
+.stats-chart-card[hidden] {
+    display: none;
 }
 
 .stats-columns {

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -72,6 +72,7 @@
     --color-accent: light-dark(#B8860B, #D4A853);
     --color-accent-hover: light-dark(#9A7209, #E0BA6A);
     --color-accent-subtle: light-dark(rgba(184, 134, 11, 0.1), rgba(212, 168, 83, 0.12));
+    --color-accent-muted: light-dark(rgba(184, 134, 11, 0.4), rgba(212, 168, 83, 0.4));
     --color-success: light-dark(#2D7A3A, #4ADE80);
     --color-error: light-dark(#B91C1C, #F87171);
     --color-warning: light-dark(#92610E, #FBBF24);
@@ -2390,7 +2391,6 @@ summary {
     display: flex;
     align-items: stretch;
     gap: var(--space-2);
-    margin-bottom: var(--space-6);
     touch-action: manipulation;
 }
 .stats-y-axis {
@@ -2444,7 +2444,7 @@ summary {
 }
 .stats-bar {
     width: 100%;
-    background: var(--color-accent-subtle);
+    background: var(--color-accent-muted);
     border-radius: var(--radius-sm) var(--radius-sm) 0 0;
     min-height: 2px;
     transition: height 0.2s, background 0.15s;

--- a/static/js/components/rdrs-reading-chart.js
+++ b/static/js/components/rdrs-reading-chart.js
@@ -1,0 +1,59 @@
+// <rdrs-reading-chart> — tap/click a bar to highlight it and show an info card.
+// Light DOM: enhances the server-rendered bars on /statistics. Pointer/click
+// events cover mouse, touch, and pen with one code path; bars are focusable so
+// Enter/Space work too. With JS disabled the static chart + native title remain.
+
+class RdrsReadingChart extends HTMLElement {
+    connectedCallback() {
+        this.card = this.querySelector('[data-chart-card]');
+        this.cols = Array.from(this.querySelectorAll('.stats-bar-col'));
+        this._active = null;
+
+        this.cols.forEach((col) => {
+            col.addEventListener('click', () => this._toggle(col));
+            col.addEventListener('keydown', (e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    this._toggle(col);
+                }
+            });
+        });
+
+        // Tap the chart's empty area to dismiss.
+        this.addEventListener('click', (e) => {
+            if (e.target === this) this._clear();
+        });
+        this.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape') this._clear();
+        });
+    }
+
+    _toggle(col) {
+        if (this._active === col) {
+            this._clear();
+        } else {
+            this._show(col);
+        }
+    }
+
+    _show(col) {
+        if (this._active) this._active.classList.remove('is-active');
+        this._active = col;
+        col.classList.add('is-active');
+
+        this.card.textContent = `${col.dataset.date} · ${col.dataset.count}`;
+        const wrapRect = this.getBoundingClientRect();
+        const colRect = col.getBoundingClientRect();
+        const left = colRect.left - wrapRect.left + colRect.width / 2;
+        this.card.style.left = `${left}px`;
+        this.card.hidden = false;
+    }
+
+    _clear() {
+        if (this._active) this._active.classList.remove('is-active');
+        this._active = null;
+        this.card.hidden = true;
+    }
+}
+
+customElements.define('rdrs-reading-chart', RdrsReadingChart);

--- a/static/js/components/rdrs-reading-chart.js
+++ b/static/js/components/rdrs-reading-chart.js
@@ -6,6 +6,7 @@
 class RdrsReadingChart extends HTMLElement {
     connectedCallback() {
         this.card = this.querySelector('[data-chart-card]');
+        if (!this.card) return;
         this.cols = Array.from(this.querySelectorAll('.stats-bar-col'));
         this._active = null;
 

--- a/static/js/components/rdrs-reading-chart.js
+++ b/static/js/components/rdrs-reading-chart.js
@@ -43,10 +43,15 @@ class RdrsReadingChart extends HTMLElement {
         col.classList.add('is-active');
 
         this.card.textContent = `${col.dataset.date} · ${col.dataset.count}`;
+        // Anchor the card to the visible bar fill, not the full-height column —
+        // otherwise it floats at the chart's top edge for every short bar.
         const wrapRect = this.getBoundingClientRect();
-        const colRect = col.getBoundingClientRect();
-        const left = colRect.left - wrapRect.left + colRect.width / 2;
+        const bar = col.querySelector('.stats-bar') || col;
+        const barRect = bar.getBoundingClientRect();
+        const left = barRect.left - wrapRect.left + barRect.width / 2;
+        const top = barRect.top - wrapRect.top - 6;
         this.card.style.left = `${left}px`;
+        this.card.style.top = `${top}px`;
         this.card.hidden = false;
     }
 

--- a/templates/statistics.html
+++ b/templates/statistics.html
@@ -54,14 +54,27 @@
                     {% if daily_max == 0 %}
                         <p class="muted">No read activity in this period</p>
                     {% else %}
-                        <div class="stats-chart">
-                            {% for d in daily_read_counts %}
-                                <div class="stats-bar-col" title="{{ d.date }}: {{ d.count }}">
-                                    <div class="stats-bar" style="height: {{ d.height_percent }}%"></div>
-                                    <div class="stats-bar-label">{{ d.short_label }}</div>
-                                </div>
-                            {% endfor %}
-                        </div>
+                        <rdrs-reading-chart class="stats-chart-wrap">
+                            <div class="stats-y-axis" aria-hidden="true">
+                                {% for t in y_ticks %}
+                                    <span class="stats-y-tick" style="bottom: {{ t.percent }}%">{{ t.value }}</span>
+                                {% endfor %}
+                            </div>
+                            <div class="stats-chart">
+                                {% for t in y_ticks %}
+                                    <div class="stats-gridline" style="bottom: {{ t.percent }}%" aria-hidden="true"></div>
+                                {% endfor %}
+                                {% for d in daily_read_counts %}
+                                    <div class="stats-bar-col" data-date="{{ d.short_label }}" data-count="{{ d.count }}"
+                                         title="{{ d.date }}: {{ d.count }}" tabindex="0" role="button"
+                                         aria-label="{{ d.date }}: {{ d.count }} read">
+                                        <div class="stats-bar" style="height: {{ d.height_percent }}%"></div>
+                                        <div class="stats-bar-label">{{ d.short_label }}</div>
+                                    </div>
+                                {% endfor %}
+                            </div>
+                            <div class="stats-chart-card" data-chart-card hidden></div>
+                        </rdrs-reading-chart>
                     {% endif %}
                 </div>
 

--- a/templates/statistics.html
+++ b/templates/statistics.html
@@ -174,4 +174,8 @@
             </div>
         </main>
     </div>
+    {% block page_script %}
+    <link rel="modulepreload" href="/static/js/components/rdrs-reading-chart.js?v={{ layout.git_version }}">
+    <script type="module" src="/static/js/components/rdrs-reading-chart.js?v={{ layout.git_version }}"></script>
+    {% endblock %}
 {% endblock %}


### PR DESCRIPTION
## Summary

The `/statistics` "Daily Read Articles" chart previously rendered shape only — a
pure-CSS bar chart with no numeric scale and no interaction; exact values were
reachable only through the browser-native `title` tooltip on hover, invisible on
touch screens. This PR turns it into an interactive, touch-friendly chart that
surfaces the numbers.

## What changed

- **Numeric Y-axis.** The handler computes a "nice-max" ceiling (1-2-5 × 10ⁿ
  steps) and tick values server-side; the template renders always-visible axis
  labels and gridlines. Bars are scaled against the same nice-max so their tops
  align with the gridlines.
- **Tap to inspect.** A new vanilla `<rdrs-reading-chart>` custom element
  (light DOM, click + keyboard events) highlights a tapped/clicked bar and shows
  an info card (`MM/DD · count`). Dismiss on empty-area tap, re-tap, or `Esc`.
- **Touch support.** `touch-action: manipulation` plus pointer-agnostic `click`
  handling covers mouse, touch, and pen; bars are focusable (`role="button"`,
  `tabindex`, `aria-label`) so `Enter`/`Space` work too.
- **Progressive enhancement.** With JS disabled, the static chart, axis numbers,
  and native `title` fallback still render.

No charting library, no build tooling — a vanilla ES module embedded via
`include_str!`, loaded only on `/statistics`. Theming is fully inherited through
CSS custom properties (light/dark).

## Tests

- Unit tests for the nice-max/tick math (`nice_step`, `compute_y_axis`): small
  ranges, single day, round-up (11 → 15), already-nice.
- Playwright BDD scenario: seed read history, tap the tallest bar, assert the
  info card shows the correct count.
- `cargo fmt`, `cargo clippy -- -D warnings`, and `cargo nextest run` (928/928)
  all green.

The four README screenshots only capture the unread list and the keyboard-help
overlay (never `/statistics`), so none are affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)