### PR TITLE
Daily Read chart: tappable bars + tooltips on every screen

### DIFF
--- a/e2e/features/responsive.feature
+++ b/e2e/features/responsive.feature
@@ -216,3 +216,7 @@ Feature: Responsive layout
     And the daily-read chart has at most 14 bars
     And the daily-read bars are each at least 16px wide
     And the page has no horizontal scroll
+    When I hover daily-read bar number 2
+    Then the visible daily-read tooltip is within the viewport
+    When I hover the last daily-read bar
+    Then the visible daily-read tooltip is within the viewport

--- a/e2e/features/responsive.feature
+++ b/e2e/features/responsive.feature
@@ -195,3 +195,14 @@ Feature: Responsive layout
     Given I am viewing on a mobile screen
     When I open the import page
     Then the "input[type='file']" control is at least 44px tall
+
+  @mobile
+  Scenario: Statistics Daily Read chart never causes horizontal scroll on mobile
+    Given I am viewing on a mobile screen
+    And I have read entries across several days
+    When I open the statistics page
+    Then the ".stats-chart" element is visible
+    And the page has no horizontal scroll
+    When I hover the last daily-read bar
+    Then the ".stats-bar-col:last-child .stats-bar-tip" element is visible
+    And the page has no horizontal scroll

--- a/e2e/features/responsive.feature
+++ b/e2e/features/responsive.feature
@@ -206,3 +206,13 @@ Feature: Responsive layout
     When I hover the last daily-read bar
     Then the ".stats-bar-col:last-child .stats-bar-tip" element is visible
     And the page has no horizontal scroll
+
+  @mobile
+  Scenario: Dense statistics ranges bucket into a tappable number of bars on mobile
+    Given I am viewing on a mobile screen
+    And I have read entries spanning several weeks
+    When I open the statistics page for the "90d" period
+    Then the daily-read chart is visible
+    And the daily-read chart has at most 14 bars
+    And the daily-read bars are each at least 16px wide
+    And the page has no horizontal scroll

--- a/e2e/features/responsive.feature
+++ b/e2e/features/responsive.feature
@@ -215,6 +215,7 @@ Feature: Responsive layout
     Then the daily-read chart is visible
     And the daily-read chart has at most 14 bars
     And the daily-read bars are each at least 16px wide
+    And some daily-read axis labels are hidden
     And the page has no horizontal scroll
     When I hover daily-read bar number 2
     Then the visible daily-read tooltip is within the viewport

--- a/e2e/steps/responsive.steps.js
+++ b/e2e/steps/responsive.steps.js
@@ -23,8 +23,34 @@ Given("I have a feed with {int} test entries", async ({ seed, currentUser }, cou
   seed.seedTestEntries(feedId, count);
 });
 
+Given("I have read entries across several days", async ({ seed, currentUser }) => {
+  const userId = seed.getUserId(currentUser.username);
+  const categoryId = seed.createCategory(userId, `Cat-${currentUser.username}`);
+  const feedId = seed.createFeed(
+    categoryId,
+    `https://example.com/${currentUser.username}.xml`,
+    "Stats Feed",
+  );
+  // One read entry per day across the default 7-day window so the chart
+  // renders a full row of bars (incl. the rightmost, whose tooltip is what
+  // used to overflow the viewport).
+  const ids = seed.seedTestEntries(feedId, 8);
+  ids.forEach((id, dayOffset) => seed.markRead(id, `-${dayOffset} days`));
+});
+
 When("I open the inbox", async ({ page, serverUrl }) => {
   await page.goto(`${serverUrl}/`);
+});
+
+When("I hover the last daily-read bar", async ({ page }) => {
+  await page.locator(".stats-bar-col").last().hover();
+});
+
+Then("the page has no horizontal scroll", async ({ page }) => {
+  const overflow = await page.evaluate(
+    () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
+  );
+  expect(overflow).toBeLessThanOrEqual(0);
 });
 
 When("I open the categories page", async ({ page, serverUrl }) => {

--- a/e2e/steps/responsive.steps.js
+++ b/e2e/steps/responsive.steps.js
@@ -42,8 +42,46 @@ When("I open the inbox", async ({ page, serverUrl }) => {
   await page.goto(`${serverUrl}/`);
 });
 
+Given("I have read entries spanning several weeks", async ({ seed, currentUser }) => {
+  const userId = seed.getUserId(currentUser.username);
+  const categoryId = seed.createCategory(userId, `Cat-${currentUser.username}`);
+  const feedId = seed.createFeed(
+    categoryId,
+    `https://example.com/${currentUser.username}.xml`,
+    "Stats Feed",
+  );
+  // One read entry per day across ~30 days so a 90d range has plenty of
+  // activity to bucket into bars.
+  const ids = seed.seedTestEntries(feedId, 30);
+  ids.forEach((id, dayOffset) => seed.markRead(id, `-${dayOffset} days`));
+});
+
+When("I open the statistics page for the {string} period", async ({ page, serverUrl }, period) => {
+  await page.goto(`${serverUrl}/statistics?period=${period}`);
+});
+
 When("I hover the last daily-read bar", async ({ page }) => {
   await page.locator(".stats-bar-col").last().hover();
+});
+
+Then("the daily-read chart is visible", async ({ page }) => {
+  await expect(page.locator(".stats-chart")).toBeVisible();
+});
+
+Then("the daily-read chart has at most {int} bars", async ({ page }, max) => {
+  const count = await page.locator(".stats-bar-col").count();
+  expect(count).toBeGreaterThan(0);
+  expect(count).toBeLessThanOrEqual(max);
+});
+
+Then("the daily-read bars are each at least {int}px wide", async ({ page }, min) => {
+  const cols = await page.locator(".stats-bar-col").all();
+  expect(cols.length).toBeGreaterThan(0);
+  for (const col of cols) {
+    const box = await col.boundingBox();
+    expect(box).not.toBeNull();
+    expect(box.width).toBeGreaterThanOrEqual(min);
+  }
 });
 
 Then("the page has no horizontal scroll", async ({ page }) => {

--- a/e2e/steps/responsive.steps.js
+++ b/e2e/steps/responsive.steps.js
@@ -92,6 +92,13 @@ Then("the daily-read chart has at most {int} bars", async ({ page }, max) => {
   expect(count).toBeLessThanOrEqual(max);
 });
 
+Then("some daily-read axis labels are hidden", async ({ page }) => {
+  const total = await page.locator(".stats-bar-label").count();
+  const visible = await page.locator(".stats-bar-label:visible").count();
+  expect(total).toBeGreaterThan(0);
+  expect(visible).toBeLessThan(total);
+});
+
 Then("the daily-read bars are each at least {int}px wide", async ({ page }, min) => {
   const cols = await page.locator(".stats-bar-col").all();
   expect(cols.length).toBeGreaterThan(0);

--- a/e2e/steps/responsive.steps.js
+++ b/e2e/steps/responsive.steps.js
@@ -64,6 +64,24 @@ When("I hover the last daily-read bar", async ({ page }) => {
   await page.locator(".stats-bar-col").last().hover();
 });
 
+When("I hover daily-read bar number {int}", async ({ page }, n) => {
+  await page.locator(".stats-bar-col").nth(n - 1).hover();
+});
+
+Then("the visible daily-read tooltip is within the viewport", async ({ page }) => {
+  const rect = await page.evaluate(() => {
+    const tip = [...document.querySelectorAll(".stats-bar-tip")].find(
+      (t) => getComputedStyle(t).visibility === "visible",
+    );
+    if (!tip) return null;
+    const r = tip.getBoundingClientRect();
+    return { left: r.left, right: r.right, vw: document.documentElement.clientWidth };
+  });
+  expect(rect, "a tooltip should be visible").not.toBeNull();
+  expect(rect.left).toBeGreaterThanOrEqual(-0.5);
+  expect(rect.right).toBeLessThanOrEqual(rect.vw + 0.5);
+});
+
 Then("the daily-read chart is visible", async ({ page }) => {
   await expect(page.locator(".stats-chart")).toBeVisible();
 });

--- a/src/handlers/pages/mod.rs
+++ b/src/handlers/pages/mod.rs
@@ -2132,9 +2132,14 @@ impl IntoResponse for AdminTemplate {
     }
 }
 
-/// One day in the daily-read chart, with pre-computed bar height + label.
+/// One bar in the daily-read chart, with pre-computed bar height + labels.
+///
+/// A bar may span more than one day once the range is bucketed (see
+/// [`crate::models::statistics::bucket_daily_counts`]); `date_label` is the
+/// human-facing span shown in the tooltip, while `short_label` is the compact
+/// axis label under the bar.
 pub struct DailyReadView {
-    pub date: String,
+    pub date_label: String,
     pub count: i64,
     pub height_percent: f64,
     pub short_label: String,
@@ -2635,27 +2640,34 @@ pub async fn statistics_page(
         (String::new(), String::new())
     };
 
-    let daily_max = daily.iter().map(|d| d.count).max().unwrap_or(0);
+    // Collapse the per-day series into at most MAX_DAILY_BARS bars so dense
+    // ranges (30d/90d) stay wide enough to tap on mobile instead of degrading
+    // into hairline bars. 7-day ranges fit within the cap and stay per-day.
+    const MAX_DAILY_BARS: usize = 14;
+    let buckets = crate::models::statistics::bucket_daily_counts(&daily, MAX_DAILY_BARS);
+
+    let daily_max = buckets.iter().map(|b| b.count).max().unwrap_or(0);
     let cat_max = cats.iter().map(|c| c.count).max().unwrap_or(0);
     let feed_max = feeds.iter().map(|f| f.count).max().unwrap_or(0);
 
-    let daily_read_counts = daily
+    let daily_read_counts = buckets
         .into_iter()
-        .map(|d| {
-            let date_str = d.date.format("%Y-%m-%d").to_string();
-            let short_label = if date_str.len() >= 10 {
-                format!("{}/{}", &date_str[5..7], &date_str[8..10])
+        .map(|b| {
+            let short_label = b.start.format("%m/%d").to_string();
+            let date_label = if b.start == b.end {
+                b.start.format("%Y-%m-%d").to_string()
             } else {
-                date_str.clone()
+                // Multi-day bucket: full start date, compact end date.
+                format!("{} – {}", b.start.format("%Y-%m-%d"), b.end.format("%m/%d"))
             };
             let height_percent = if daily_max > 0 {
-                (d.count as f64 * 100.0) / daily_max as f64
+                (b.count as f64 * 100.0) / daily_max as f64
             } else {
                 0.0
             };
             DailyReadView {
-                date: date_str,
-                count: d.count,
+                date_label,
+                count: b.count,
                 height_percent,
                 short_label,
             }

--- a/src/handlers/static_assets.rs
+++ b/src/handlers/static_assets.rs
@@ -9,6 +9,10 @@ const FILES: &[(&str, &str)] = &[
     ("css/app.css", include_str!("../../static/css/app.css")),
     ("js/app.js", include_str!("../../static/js/app.js")),
     ("js/passkey.js", include_str!("../../static/js/passkey.js")),
+    (
+        "js/statistics.js",
+        include_str!("../../static/js/statistics.js"),
+    ),
     ("js/utils.js", include_str!("../../static/js/utils.js")),
     (
         "js/components/rdrs-flash.js",

--- a/src/models/statistics.rs
+++ b/src/models/statistics.rs
@@ -34,6 +34,39 @@ pub struct DailyReadCount {
     pub count: i64,
 }
 
+/// A contiguous span of days collapsed into one chart bar.
+///
+/// `start == end` when the bucket covers a single day; otherwise it spans
+/// `[start, end]` inclusive and `count` is the sum over those days.
+pub struct DailyBucket {
+    pub start: NaiveDate,
+    pub end: NaiveDate,
+    pub count: i64,
+}
+
+/// Collapse per-day read counts into at most `max_bars` contiguous buckets so
+/// a dense date range stays readable (and tappable) as a fixed number of bars.
+///
+/// Each bucket covers `ceil(len / max_bars)` consecutive days; when the input
+/// already fits within `max_bars`, every bucket is a single day (no change).
+/// Input is assumed chronologically ordered, as produced by
+/// [`get_daily_read_counts`].
+pub fn bucket_daily_counts(daily: &[DailyReadCount], max_bars: usize) -> Vec<DailyBucket> {
+    let max_bars = max_bars.max(1);
+    if daily.is_empty() {
+        return Vec::new();
+    }
+    let bucket_size = daily.len().div_ceil(max_bars);
+    daily
+        .chunks(bucket_size)
+        .map(|chunk| DailyBucket {
+            start: chunk.first().expect("chunk is non-empty").date,
+            end: chunk.last().expect("chunk is non-empty").date,
+            count: chunk.iter().map(|d| d.count).sum(),
+        })
+        .collect()
+}
+
 /// A category with its entry count.
 pub struct CategoryCount {
     pub name: String,
@@ -570,6 +603,80 @@ mod tests {
         assert_eq!(counts[1].count, 2); // Jan 2: e1+e2 read
         assert_eq!(counts[2].count, 1); // Jan 3: e3 read
         assert_eq!(counts[3].count, 0); // Jan 4: nothing
+    }
+
+    /// Build a chronological run of `DailyReadCount`s starting at `2024-01-01`,
+    /// one per element of `counts`.
+    fn daily_run(counts: &[i64]) -> Vec<DailyReadCount> {
+        let start = NaiveDate::from_ymd_opt(2024, 1, 1).unwrap();
+        counts
+            .iter()
+            .enumerate()
+            .map(|(i, &count)| DailyReadCount {
+                date: start + chrono::Duration::days(i as i64),
+                count,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_bucket_daily_counts_empty() {
+        assert!(bucket_daily_counts(&[], 14).is_empty());
+    }
+
+    #[test]
+    fn test_bucket_daily_counts_no_aggregation_within_max() {
+        let daily = daily_run(&[0, 2, 1, 0]);
+        let buckets = bucket_daily_counts(&daily, 14);
+
+        assert_eq!(buckets.len(), 4);
+        for (i, b) in buckets.iter().enumerate() {
+            assert_eq!(b.start, daily[i].date);
+            assert_eq!(b.end, daily[i].date, "single-day bucket spans one day");
+            assert_eq!(b.count, daily[i].count);
+        }
+    }
+
+    #[test]
+    fn test_bucket_daily_counts_aggregates_over_max() {
+        // 15 days > max 14 → bucket_size = ceil(15/14) = 2 → ceil(15/2) = 8 buckets.
+        let daily = daily_run(&[1; 15]);
+        let buckets = bucket_daily_counts(&daily, 14);
+
+        assert_eq!(buckets.len(), 8);
+        // First bucket spans the first two days, summed.
+        assert_eq!(
+            buckets[0].start,
+            NaiveDate::from_ymd_opt(2024, 1, 1).unwrap()
+        );
+        assert_eq!(buckets[0].end, NaiveDate::from_ymd_opt(2024, 1, 2).unwrap());
+        assert_eq!(buckets[0].count, 2);
+        // Every bucket holds at most 14 bars and no bucket exceeds bucket_size days.
+        assert!(buckets.len() <= 14);
+    }
+
+    #[test]
+    fn test_bucket_daily_counts_last_bucket_partial() {
+        // 15 days, size 2 → last (8th) bucket has a single leftover day.
+        let daily = daily_run(&[1; 15]);
+        let buckets = bucket_daily_counts(&daily, 14);
+
+        let last = buckets.last().unwrap();
+        assert_eq!(last.start, NaiveDate::from_ymd_opt(2024, 1, 15).unwrap());
+        assert_eq!(last.end, NaiveDate::from_ymd_opt(2024, 1, 15).unwrap());
+        assert_eq!(last.count, 1);
+    }
+
+    #[test]
+    fn test_bucket_daily_counts_sums_within_bucket() {
+        // 28 days → size = ceil(28/14) = 2; counts 1..=28 → bucket 0 = 1+2 = 3.
+        let counts: Vec<i64> = (1..=28).collect();
+        let daily = daily_run(&counts);
+        let buckets = bucket_daily_counts(&daily, 14);
+
+        assert_eq!(buckets.len(), 14);
+        assert_eq!(buckets[0].count, 3); // 1 + 2
+        assert_eq!(buckets[13].count, 55); // 27 + 28
     }
 
     #[test]

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -2393,6 +2393,12 @@ summary {
     padding-top: var(--space-6);
     padding-bottom: var(--space-6);
     position: relative;
+    /* Edge-bar tooltips extend past the chart; clip horizontally so they
+       never add a page-wide horizontal scrollbar on narrow viewports
+       (e.g. iPhone SE). `clip` coexists with overflow-y: visible, so the
+       tooltip still floats up into the reserved top padding. */
+    overflow-x: clip;
+    overflow-y: visible;
 }
 .stats-bar-col {
     flex: 1;
@@ -2458,6 +2464,17 @@ summary {
 .stats-bar-col:focus .stats-bar-tip {
     opacity: 1;
     visibility: visible;
+}
+/* Keep the outermost tooltips inside the chart so they stay fully readable
+   (the overflow-x: clip above is the safety net for dense, many-bar views). */
+.stats-bar-col:first-child .stats-bar-tip {
+    left: 0;
+    transform: translateX(0);
+}
+.stats-bar-col:last-child .stats-bar-tip {
+    left: auto;
+    right: 0;
+    transform: translateX(0);
 }
 
 .stats-columns {

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -2464,17 +2464,10 @@ summary {
     opacity: 1;
     visibility: visible;
 }
-/* Keep the outermost tooltips inside the chart so they stay fully readable
-   (the overflow-x: clip above is the safety net for dense, many-bar views). */
-.stats-bar-col:first-child .stats-bar-tip {
-    left: 0;
-    transform: translateX(0);
-}
-.stats-bar-col:last-child .stats-bar-tip {
-    left: auto;
-    right: 0;
-    transform: translateX(0);
-}
+/* statistics.js shifts an edge tooltip horizontally (overriding the
+   translateX baseline below) so it stays inside the chart. Without JS the
+   overflow-x: clip above keeps the page from scrolling; outermost tooltips
+   simply clip at the edge and the value remains in each bar's aria-label. */
 
 .stats-columns {
     display: grid;

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -2390,6 +2390,7 @@ summary {
     align-items: flex-end;
     gap: 2px;
     height: 160px;
+    padding-top: var(--space-6);
     padding-bottom: var(--space-6);
     position: relative;
 }
@@ -2423,6 +2424,40 @@ summary {
     left: 0;
     right: 0;
     text-align: center;
+}
+.stats-bar-col:focus {
+    outline: none;
+}
+.stats-bar-col:focus-visible .stats-bar,
+.stats-bar-col:hover .stats-bar {
+    background: var(--color-accent-hover);
+}
+.stats-bar-tip {
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    margin-bottom: var(--space-1);
+    padding: 2px var(--space-2);
+    font-family: var(--font-ui);
+    font-size: 11px;
+    line-height: 1.4;
+    white-space: nowrap;
+    color: var(--color-text);
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    box-shadow: var(--shadow-lg);
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 0.1s;
+    pointer-events: none;
+    z-index: 5;
+}
+.stats-bar-col:hover .stats-bar-tip,
+.stats-bar-col:focus .stats-bar-tip {
+    opacity: 1;
+    visibility: visible;
 }
 
 .stats-columns {

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -2453,7 +2453,6 @@ summary {
     background: var(--color-bg);
     border: 1px solid var(--color-border);
     border-radius: var(--radius-sm);
-    box-shadow: var(--shadow-lg);
     opacity: 0;
     visibility: hidden;
     transition: opacity 0.1s;

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -2477,6 +2477,17 @@ summary {
 @media (max-width: 768px) {
     .stats-columns { grid-template-columns: 1fr; }
     .stats-period-divider { display: none; }
+    /* Dense charts (bucketed 30d/90d) pack too many bars to label every one on
+       a narrow screen, so each MM/DD label truncates to "03/…". Show every
+       other label (plus the last) and let the shown ones overflow into the
+       now-empty neighbouring columns instead of clipping. */
+    .stats-chart--dense .stats-bar-label {
+        overflow: visible;
+        text-overflow: clip;
+    }
+    .stats-chart--dense .stats-bar-col:nth-child(even):not(:last-child) .stats-bar-label {
+        display: none;
+    }
 }
 
 .stats-bar-row { margin-bottom: var(--space-2); }

--- a/static/js/statistics.js
+++ b/static/js/statistics.js
@@ -1,0 +1,46 @@
+// static/js/statistics.js — Statistics page enhancements.
+//
+// Keeps the Daily Read chart's hover/focus tooltip inside the chart box.
+// Bars are bucketed to a fixed count, so a tooltip centred over a bar near
+// the chart edge would otherwise be clipped by the chart's `overflow-x: clip`
+// (the no-JS safety net that stops the page scrolling). Here we measure the
+// tooltip on interaction and shift it horizontally just enough to fit.
+//
+// Progressive enhancement: without this script the tooltips still appear —
+// the outermost ones simply clip at the edge, and the full value remains in
+// each bar's `aria-label`.
+
+/**
+ * Shift `col`'s tooltip horizontally so it stays within the chart, starting
+ * from its CSS baseline (`left: 50%` + `translateX(-50%)`).
+ */
+function placeTooltip(chart, col) {
+    const tip = col.querySelector('.stats-bar-tip');
+    if (!tip) return;
+    const PAD = 4;
+    // Reset to the centred baseline before measuring.
+    tip.style.transform = 'translateX(-50%)';
+    const chartRect = chart.getBoundingClientRect();
+    const tipRect = tip.getBoundingClientRect();
+    let shift = 0;
+    if (tipRect.left < chartRect.left + PAD) {
+        shift = chartRect.left + PAD - tipRect.left;
+    } else if (tipRect.right > chartRect.right - PAD) {
+        shift = chartRect.right - PAD - tipRect.right;
+    }
+    if (shift !== 0) {
+        tip.style.transform = `translateX(calc(-50% + ${Math.round(shift)}px))`;
+    }
+}
+
+function installChartTooltips() {
+    const chart = document.querySelector('.stats-chart');
+    if (!chart) return;
+    chart.querySelectorAll('.stats-bar-col').forEach((col) => {
+        // Recompute on each interaction so viewport resizes are handled for free.
+        col.addEventListener('pointerenter', () => placeTooltip(chart, col));
+        col.addEventListener('focus', () => placeTooltip(chart, col));
+    });
+}
+
+installChartTooltips();

--- a/templates/statistics.html
+++ b/templates/statistics.html
@@ -58,7 +58,7 @@
                     {% if daily_max == 0 %}
                         <p class="muted">No read activity in this period</p>
                     {% else %}
-                        <div class="stats-chart">
+                        <div class="stats-chart{% if daily_read_counts.len() > 10 %} stats-chart--dense{% endif %}">
                             {% for d in daily_read_counts %}
                                 <div class="stats-bar-col" tabindex="0" aria-label="{{ d.date_label }}: {{ d.count }} read">
                                     <div class="stats-bar-tip" role="tooltip">{{ d.date_label }}: <strong>{{ d.count }}</strong></div>

--- a/templates/statistics.html
+++ b/templates/statistics.html
@@ -56,8 +56,8 @@
                     {% else %}
                         <div class="stats-chart">
                             {% for d in daily_read_counts %}
-                                <div class="stats-bar-col" tabindex="0" aria-label="{{ d.date }}: {{ d.count }} read">
-                                    <div class="stats-bar-tip" role="tooltip">{{ d.date }}: <strong>{{ d.count }}</strong></div>
+                                <div class="stats-bar-col" tabindex="0" aria-label="{{ d.date_label }}: {{ d.count }} read">
+                                    <div class="stats-bar-tip" role="tooltip">{{ d.date_label }}: <strong>{{ d.count }}</strong></div>
                                     <div class="stats-bar" style="height: {{ d.height_percent }}%"></div>
                                     <div class="stats-bar-label">{{ d.short_label }}</div>
                                 </div>

--- a/templates/statistics.html
+++ b/templates/statistics.html
@@ -56,7 +56,8 @@
                     {% else %}
                         <div class="stats-chart">
                             {% for d in daily_read_counts %}
-                                <div class="stats-bar-col" title="{{ d.date }}: {{ d.count }}">
+                                <div class="stats-bar-col" tabindex="0" aria-label="{{ d.date }}: {{ d.count }} read">
+                                    <div class="stats-bar-tip" role="tooltip">{{ d.date }}: <strong>{{ d.count }}</strong></div>
                                     <div class="stats-bar" style="height: {{ d.height_percent }}%"></div>
                                     <div class="stats-bar-label">{{ d.short_label }}</div>
                                 </div>

--- a/templates/statistics.html
+++ b/templates/statistics.html
@@ -1,5 +1,9 @@
 {% extends "app_layout.html" %}
 
+{% block page_script %}
+    <script type="module" src="/static/js/statistics.js?v={{ layout.git_version }}"></script>
+{% endblock %}
+
 {% block page %}
     <div class="app-layout">
         <rdrs-sidebar active="statistics"></rdrs-sidebar>


### PR DESCRIPTION
## Summary

Reworks the **Daily Read Articles** chart on `/statistics` so its values are
legible and the bars are tappable across screen sizes (the chart previously
showed bars + dates only, with no visible counts, and degraded badly on
narrow/dense views).

## Changes

- **Tooltips** — each bar shows its date + read count on hover (desktop) and
  on tap/focus (mobile), replacing the desktop-only native `title`.
- **No horizontal scroll** — the chart clips edge tooltips so a hidden
  tooltip can no longer add a page-wide horizontal scrollbar (regressed onto
  iPhone SE at 375px).
- **Fixed bar count** — dense ranges (30d/90d) bucket into at most 14
  contiguous bars (`ceil(days / 14)` days each) so bars stay wide enough to
  tap on mobile instead of collapsing into hairlines; 7-day ranges stay
  per-day. Multi-day bars show their span in the tooltip (e.g.
  `2026-05-01 – 05/07`). Behaviour is identical on desktop.
- **Edge tooltip positioning** — a small `statistics.js` shifts an
  interior/edge bar's tooltip horizontally so it stays inside the chart for
  every bar, not just the first/last. `overflow-x: clip` remains the no-JS
  safety net; the value also lives in each bar's `aria-label`.
- **Axis labels** — on dense mobile charts, show every other label (plus the
  last) and let them overflow into empty neighbouring columns instead of
  truncating to `03/…`.
- Dropped the tooltip drop-shadow (it was clipped at the chart edge).

## Tests

- Unit tests for the pure `bucket_daily_counts` helper (no-aggregation,
  aggregation + summing, partial last bucket, empty).
- `@mobile` e2e responsive scenarios: statistics page has no horizontal
  scroll (idle + with the last tooltip shown); a 90d range caps at 14 bars,
  each comfortably wide, with thinned labels, and interior/last tooltips stay
  within the viewport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)