### PR TITLE
docs: reorganize README badges (add release + vibe-coded)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,12 @@
 
 [![CI](https://github.com/henry40408/rdrs/actions/workflows/ci.yml/badge.svg)](https://github.com/henry40408/rdrs/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/henry40408/rdrs/graph/badge.svg)](https://codecov.io/gh/henry40408/rdrs)
+[![Release](https://img.shields.io/github/v/release/henry40408/rdrs)](https://github.com/henry40408/rdrs/releases/latest)
 [![License](https://img.shields.io/github/license/henry40408/rdrs)](LICENSE.txt)
-[![Rust](https://img.shields.io/badge/rust-1.92%2B-blue.svg)](https://www.rust-lang.org/)
+[![Rust](https://img.shields.io/badge/Rust-informational?logo=rust&logoColor=white)](https://www.rust-lang.org/)
 [![Docker](https://img.shields.io/badge/docker-ghcr.io-blue.svg)](https://ghcr.io/henry40408/rdrs)
 [![Casual Maintenance Intended](https://casuallymaintained.tech/badge.svg)](https://casuallymaintained.tech/)
+[![Vibe Coded](https://img.shields.io/badge/vibe_coded-Claude-d97757?logo=anthropic&logoColor=white)](https://claude.com/claude-code)
 
 A self-hosted RSS/Atom feed reader built with Rust. Privacy-focused, lightweight, and designed for personal use.
 


### PR DESCRIPTION
## Summary

Reorganizes the README badges by purpose and tightens the set.

**Grouping (source order):**
- **Status** (auto-updating health): CI, codecov, Release
- **Facts**: License, Rust, Docker
- **Posture**: Casual Maintenance Intended, Vibe Coded

**Changes:**
- **Add** a dynamic `Release` badge (`github/v/release`) linking to the latest release — the repo ships releases (v0.50.0) but had no version badge.
- **Add** a `Vibe Coded` badge (Claude) linking to Claude Code.
- **Replace** the hand-maintained `rust 1.92+` badge with a version-less Rust identity badge. There is no `rust-version` in `Cargo.toml`, so the version claim had no source of truth and would silently rot.

Deliberately not added (kept converged, no vanity/noise): stars, issue/PR counts, last-commit, downloads.

All badge image URLs were verified to render (HTTP 200 SVG; the `anthropic` logo embeds correctly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
