### PR TITLE
chore: bump Rust to 1.96.0 and reorganize README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,12 @@
 
 [![CI](https://github.com/henry40408/rdrs/actions/workflows/ci.yml/badge.svg)](https://github.com/henry40408/rdrs/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/henry40408/rdrs/graph/badge.svg)](https://codecov.io/gh/henry40408/rdrs)
+[![Release](https://img.shields.io/github/v/release/henry40408/rdrs)](https://github.com/henry40408/rdrs/releases/latest)
 [![License](https://img.shields.io/github/license/henry40408/rdrs)](LICENSE.txt)
-[![Rust](https://img.shields.io/badge/rust-1.92%2B-blue.svg)](https://www.rust-lang.org/)
+[![Rust toolchain](https://img.shields.io/badge/dynamic/toml?url=https://raw.githubusercontent.com/henry40408/rdrs/main/rust-toolchain.toml&query=$.toolchain.channel&label=rust%20toolchain&logo=rust)](https://www.rust-lang.org/)
 [![Docker](https://img.shields.io/badge/docker-ghcr.io-blue.svg)](https://ghcr.io/henry40408/rdrs)
 [![Casual Maintenance Intended](https://casuallymaintained.tech/badge.svg)](https://casuallymaintained.tech/)
+[![Vibe Coded](https://img.shields.io/badge/vibe_coded-Claude-d97757?logo=anthropic&logoColor=white)](https://claude.com/claude-code)
 
 A self-hosted RSS/Atom feed reader built with Rust. Privacy-focused, lightweight, and designed for personal use.
 
@@ -151,7 +153,7 @@ The Dockerfile uses multi-stage builds with a distroless base image for minimal 
 
 ### Prerequisites
 
-- Rust 1.95+
+- Rust 1.96 (pinned via `rust-toolchain.toml`; rustup installs it automatically)
 - SQLite (bundled via rusqlite)
 
 ### Running Tests

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.95.0"
+channel = "1.96.0"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
## Summary

Bumps the Rust toolchain to the latest stable and reorganizes the README badges.

### Rust 1.96.0
- `rust-toolchain.toml`: `1.95.0` → `1.96.0` (latest stable, released 2026-05-28).
- No Dockerfile change needed — the base image already targets `rust:1.96`, so the pin now aligns with it.
- No CI change needed — `dtolnay/rust-toolchain` is pinned by SHA with no explicit toolchain input, so it reads the version from `rust-toolchain.toml`.
- Verified locally under 1.96.0: `cargo fmt --all -- --check` clean, `cargo clippy --all-targets -- -D warnings` clean, 953/953 tests pass (`cargo nextest run`).

### README badges
Grouped by purpose (status / facts / posture) and tightened:
- **Add** a dynamic `Release` badge (`github/v/release`) linking to the latest release.
- **Add** a `Vibe Coded` badge (Claude) linking to Claude Code.
- **Replace** the hardcoded `rust 1.92+` badge with a dynamic **toolchain** badge sourced from `rust-toolchain.toml` (`$.toolchain.channel`) — it auto-tracks the pinned toolchain and cannot go stale. It reflects `main`, so it shows the pinned version once merged.
- Update the Prerequisites note to Rust 1.96.

Deliberately not added (kept converged): stars, issue/PR counts, last-commit, downloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
