### PR TITLE
feat(auth): forward-auth (trusted-header) login

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -96,7 +96,8 @@ src/
 ├── middleware/          # HTTP middleware
 │   ├── auth.rs          # Session authentication
 │   ├── date_header.rs   # Date response header
-│   └── flash.rs         # Flash messages
+│   ├── flash.rs         # Flash messages
+│   └── forward_auth.rs  # Forward-auth / trusted-header browser login
 │
 └── auth/
     ├── password.rs      # Password hashing (Argon2)
@@ -126,6 +127,12 @@ Loads settings from environment variables:
 - `SERVER_PORT` - HTTP port
 - `SIGNUP_ENABLED` / `MULTI_USER_ENABLED` - Registration settings
 - `IMAGE_PROXY_SECRET` - HMAC secret for image proxy
+- `AUTH_PROXY_HEADER` - Header name carrying the username from a forward-auth proxy; empty disables the feature
+- `TRUSTED_PROXY_NETWORKS` - Comma-separated CIDRs/IPs whose TCP peer is allowed to supply the identity header; required when `AUTH_PROXY_HEADER` is set
+- `AUTH_PROXY_USER_CREATION` - Whether to JIT-create an account for an unknown proxy-provided username (`false` by default; on mismatch, redirects to `/login`)
+- `AUTH_PROXY_GROUPS_HEADER` - Header name carrying comma-separated group names from the proxy
+- `AUTH_PROXY_ADMIN_GROUP` - Group membership grants the admin role; active only when both this and `AUTH_PROXY_GROUPS_HEADER` are set
+- `DISABLE_LOCAL_AUTH` - Hides the browser password form and makes `POST /api/session` return 403; does not affect GReader `ClientLogin` or passkey auth; startup refuses if set without `AUTH_PROXY_HEADER`
 
 ### Error Handling (`error.rs`)
 
@@ -216,6 +223,43 @@ RDRS supports passwordless authentication via WebAuthn/Passkey:
 3. Browser prompts user to verify passkey
 4. Client sends assertion to server
 5. Server validates signature and creates session
+
+### Forward-Auth (Trusted-Header) Login
+
+RDRS supports delegating browser authentication to an external forward-auth proxy (e.g., Authelia, authentik, Traefik ForwardAuth). When enabled, a Tower middleware (`middleware/forward_auth.rs`) intercepts browser page requests and attempts to establish a session from a trusted identity header before falling back to the normal cookie login flow.
+
+**Trust model:**
+
+The middleware checks the TCP peer IP of the incoming connection against a set of trusted CIDRs/IPs (`TRUSTED_PROXY_NETWORKS`). The peer address comes from the connection itself (`ConnectInfo`), not from `X-Forwarded-For`, so it cannot be spoofed by a downstream client. If the peer is untrusted, the identity header is ignored and the request proceeds to the normal session-cookie check. The middleware fails closed: any of untrusted peer, missing header, absent `ConnectInfo`, or DB error leaves the user unauthenticated.
+
+**Username mapping (no schema change):**
+
+The proxy-provided username is matched against existing rdrs accounts by username. No database migration is required. Existing password accounts continue to work and automatically gain forward-auth login when their username matches the proxy-provided value.
+
+**JIT account creation:**
+
+When `AUTH_PROXY_USER_CREATION=true`, a proxy-provided username that matches no existing account causes a new local account to be created with a sentinel password hash (`"!"`) that cannot match any real password input, making local password login impossible for that account.
+
+**Group → role sync:**
+
+When both `AUTH_PROXY_GROUPS_HEADER` and `AUTH_PROXY_ADMIN_GROUP` are set, the user's role is recomputed from the groups header on every forward-auth login and persisted if it changed. The proxy/IdP is authoritative for role assignment while this mapping is active.
+
+**`DISABLE_LOCAL_AUTH` scope:**
+
+Setting `DISABLE_LOCAL_AUTH=true` hides the browser password-entry form and makes `POST /api/session` return HTTP 403. It does **not** affect GReader `ClientLogin` (`/accounts/ClientLogin`) or WebAuthn/passkey authentication, so native RSS clients and passkey users are unaffected.
+
+**Middleware scope:**
+
+The middleware is applied only to browser page routes. It is never invoked for the prefixes `/api`, `/reader`, `/accounts`, `/events`, `/static`, `/favicon`, and `/health`. It also skips requests that already carry a valid session cookie, so it adds no overhead for already-logged-in users.
+
+**Forward and passkey auth coexist:**
+
+Forward-auth, local password, and passkey authentication all work simultaneously by default. `DISABLE_LOCAL_AUTH` is the only knob that narrows that set.
+
+**Operator warnings:**
+
+1. The reverse proxy **must** authoritatively set (and strip any client-supplied copy of) the identity and groups headers on every request before forwarding to RDRS. A downstream client that can inject these headers bypasses the trust model entirely.
+2. The reverse proxy **must** be configured to bypass forward-auth for `/accounts/ClientLogin` and `/reader/api/...` so native GReader clients (FeedMe, Read You, etc.) can still authenticate with their stored username and password.
 
 ## Services
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3131,6 +3131,7 @@ dependencies = [
  "http-body-util",
  "ico",
  "image",
+ "ipnet",
  "libmimalloc-sys",
  "lol_html",
  "mimalloc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ libmimalloc-sys = { version = "0.1", features = ["extended"] }
 lol_html = "3.0.0"
 async-stream = "0.3"
 tokio-stream = "0.1"
+ipnet = "2.12"
 
 [build-dependencies]
 resvg = "0.47"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ ammonia = "4"
 readability = { version = "0.3", default-features = false }
 base64 = "0.22"
 hmac = "0.13"
+ipnet = "2.12"
 sha2 = "0.11"
 webauthn-rs = { version = "0.5", features = [
   "danger-allow-state-serialisation",
@@ -70,7 +71,6 @@ libmimalloc-sys = { version = "0.1", features = ["extended"] }
 lol_html = "3.0.0"
 async-stream = "0.3"
 tokio-stream = "0.1"
-ipnet = "2.12"
 
 [build-dependencies]
 resvg = "0.47"

--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ All configuration is done via environment variables:
 | `WEBAUTHN_RP_ORIGIN` | `http://localhost:{port}` | WebAuthn Relying Party origin URL |
 | `WEBAUTHN_RP_NAME` | `rdrs` | WebAuthn Relying Party display name |
 | `RUST_LOG` | - | Log level filter (e.g., `info`, `debug`, `rdrs=debug`) |
+| `AUTH_PROXY_HEADER` | - | Header carrying the username from a forward-auth proxy (e.g. `Remote-User`, `X-Forwarded-User`). Empty disables the feature. |
+| `TRUSTED_PROXY_NETWORKS` | - | Comma-separated CIDRs or bare IPs (e.g. `10.0.0.0/8, 192.168.1.5`). The TCP peer IP must fall within one of these for the identity header to be trusted. Required when `AUTH_PROXY_HEADER` is set. |
+| `AUTH_PROXY_USER_CREATION` | `false` | When `true`, JIT-create a local account for an unknown proxy-provided username instead of redirecting to `/login`. |
+| `AUTH_PROXY_GROUPS_HEADER` | - | Header carrying comma-separated group names from the proxy (e.g. `Remote-Groups`). |
+| `AUTH_PROXY_ADMIN_GROUP` | - | Membership in this group grants the admin role, synced on every forward-auth login. Active only when `AUTH_PROXY_GROUPS_HEADER` is also set. |
+| `DISABLE_LOCAL_AUTH` | `false` | Hides the browser password form and rejects `POST /api/session` with 403. Does not affect GReader API or passkey auth. Requires `AUTH_PROXY_HEADER`. |
 
 > **Deploying behind a domain?** `WEBAUTHN_RP_ID` and `WEBAUTHN_RP_ORIGIN`
 > default to `localhost` and **must** be overridden to your public host (e.g.

--- a/docs/superpowers/plans/2026-06-25-forward-auth-login.md
+++ b/docs/superpowers/plans/2026-06-25-forward-auth-login.md
@@ -1,0 +1,902 @@
+# Forward-Auth (Trusted-Header) Login Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let users sign in to rdrs via an upstream forward-auth proxy (Authelia, authentik, oauth2-proxy, …) that injects a trusted identity header, mapping it to existing rdrs accounts by username with zero schema change.
+
+**Architecture:** A tower middleware on the SSR page routes reads a configurable identity header — but only when the request's TCP peer IP is inside a trusted CIDR list — looks up the account by username (optionally JIT-creating it), establishes a normal session cookie, and redirects. Local password/passkey/GReader auth are untouched; an optional `DISABLE_LOCAL_AUTH` switch hides the browser password form.
+
+**Tech Stack:** Rust, axum 0.8, axum-extra (cookies), rusqlite, `ipnet` (new), axum-test for integration tests, nextest.
+
+## Global Constraints
+
+- Run tests with `cargo nextest run` (never `cargo test`); set `RDRS_FAST_HASH=1` for local runs.
+- Run `cargo fmt` before every commit; `cargo clippy -- -D warnings` must pass.
+- All commits GPG-signed (default git config); end messages with the `Co-Authored-By` trailer.
+- Stage files explicitly by name — never `git add -A`/`git add .`.
+- New dependency `ipnet` MUST be pinned to a version published ≥7 days ago (verify with `cargo info ipnet`; expected `2.12`, released >1 year ago).
+- No database schema change / migration. Account mapping is by **username** only.
+- Match existing code style: `*Params`-free small functions, inline env-bool parsing as in `config.rs`.
+
+---
+
+### Task 1: Config fields, CIDR parsing, and startup validation
+
+Adds the six env vars, the `ipnet` dependency, CIDR parsing, trust/role helper methods, and a `validate()` invoked at startup. Adding fields to `Config` breaks every struct literal, so all three are updated in the same commit.
+
+**Files:**
+- Modify: `Cargo.toml` (add `ipnet`)
+- Modify: `src/config.rs` (fields, parsing, methods, validation, tests)
+- Modify: `src/main.rs:22` (call `validate()` after `from_env`)
+- Modify: `tests/common/mod.rs` (`default_test_config` literal)
+- Modify: `src/auth/webauthn.rs:25` (`test_config` literal)
+
+**Interfaces:**
+- Produces:
+  - `Config` fields: `auth_proxy_header: String`, `trusted_proxy_networks: Vec<ipnet::IpNet>`, `auth_proxy_user_creation: bool`, `disable_local_auth: bool`, `auth_proxy_groups_header: String`, `auth_proxy_admin_group: String`
+  - `Config::auth_proxy_enabled(&self) -> bool`
+  - `Config::group_mapping_enabled(&self) -> bool`
+  - `Config::is_trusted_peer(&self, ip: std::net::IpAddr) -> bool`
+  - `Config::validate(&self) -> Result<(), String>`
+  - `config::parse_trusted_networks(raw: &str) -> Result<Vec<ipnet::IpNet>, String>` (pub)
+
+- [ ] **Step 1: Add the dependency**
+
+Run: `cargo info ipnet` to confirm the latest version is ≥7 days old, then add it:
+
+```bash
+cargo add ipnet@2.12
+```
+
+Expected: `Cargo.toml` gains `ipnet = "2.12"`.
+
+- [ ] **Step 2: Write failing config tests**
+
+Add to the `tests` module in `src/config.rs`:
+
+```rust
+#[test]
+fn test_parse_trusted_networks() {
+    let nets = parse_trusted_networks("10.0.0.0/8, 192.168.1.0/24 , 127.0.0.1").unwrap();
+    assert_eq!(nets.len(), 3);
+    assert!(parse_trusted_networks("").unwrap().is_empty());
+    assert!(parse_trusted_networks("not-an-ip").is_err());
+}
+
+#[test]
+fn test_is_trusted_peer() {
+    let cfg = Config {
+        trusted_proxy_networks: parse_trusted_networks("10.0.0.0/8").unwrap(),
+        ..test_config()
+    };
+    assert!(cfg.is_trusted_peer("10.1.2.3".parse().unwrap()));
+    assert!(!cfg.is_trusted_peer("192.168.0.1".parse().unwrap()));
+}
+
+#[test]
+fn test_validate_header_requires_trusted_networks() {
+    // Header set, no trusted networks → error.
+    let bad = Config {
+        auth_proxy_header: "Remote-User".to_string(),
+        trusted_proxy_networks: Vec::new(),
+        ..test_config()
+    };
+    assert!(bad.validate().is_err());
+
+    // Header set with trusted networks → ok.
+    let good = Config {
+        auth_proxy_header: "Remote-User".to_string(),
+        trusted_proxy_networks: parse_trusted_networks("10.0.0.0/8").unwrap(),
+        ..test_config()
+    };
+    assert!(good.validate().is_ok());
+}
+
+#[test]
+fn test_validate_disable_local_auth_requires_header() {
+    let bad = Config {
+        disable_local_auth: true,
+        auth_proxy_header: String::new(),
+        ..test_config()
+    };
+    assert!(bad.validate().is_err());
+}
+
+#[test]
+fn test_group_mapping_enabled() {
+    let off = test_config();
+    assert!(!off.group_mapping_enabled());
+    let on = Config {
+        auth_proxy_groups_header: "Remote-Groups".to_string(),
+        auth_proxy_admin_group: "admins".to_string(),
+        ..test_config()
+    };
+    assert!(on.group_mapping_enabled());
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `RDRS_FAST_HASH=1 cargo nextest run -p rdrs config::`
+Expected: FAIL — `parse_trusted_networks`, `is_trusted_peer`, `validate`, `group_mapping_enabled`, and the new fields don't exist yet.
+
+- [ ] **Step 4: Add fields, parsing, methods, and validation**
+
+In `src/config.rs`, add imports at the top:
+
+```rust
+use std::net::IpAddr;
+
+use ipnet::{IpNet, Ipv4Net, Ipv6Net};
+```
+
+Add the six fields to `struct Config` (after `public_base_url`):
+
+```rust
+    pub auth_proxy_header: String,
+    pub trusted_proxy_networks: Vec<IpNet>,
+    pub auth_proxy_user_creation: bool,
+    pub disable_local_auth: bool,
+    pub auth_proxy_groups_header: String,
+    pub auth_proxy_admin_group: String,
+```
+
+Add this free function above `impl Config`:
+
+```rust
+/// Parse a comma-separated list of CIDR networks or bare IPs into `IpNet`s.
+/// Whitespace around entries and empty entries are ignored. A bare IP becomes
+/// a host route (`/32` or `/128`).
+pub fn parse_trusted_networks(raw: &str) -> Result<Vec<IpNet>, String> {
+    let mut nets = Vec::new();
+    for part in raw.split(',') {
+        let s = part.trim();
+        if s.is_empty() {
+            continue;
+        }
+        if let Ok(net) = s.parse::<IpNet>() {
+            nets.push(net);
+        } else if let Ok(ip) = s.parse::<IpAddr>() {
+            let net = match ip {
+                IpAddr::V4(v4) => IpNet::V4(Ipv4Net::new(v4, 32).expect("host prefix is valid")),
+                IpAddr::V6(v6) => IpNet::V6(Ipv6Net::new(v6, 128).expect("host prefix is valid")),
+            };
+            nets.push(net);
+        } else {
+            return Err(format!(
+                "invalid CIDR or IP in TRUSTED_PROXY_NETWORKS: '{}'",
+                s
+            ));
+        }
+    }
+    Ok(nets)
+}
+```
+
+In `from_env`, add the six fields to the returned `Self { ... }`:
+
+```rust
+            auth_proxy_header: env::var("AUTH_PROXY_HEADER").unwrap_or_default(),
+            trusted_proxy_networks: parse_trusted_networks(
+                &env::var("TRUSTED_PROXY_NETWORKS").unwrap_or_default(),
+            )
+            .unwrap_or_default(),
+            auth_proxy_user_creation: env::var("AUTH_PROXY_USER_CREATION")
+                .map(|v| v.to_lowercase() == "true" || v == "1")
+                .unwrap_or(false),
+            disable_local_auth: env::var("DISABLE_LOCAL_AUTH")
+                .map(|v| v.to_lowercase() == "true" || v == "1")
+                .unwrap_or(false),
+            auth_proxy_groups_header: env::var("AUTH_PROXY_GROUPS_HEADER").unwrap_or_default(),
+            auth_proxy_admin_group: env::var("AUTH_PROXY_ADMIN_GROUP").unwrap_or_default(),
+```
+
+Add these methods inside `impl Config`:
+
+```rust
+    /// Whether forward-auth (trusted-header) login is enabled.
+    pub fn auth_proxy_enabled(&self) -> bool {
+        !self.auth_proxy_header.is_empty()
+    }
+
+    /// Whether group → role mapping is active (both header and admin group set).
+    pub fn group_mapping_enabled(&self) -> bool {
+        !self.auth_proxy_groups_header.is_empty() && !self.auth_proxy_admin_group.is_empty()
+    }
+
+    /// Whether `ip` (the TCP peer) falls inside a trusted proxy network.
+    pub fn is_trusted_peer(&self, ip: IpAddr) -> bool {
+        self.trusted_proxy_networks.iter().any(|net| net.contains(&ip))
+    }
+
+    /// Validate cross-field invariants at startup. Returns the first problem.
+    pub fn validate(&self) -> Result<(), String> {
+        // Surface CIDR parse errors with the offending entry.
+        if let Ok(raw) = std::env::var("TRUSTED_PROXY_NETWORKS") {
+            parse_trusted_networks(&raw)?;
+        }
+        if self.auth_proxy_enabled() && self.trusted_proxy_networks.is_empty() {
+            return Err("AUTH_PROXY_HEADER is set but TRUSTED_PROXY_NETWORKS is empty. \
+                 Refusing to trust an identity header without a trusted-source check."
+                .to_string());
+        }
+        if self.disable_local_auth && !self.auth_proxy_enabled() {
+            return Err("DISABLE_LOCAL_AUTH is set but AUTH_PROXY_HEADER is not configured. \
+                 This would leave no way to log in via the browser."
+                .to_string());
+        }
+        Ok(())
+    }
+```
+
+Update the `test_config()` helper inside `src/config.rs` tests to include the new fields:
+
+```rust
+            auth_proxy_header: String::new(),
+            trusted_proxy_networks: Vec::new(),
+            auth_proxy_user_creation: false,
+            disable_local_auth: false,
+            auth_proxy_groups_header: String::new(),
+            auth_proxy_admin_group: String::new(),
+```
+
+- [ ] **Step 5: Fix the other two Config literals**
+
+Add the same six lines to the `Config { ... }` literal in `tests/common/mod.rs` (`default_test_config`) and in `src/auth/webauthn.rs` (`test_config`, ~line 36, before the closing `}`).
+
+- [ ] **Step 6: Wire validation into startup**
+
+In `src/main.rs`, immediately after `let config = Config::from_env();` (line 22):
+
+```rust
+    if let Err(msg) = config.validate() {
+        eprintln!("Configuration error: {msg}");
+        std::process::exit(1);
+    }
+```
+
+- [ ] **Step 7: Run the full check**
+
+Run: `cargo fmt && RDRS_FAST_HASH=1 cargo nextest run -p rdrs config:: && cargo clippy -- -D warnings`
+Expected: config tests PASS, clippy clean, whole workspace still compiles (all three Config literals updated).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock src/config.rs src/main.rs tests/common/mod.rs src/auth/webauthn.rs
+git commit -m "feat(config): add forward-auth settings, CIDR trust, and startup validation
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Forward-auth middleware
+
+The core feature: a `from_fn_with_state` middleware that engages on browser page routes when a trusted peer sends the identity header, resolving/creating the account and establishing a session. Includes wiring `ConnectInfo` in `main.rs` and the layer in `lib.rs`.
+
+**Files:**
+- Create: `src/middleware/forward_auth.rs`
+- Modify: `src/middleware/mod.rs` (declare module)
+- Modify: `src/main.rs` (`into_make_service_with_connect_info::<SocketAddr>()`)
+- Modify: `src/lib.rs` (add the layer to `core`)
+- Create: `tests/forward_auth_test.rs`
+
+**Interfaces:**
+- Consumes: `Config::auth_proxy_enabled`, `group_mapping_enabled`, `is_trusted_peer` (Task 1); `user::find_by_username`, `user::create_user`, `user::update_role`, `user::count`, `models::category::create_category`, `session::create_session`, `SESSION_COOKIE_NAME`.
+- Produces:
+  - `middleware::forward_auth::forward_auth` (the axum middleware fn)
+  - `middleware::forward_auth::parse_groups(raw: &str) -> Vec<String>`
+  - `middleware::forward_auth::role_from_groups(groups: &[String], admin_group: &str) -> Role`
+
+- [ ] **Step 1: Write failing unit tests for the pure helpers**
+
+Create `src/middleware/forward_auth.rs` with only:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::user::Role;
+
+    #[test]
+    fn test_parse_groups() {
+        assert_eq!(
+            parse_groups("admins, users ,, dev"),
+            vec!["admins".to_string(), "users".to_string(), "dev".to_string()]
+        );
+        assert!(parse_groups("   ").is_empty());
+    }
+
+    #[test]
+    fn test_role_from_groups() {
+        let groups = vec!["users".to_string(), "admins".to_string()];
+        assert_eq!(role_from_groups(&groups, "admins"), Role::Admin);
+        assert_eq!(role_from_groups(&groups, "superadmins"), Role::User);
+        assert_eq!(role_from_groups(&[], "admins"), Role::User);
+    }
+}
+```
+
+Declare the module in `src/middleware/mod.rs`:
+
+```rust
+pub mod forward_auth;
+```
+
+- [ ] **Step 2: Run unit tests to verify they fail**
+
+Run: `RDRS_FAST_HASH=1 cargo nextest run -p rdrs forward_auth::tests`
+Expected: FAIL — `parse_groups`/`role_from_groups` not defined.
+
+- [ ] **Step 3: Implement the middleware**
+
+Put this above the `tests` module in `src/middleware/forward_auth.rs`:
+
+```rust
+use std::net::SocketAddr;
+
+use axum::{
+    extract::{ConnectInfo, Request, State},
+    middleware::Next,
+    response::{IntoResponse, Redirect, Response},
+};
+use axum_extra::extract::cookie::{Cookie, CookieJar, SameSite};
+use time::Duration;
+
+use crate::error::AppError;
+use crate::middleware::{FlashRedirect, SESSION_COOKIE_NAME};
+use crate::models::user::{self, Role};
+use crate::models::{category, session};
+use crate::AppState;
+
+/// Path prefixes that must never trigger forward-auth auto-login: machine
+/// endpoints (GReader native clients, JSON/passkey APIs, SSE, static assets)
+/// authenticate by their own means.
+const SKIP_PREFIXES: &[&str] = &[
+    "/api", "/reader", "/accounts", "/events", "/static", "/favicon", "/health",
+];
+
+/// Parse a comma-separated groups header into trimmed, non-empty names.
+pub fn parse_groups(raw: &str) -> Vec<String> {
+    raw.split(',')
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+/// Map groups to a role: `Admin` iff `admin_group` is present, else `User`.
+pub fn role_from_groups(groups: &[String], admin_group: &str) -> Role {
+    if groups.iter().any(|g| g == admin_group) {
+        Role::Admin
+    } else {
+        Role::User
+    }
+}
+
+pub async fn forward_auth(
+    State(state): State<AppState>,
+    jar: CookieJar,
+    req: Request,
+    next: Next,
+) -> Response {
+    let config = &state.config;
+
+    // Feature off, or already carrying a session cookie → nothing to do.
+    if !config.auth_proxy_enabled() || jar.get(SESSION_COOKIE_NAME).is_some() {
+        return next.run(req).await;
+    }
+
+    // Only engage for browser page routes.
+    if SKIP_PREFIXES
+        .iter()
+        .any(|p| req.uri().path().starts_with(p))
+    {
+        return next.run(req).await;
+    }
+
+    // Fail closed: without a known peer IP we cannot trust the header.
+    let Some(peer_ip) = req
+        .extensions()
+        .get::<ConnectInfo<SocketAddr>>()
+        .map(|c| c.0.ip())
+    else {
+        return next.run(req).await;
+    };
+    if !config.is_trusted_peer(peer_ip) {
+        return next.run(req).await;
+    }
+
+    // Read the identity header.
+    let Some(username) = req
+        .headers()
+        .get(config.auth_proxy_header.as_str())
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+    else {
+        return next.run(req).await;
+    };
+
+    // Optional group → role mapping (recomputed on every login when enabled).
+    let desired_role = if config.group_mapping_enabled() {
+        let groups = req
+            .headers()
+            .get(config.auth_proxy_groups_header.as_str())
+            .and_then(|v| v.to_str().ok())
+            .map(parse_groups)
+            .unwrap_or_default();
+        Some(role_from_groups(&groups, &config.auth_proxy_admin_group))
+    } else {
+        None
+    };
+
+    let allow_creation = config.auth_proxy_user_creation;
+
+    // Resolve (or JIT-create) the account and open a session. `None` means
+    // "reject" (unknown user with creation off, or a disabled account).
+    let outcome = state
+        .db
+        .user(move |conn| {
+            let user = match user::find_by_username(conn, &username)? {
+                Some(u) => {
+                    if u.is_disabled() {
+                        return Ok::<Option<String>, AppError>(None);
+                    }
+                    if let Some(role) = desired_role {
+                        if u.role != role {
+                            user::update_role(conn, u.id, role)?;
+                        }
+                    }
+                    u
+                }
+                None => {
+                    if !allow_creation {
+                        return Ok(None);
+                    }
+                    let role = match desired_role {
+                        Some(r) => r,
+                        None if user::count(conn)? == 0 => Role::Admin,
+                        None => Role::User,
+                    };
+                    // Sentinel hash never verifies, so local password login is
+                    // impossible for forward-auth-provisioned accounts.
+                    let created = user::create_user(conn, &username, "!", role)?;
+                    category::create_category(conn, created.id, "Uncategorized")?;
+                    created
+                }
+            };
+            let new_session = session::create_session(conn, user.id)?;
+            Ok(Some(new_session.session_token))
+        })
+        .await;
+
+    let token = match outcome {
+        Ok(Ok(Some(token))) => token,
+        Ok(Ok(None)) => {
+            return FlashRedirect::warning(
+                "/login",
+                "You are not authorized to access this instance.",
+            )
+            .into_response();
+        }
+        // DB/join error → fail closed: fall back to the normal (cookie) flow.
+        _ => return next.run(req).await,
+    };
+
+    let cookie = Cookie::build((SESSION_COOKIE_NAME, token))
+        .path("/")
+        .http_only(true)
+        .same_site(SameSite::Lax)
+        .max_age(Duration::days(session::SESSION_ABSOLUTE_MAX_DAYS))
+        .build();
+
+    // Redirect to the same URL; the just-set cookie authenticates the retry.
+    let location = req
+        .uri()
+        .path_and_query()
+        .map(|pq| pq.as_str().to_string())
+        .unwrap_or_else(|| "/".to_string());
+
+    (jar.add(cookie), Redirect::to(&location)).into_response()
+}
+```
+
+- [ ] **Step 4: Run unit tests to verify they pass**
+
+Run: `RDRS_FAST_HASH=1 cargo nextest run -p rdrs forward_auth::tests`
+Expected: PASS.
+
+- [ ] **Step 5: Wire `ConnectInfo` in `main.rs`**
+
+Add near the other `use` lines in `src/main.rs`:
+
+```rust
+use std::net::SocketAddr;
+```
+
+Change the serve call (line ~127) from `axum::serve(listener, app)` to:
+
+```rust
+    axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<SocketAddr>(),
+    )
+```
+
+- [ ] **Step 6: Add the layer in `lib.rs`**
+
+In `src/lib.rs`, in `create_router`, append one more `.layer(...)` to the end of the `core` chain — immediately after the existing `.layer(TimeoutLayer::with_status_code(...))` and before the terminating `;`:
+
+```rust
+        .layer(axum::middleware::from_fn_with_state(
+            state.clone(),
+            middleware::forward_auth::forward_auth,
+        ));
+```
+
+(`state` is still owned here; it is moved into `.with_state(state)` afterwards. `AppState` derives `Clone`.)
+
+- [ ] **Step 7: Write failing integration tests**
+
+Create `tests/forward_auth_test.rs`:
+
+```rust
+mod common;
+use common::default_test_config;
+
+use std::sync::Arc;
+
+use axum::http::StatusCode;
+use axum_test::TestServer;
+use rdrs::{auth, config::parse_trusted_networks, create_router, db, services, AppState, Config, DbPool};
+use rusqlite::Connection;
+
+fn open_shared_memory(name: &str) -> Connection {
+    let uri = format!("file:{}?mode=memory&cache=shared", name);
+    Connection::open_with_flags(
+        uri,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_WRITE
+            | rusqlite::OpenFlags::SQLITE_OPEN_CREATE
+            | rusqlite::OpenFlags::SQLITE_OPEN_URI,
+    )
+    .unwrap()
+}
+
+const DB_NAME: &str = "test_forward_auth";
+
+/// Build a server over a real loopback HTTP transport so the middleware sees a
+/// genuine `ConnectInfo` peer (127.0.0.1). `trusted` controls whether loopback
+/// is inside the trusted network.
+fn create_server(mut mutate: impl FnMut(&mut Config)) -> TestServer {
+    let write_conn = open_shared_memory(DB_NAME);
+    db::init_db(&write_conn).unwrap();
+    let read_conn = open_shared_memory(DB_NAME);
+
+    let mut config = default_test_config();
+    config.auth_proxy_header = "Remote-User".to_string();
+    config.auth_proxy_groups_header = "Remote-Groups".to_string();
+    config.auth_proxy_admin_group = "admins".to_string();
+    mutate(&mut config);
+
+    let webauthn = auth::create_webauthn(&config).unwrap();
+    let summary_cache = services::create_summary_cache(100, 24);
+    let (summary_tx, _rx) = services::create_summary_channel(10);
+    let (pool, _handle) = DbPool::new(write_conn, read_conn);
+    let state = AppState {
+        db: pool,
+        config: Arc::new(config),
+        webauthn: Arc::new(webauthn),
+        summary_cache,
+        summary_tx,
+        sidebar_cache: Arc::new(services::SidebarCache::default()),
+        summary_cancels: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        events: services::EventBus::new(16),
+        shutdown: tokio_util::sync::CancellationToken::new(),
+    };
+    let app = create_router(state);
+    TestServer::builder()
+        .http_transport()
+        .save_cookies()
+        .build(app)
+}
+
+fn seed_user(name: &str, role: rdrs::models::user::Role) {
+    let conn = open_shared_memory(DB_NAME);
+    rdrs::models::user::create_user(&conn, name, "$argon2id$invalid", role).unwrap();
+}
+
+#[tokio::test]
+async fn test_trusted_existing_user_gets_session() {
+    let server = create_server(|c| {
+        c.trusted_proxy_networks = parse_trusted_networks("127.0.0.0/8").unwrap();
+    });
+    seed_user("alice", rdrs::models::user::Role::User);
+
+    let res = server.get("/").add_header("Remote-User", "alice").await;
+
+    // Redirect carrying a freshly-minted session cookie.
+    assert!(res.status_code().is_redirection());
+    assert!(res.maybe_cookie("session_token").is_some());
+}
+
+#[tokio::test]
+async fn test_untrusted_peer_ignores_header() {
+    let server = create_server(|c| {
+        // Loopback is NOT in this network → header must be ignored.
+        c.trusted_proxy_networks = parse_trusted_networks("10.0.0.0/8").unwrap();
+    });
+    seed_user("alice", rdrs::models::user::Role::User);
+
+    let res = server.get("/").add_header("Remote-User", "alice").await;
+
+    assert!(res.maybe_cookie("session_token").is_none());
+}
+
+#[tokio::test]
+async fn test_unknown_user_creation_disabled_rejected() {
+    let server = create_server(|c| {
+        c.trusted_proxy_networks = parse_trusted_networks("127.0.0.0/8").unwrap();
+        c.auth_proxy_user_creation = false;
+    });
+
+    let res = server.get("/").add_header("Remote-User", "ghost").await;
+
+    assert!(res.maybe_cookie("session_token").is_none());
+    assert_eq!(res.header("location"), "/login");
+}
+
+#[tokio::test]
+async fn test_unknown_user_jit_created_as_admin_via_groups() {
+    let server = create_server(|c| {
+        c.trusted_proxy_networks = parse_trusted_networks("127.0.0.0/8").unwrap();
+        c.auth_proxy_user_creation = true;
+    });
+
+    let res = server
+        .get("/")
+        .add_header("Remote-User", "bob")
+        .add_header("Remote-Groups", "users,admins")
+        .await;
+
+    assert!(res.status_code().is_redirection());
+    assert!(res.maybe_cookie("session_token").is_some());
+
+    // Account was created with Admin role from the groups header.
+    let conn = open_shared_memory(DB_NAME);
+    let created = rdrs::models::user::find_by_username(&conn, "bob")
+        .unwrap()
+        .unwrap();
+    assert_eq!(created.role, rdrs::models::user::Role::Admin);
+}
+
+#[tokio::test]
+async fn test_disabled_user_rejected() {
+    let server = create_server(|c| {
+        c.trusted_proxy_networks = parse_trusted_networks("127.0.0.0/8").unwrap();
+    });
+    seed_user("carol", rdrs::models::user::Role::User);
+    let conn = open_shared_memory(DB_NAME);
+    let u = rdrs::models::user::find_by_username(&conn, "carol")
+        .unwrap()
+        .unwrap();
+    rdrs::models::user::disable_user(&conn, u.id).unwrap();
+
+    let res = server.get("/").add_header("Remote-User", "carol").await;
+
+    assert!(res.maybe_cookie("session_token").is_none());
+}
+```
+
+Note: this test references `rdrs::models::user` and `rdrs::config::parse_trusted_networks` as public paths. Confirm `pub mod models;` / `pub mod config;` re-exports exist in `src/lib.rs`; they are already public (used by other test files). If `models` is not `pub`, add `pub use` as needed in a tiny follow-up — do not broaden visibility beyond what the tests need.
+
+- [ ] **Step 8: Run integration tests to verify they fail, then pass**
+
+Run: `cargo fmt && RDRS_FAST_HASH=1 cargo nextest run -p rdrs --test forward_auth_test`
+Expected: after Steps 3/5/6 are in place, all five PASS. If `ConnectInfo` is absent under the test transport, the trusted tests will not set a cookie — that indicates `.http_transport()` is required (already used above); do not switch to mock transport.
+
+- [ ] **Step 9: Full lint + workspace test**
+
+Run: `cargo fmt && cargo clippy -- -D warnings && RDRS_FAST_HASH=1 cargo nextest run`
+Expected: clean; no regressions.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/middleware/forward_auth.rs src/middleware/mod.rs src/main.rs src/lib.rs tests/forward_auth_test.rs
+git commit -m "feat(auth): forward-auth trusted-header login middleware
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Enforce `DISABLE_LOCAL_AUTH`
+
+Blocks the browser password path when configured, while leaving GReader `ClientLogin` and passkey APIs untouched.
+
+**Files:**
+- Modify: `src/handlers/auth.rs` (`login` guard)
+- Modify: `src/handlers/pages/mod.rs` (`LoginTemplate` field + `login_page`)
+- Modify: `templates/login.html` (conditionally render the password form)
+- Modify: `tests/auth_test.rs` (new tests)
+
+**Interfaces:**
+- Consumes: `Config::disable_local_auth` (Task 1).
+- Produces: `LoginTemplate.local_auth_enabled: bool`.
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `tests/auth_test.rs` (uses that file's existing `create_test_server`/`default_test_config`):
+
+```rust
+#[tokio::test]
+async fn test_disable_local_auth_blocks_password_login() {
+    let mut config = default_test_config();
+    config.disable_local_auth = true;
+    config.auth_proxy_header = "Remote-User".to_string();
+    config.trusted_proxy_networks =
+        rdrs::config::parse_trusted_networks("127.0.0.0/8").unwrap();
+    let server = create_test_server(config);
+
+    // Seed a normal password user.
+    server
+        .post("/api/register")
+        .json(&json!({ "username": "u", "password": "password123" }))
+        .await
+        .assert_status(StatusCode::CREATED);
+
+    // Password login is now forbidden.
+    let res = server
+        .post("/api/session")
+        .json(&json!({ "username": "u", "password": "password123" }))
+        .await;
+    res.assert_status(StatusCode::FORBIDDEN);
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `RDRS_FAST_HASH=1 cargo nextest run -p rdrs --test auth_test test_disable_local_auth_blocks_password_login`
+Expected: FAIL — login still returns 200/cookie.
+
+- [ ] **Step 3: Guard the login handler**
+
+In `src/handlers/auth.rs`, at the very start of `pub async fn login(...)` (before the DB closure):
+
+```rust
+    if state.config.disable_local_auth {
+        return Err(AppError::Forbidden);
+    }
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `RDRS_FAST_HASH=1 cargo nextest run -p rdrs --test auth_test test_disable_local_auth_blocks_password_login`
+Expected: PASS.
+
+- [ ] **Step 5: Hide the password form in the UI**
+
+Add a field to `LoginTemplate` in `src/handlers/pages/mod.rs`:
+
+```rust
+    pub local_auth_enabled: bool,
+```
+
+Set it in `login_page` (inside the returned `LoginTemplate { ... }`):
+
+```rust
+            local_auth_enabled: !state.config.disable_local_auth,
+```
+
+In `templates/login.html`, wrap the password form and its "or use password" divider. Replace the divider line and the `<form id="login-form">…</form>` block so they render only when enabled:
+
+```html
+        <div id="passkey-section" style="display: none;">
+            <button type="button" id="passkey-login-btn" class="btn-primary auth-passkey-btn">
+                Login with Passkey
+            </button>
+            {% if local_auth_enabled %}
+            <p class="muted auth-divider">or use password</p>
+            {% endif %}
+        </div>
+
+        {% if local_auth_enabled %}
+        <form id="login-form" data-testid="login-form">
+            <div class="form-group">
+                <label for="username">Username</label>
+                <input type="text" id="username" name="username" required autocomplete="username" data-testid="username-input">
+            </div>
+            <div class="form-group">
+                <label for="password">Password</label>
+                <input type="password" id="password" name="password" required autocomplete="current-password" data-testid="password-input">
+            </div>
+            <button type="submit" class="btn-block" data-testid="login-submit">Sign In</button>
+        </form>
+        {% endif %}
+```
+
+The login `<script>` references `getElementById('login-form')`; guard the listener so it no-ops when the form is absent. In the script, change the listener attachment to:
+
+```javascript
+    const loginForm = document.getElementById('login-form');
+    if (loginForm) loginForm.addEventListener('submit', async (e) => {
+```
+
+and close the `if` with the existing `});` (no other change to the body).
+
+- [ ] **Step 6: Rebuild (templates are embedded) and verify**
+
+Run: `cargo build && cargo fmt && cargo clippy -- -D warnings && RDRS_FAST_HASH=1 cargo nextest run -p rdrs --test auth_test`
+Expected: builds (template compiles with the new `local_auth_enabled` field), clippy clean, auth tests PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/handlers/auth.rs src/handlers/pages/mod.rs templates/login.html tests/auth_test.rs
+git commit -m "feat(auth): honor DISABLE_LOCAL_AUTH for browser password login
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Documentation
+
+Document the new env vars, the trust model, and the migration story.
+
+**Files:**
+- Modify: `ARCHITECTURE.md` (authentication section + config list)
+- Modify: `README.md` (environment variable table)
+
+**Interfaces:** none.
+
+- [ ] **Step 1: Update `ARCHITECTURE.md`**
+
+In the Configuration section, add the six new variables. In the "Authentication Flow" area, add a "Forward-Auth (Trusted-Header) Login" subsection summarizing: configurable identity header; trusted-peer CIDR check on the TCP peer IP (not `X-Forwarded-For`); username-based mapping (no schema change); optional JIT creation; optional group→role sync; `DISABLE_LOCAL_AUTH` affects only the browser password form, not GReader/passkey. Include the operator warning that the proxy must authoritatively overwrite/strip the inbound identity/groups headers, and must bypass forward-auth for `/accounts/ClientLogin` and `/reader/api/...` so native clients keep working.
+
+- [ ] **Step 2: Update `README.md`**
+
+Add a row per variable to the environment table:
+
+| Variable | Default | Description |
+|---|---|---|
+| `AUTH_PROXY_HEADER` | (unset) | Header carrying the username from a forward-auth proxy (e.g. `Remote-User`). Empty disables the feature. |
+| `TRUSTED_PROXY_NETWORKS` | (unset) | Comma-separated CIDRs/IPs; the TCP peer must match for the header to be trusted. Required when `AUTH_PROXY_HEADER` is set. |
+| `AUTH_PROXY_USER_CREATION` | `false` | JIT-create unknown users instead of rejecting. |
+| `AUTH_PROXY_GROUPS_HEADER` | (unset) | Header with comma-separated groups (e.g. `Remote-Groups`). |
+| `AUTH_PROXY_ADMIN_GROUP` | (unset) | Membership grants the admin role (synced on every forward-auth login). |
+| `DISABLE_LOCAL_AUTH` | `false` | Hide the browser password form and reject `POST /api/session`. Does not affect GReader API or passkeys. Requires `AUTH_PROXY_HEADER`. |
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add ARCHITECTURE.md README.md
+git commit -m "docs: document forward-auth login configuration and migration
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Configurable header + multi-provider → Task 1/2 (`AUTH_PROXY_HEADER`, header read by name). ✓
+- Username mapping, no schema change → Task 2 (`find_by_username`, sentinel hash, no migration). ✓
+- Unknown identity default-reject + opt-in JIT → Task 2 (`auth_proxy_user_creation`). ✓
+- Trusted CIDR on TCP peer IP → Task 1 (`is_trusted_peer`) + Task 2 (`ConnectInfo`, fail-closed). ✓
+- Local auth coexistence + `DISABLE_LOCAL_AUTH` (browser only, GReader/passkey intact) → Task 3 (guard scoped to `POST /api/session`; `SKIP_PREFIXES` keeps `/accounts`, `/reader`, `/api` out of forward-auth). ✓
+- Group→role sync on every login, Authelia authoritative → Task 2 (`desired_role` recomputed, `update_role` on diff). ✓
+- Startup validation → Task 1 (`validate()` + main.rs). ✓
+- Docs, no screenshot regen → Task 4 (default `/login` unchanged). ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows full code. ✓
+
+**Type consistency:** `forward_auth`, `parse_groups`, `role_from_groups`, `parse_trusted_networks`, `is_trusted_peer`, `auth_proxy_enabled`, `group_mapping_enabled`, `validate`, `local_auth_enabled` used consistently across tasks. Sentinel hash `"!"` in middleware; tests seed disabled/role users via `models::user`. ✓
+
+## Notes / risks
+
+- `axum-test` `.http_transport()` is required for the middleware to observe a real `ConnectInfo` peer (loopback). The middleware fails closed when `ConnectInfo` is absent, so a wrong transport shows up as "no session cookie" in the trusted tests, not a panic.
+- If `models`/`config` are not already `pub` in `src/lib.rs`, expose exactly the items the tests use (`pub mod config;` is needed for `parse_trusted_networks`; other test files already import `rdrs::models::...`).

--- a/docs/superpowers/specs/2026-06-25-forward-auth-login-design.md
+++ b/docs/superpowers/specs/2026-06-25-forward-auth-login-design.md
@@ -1,0 +1,182 @@
+# Forward-Auth (Trusted-Header) Login — Design
+
+Date: 2026-06-25
+Status: Approved for planning
+
+## Goal
+
+Let users sign in to rdrs through an upstream identity provider (Authelia and
+friends) that performs **forward-auth**: the reverse proxy authenticates the
+request and injects an identity header, which rdrs trusts to establish a local
+session. Existing password/passkey accounts must keep working, and existing
+accounts must migrate with zero data loss.
+
+## Why forward-auth (not OIDC)
+
+Forward-auth / trusted-header SSO is the mainstream way to put SSO in front of
+apps that do not natively speak OIDC. The protocol complexity (discovery, code
+flow, JWT validation) stays in the proxy + auth service; rdrs only has to read
+one header safely. By making the header name configurable, a single
+implementation is compatible with **all** common providers — Authelia
+(`Remote-User`), authentik (`X-authentik-username`), oauth2-proxy
+(`X-Forwarded-User`), Vouch, Pomerium, Cloudflare Access, Tailscale, etc. —
+not just Authelia.
+
+OIDC was considered and rejected for this iteration: for the browser case it
+solves the same problem as forward-auth but adds a relying-party implementation
+in rdrs. It may be revisited later as an independent feature.
+
+## Non-goals
+
+- No OIDC relying-party support.
+- No `external_id` / email-based account linking. Mapping is by **username**.
+- No schema change / database migration.
+- No change to GReader API or passkey authentication mechanics.
+
+## Account mapping & migration
+
+- The identity header carries a **username**. rdrs looks it up with
+  `user::find_by_username`. This is the entire migration story: existing
+  password accounts whose username equals the Authelia username log straight in
+  and keep all their feeds / read state. **No schema change, no migration.**
+- Precondition: the upstream username must equal the existing rdrs username.
+  Mismatches are resolved by an admin renaming the rdrs account to align. An
+  `external_id` mapping column is an explicit out-of-scope follow-up.
+
+## Configuration (new env vars in `config.rs`)
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `AUTH_PROXY_HEADER` | `""` (disabled) | Header carrying the username, e.g. `Remote-User`. Empty disables the whole feature. |
+| `TRUSTED_PROXY_NETWORKS` | `""` | Comma-separated CIDR list; the TCP peer IP must fall inside one of these for the header to be trusted. |
+| `AUTH_PROXY_USER_CREATION` | `false` | When the username is unknown, JIT-create a local account instead of rejecting. |
+| `DISABLE_LOCAL_AUTH` | `false` | Hide the browser password login form and reject `POST /api/session`. Does **not** affect GReader API auth or passkeys. |
+| `AUTH_PROXY_GROUPS_HEADER` | `""` | Header carrying comma-separated groups, e.g. `Remote-Groups`. |
+| `AUTH_PROXY_ADMIN_GROUP` | `""` | Membership of this group grants the `Admin` role. |
+
+Group → role mapping is **active only when both** `AUTH_PROXY_GROUPS_HEADER`
+and `AUTH_PROXY_ADMIN_GROUP` are set.
+
+### Startup validation (mirrors Miniflux)
+
+- `AUTH_PROXY_HEADER` set but `TRUSTED_PROXY_NETWORKS` empty → refuse to start
+  (header trust without a trusted-source check is a spoofing hole).
+- `DISABLE_LOCAL_AUTH` set but `AUTH_PROXY_HEADER` empty → refuse to start (no
+  alternative browser login would remain).
+- Invalid CIDR entries in `TRUSTED_PROXY_NETWORKS` → refuse to start.
+
+## Authentication flow (new tower middleware)
+
+A middleware applied to the SSR page routes and `/login`. It runs only when the
+request has **no valid session cookie**:
+
+1. Feature disabled (`AUTH_PROXY_HEADER` empty) → pass through unchanged.
+2. Read the **TCP peer IP** from `ConnectInfo<SocketAddr>` (never
+   `X-Forwarded-For`). If it is not inside `TRUSTED_PROXY_NETWORKS` → pass
+   through (treat as if no forward-auth).
+3. Read the username from `AUTH_PROXY_HEADER`. Empty → pass through.
+4. Resolve the account:
+   - **Found, not disabled** → derive role (see below), create a session, set
+     the session cookie, and redirect to the originally requested URL. (The
+     cookie takes effect on the redirected request — same approach as Miniflux,
+     one extra round-trip on first login only.)
+   - **Found, disabled** → reject.
+   - **Not found + `AUTH_PROXY_USER_CREATION`** → JIT-create the account
+     (unusable sentinel password hash `"!"`, seed an `Uncategorized` category as
+     registration does), assign role, then create the session.
+   - **Not found + creation disabled** → reject (redirect to `/login` with a
+     warning flash).
+
+"Reject" = redirect to `/login` with a flash; it does not 500.
+
+### Why the sentinel password hash is safe
+
+`verify_password` returns `false` for any unparseable hash (confirmed in
+`auth/password.rs`: `PasswordHash::new` fails → `false`). Storing `"!"` makes
+local password login impossible for JIT accounts without a special case.
+
+## Role handling
+
+- **No group mapping configured:** roles are purely local. JIT-created accounts
+  follow the existing bootstrap rule — `Admin` when the user count is 0,
+  otherwise `User`. Admins are promoted/demoted manually in the existing admin
+  UI.
+- **Group mapping configured:** on **every** forward-auth login the role is
+  recomputed from the groups header — `Admin` if `AUTH_PROXY_ADMIN_GROUP` is in
+  the parsed group list, else `User` — and persisted if it changed. Authelia
+  becomes the authoritative source of role for forward-auth logins. This
+  overrides the bootstrap rule for JIT creation too.
+- Group mapping only affects forward-auth logins; a local-password login carries
+  no groups header and never changes the stored role.
+- **Documented caveat:** with group mapping on, a manually-set local admin can
+  be demoted on next forward-auth login, and a misconfigured admin group can
+  leave the instance with no admin. This is the operator's responsibility.
+
+## Coexistence with local auth & API clients
+
+- forward-auth, local password, and passkey coexist by default.
+- `DISABLE_LOCAL_AUTH=true` hides the `/login` password form and rejects
+  `POST /api/session`, **but** GReader `ClientLogin` and passkey API endpoints
+  keep working — native clients (FeedMe, Read You) and security keys must not be
+  locked out.
+- Deployment note (docs only): the proxy must be configured to bypass
+  forward-auth for API paths (`/accounts/ClientLogin`, `/reader/api/...`) so
+  native clients can still reach them.
+
+## Security model
+
+- `main.rs` must switch from `axum::serve(listener, app)` to
+  `axum::serve(listener, app.into_make_service_with_connect_info::<SocketAddr>())`
+  so the middleware can read the genuine TCP peer IP. (Confirmed: the project
+  does not currently wire `ConnectInfo`.)
+- The identity/groups headers are read **only** after the peer-IP trust check
+  passes, preventing a direct client from spoofing `Remote-User: admin`.
+- CIDR matching uses the `ipnet` crate (to be added, pinned to a version at
+  least 7 days old per the dependency cooldown policy).
+- Docs must warn operators that the proxy has to **authoritatively overwrite or
+  strip** the inbound identity/groups headers, so a downstream client cannot
+  smuggle them through.
+
+## Affected code
+
+- `src/config.rs` — new fields, parsing, startup validation, tests.
+- `src/main.rs` — wire `ConnectInfo<SocketAddr>`.
+- `src/middleware/` — new `forward_auth.rs` middleware + wiring in `lib.rs`.
+- `src/middleware/auth.rs` — unchanged extractors; the new middleware runs
+  before them and only acts when no session cookie is present.
+- `src/models/user.rs` — reuse `find_by_username`, `create_user`,
+  `update_role`; no schema change.
+- `templates/` — `/login` conditionally hides the password form under
+  `DISABLE_LOCAL_AUTH`.
+- `Cargo.toml` — add `ipnet`.
+
+## Testing
+
+- **Unit:** config parsing + startup validation (header requires trusted
+  networks; disable-local-auth requires header; invalid CIDR rejected); CIDR
+  membership; group parsing → role; sentinel hash never verifies.
+- **Integration:**
+  - trusted IP + existing user → session created, access granted;
+  - unknown user + creation disabled → rejected;
+  - unknown user + creation enabled → user created + session;
+  - header from untrusted IP → header ignored, no auto-login;
+  - disabled user → rejected;
+  - group mapping: admin group present → Admin; absent → demoted to User on next
+    login;
+  - `DISABLE_LOCAL_AUTH` blocks `POST /api/session` but GReader `ClientLogin`
+    still succeeds.
+
+## Docs
+
+- Update `ARCHITECTURE.md` (authentication section) and the `README` env-var
+  table.
+- No screenshot regeneration: default config leaves `/login` visually
+  unchanged; the password form only disappears when `DISABLE_LOCAL_AUTH` is
+  explicitly enabled (non-default).
+
+## Out-of-scope follow-ups
+
+- OIDC relying-party support.
+- `external_id` column for username-independent account linking.
+- email-based mapping (needs a new `email` column + backfill).
+- Per-group fine-grained permissions beyond admin/user.

--- a/src/auth/webauthn.rs
+++ b/src/auth/webauthn.rs
@@ -34,6 +34,12 @@ mod tests {
             webauthn_rp_origin: "http://localhost:3000".to_string(),
             webauthn_rp_name: "rdrs".to_string(),
             public_base_url: None,
+            auth_proxy_header: String::new(),
+            trusted_proxy_networks: Vec::new(),
+            auth_proxy_user_creation: false,
+            disable_local_auth: false,
+            auth_proxy_groups_header: String::new(),
+            auth_proxy_admin_group: String::new(),
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,8 @@
 use base64::{engine::general_purpose::STANDARD, Engine};
+use ipnet::{IpNet, Ipv4Net, Ipv6Net};
 use rand::Rng;
 use std::env;
+use std::net::IpAddr;
 
 /// Default user agent for HTTP requests (transparent and responsible crawling)
 pub const DEFAULT_USER_AGENT: &str = concat!(
@@ -22,6 +24,40 @@ pub struct Config {
     pub webauthn_rp_origin: String,
     pub webauthn_rp_name: String,
     pub public_base_url: Option<String>,
+    pub auth_proxy_header: String,
+    pub trusted_proxy_networks: Vec<IpNet>,
+    pub auth_proxy_user_creation: bool,
+    pub disable_local_auth: bool,
+    pub auth_proxy_groups_header: String,
+    pub auth_proxy_admin_group: String,
+}
+
+/// Parse a comma-separated list of CIDR networks or bare IPs into `IpNet`s.
+/// Whitespace around entries and empty entries are ignored. A bare IP becomes
+/// a host route (`/32` or `/128`).
+pub fn parse_trusted_networks(raw: &str) -> Result<Vec<IpNet>, String> {
+    let mut nets = Vec::new();
+    for part in raw.split(',') {
+        let s = part.trim();
+        if s.is_empty() {
+            continue;
+        }
+        if let Ok(net) = s.parse::<IpNet>() {
+            nets.push(net);
+        } else if let Ok(ip) = s.parse::<IpAddr>() {
+            let net = match ip {
+                IpAddr::V4(v4) => IpNet::V4(Ipv4Net::new(v4, 32).expect("host prefix is valid")),
+                IpAddr::V6(v6) => IpNet::V6(Ipv6Net::new(v6, 128).expect("host prefix is valid")),
+            };
+            nets.push(net);
+        } else {
+            return Err(format!(
+                "invalid CIDR or IP in TRUSTED_PROXY_NETWORKS: '{}'",
+                s
+            ));
+        }
+    }
+    Ok(nets)
 }
 
 impl Config {
@@ -49,6 +85,19 @@ impl Config {
                 .unwrap_or_else(|_| format!("http://localhost:{}", server_port)),
             webauthn_rp_name: env::var("WEBAUTHN_RP_NAME").unwrap_or_else(|_| "rdrs".to_string()),
             public_base_url: env::var("PUBLIC_BASE_URL").ok().filter(|s| !s.is_empty()),
+            auth_proxy_header: env::var("AUTH_PROXY_HEADER").unwrap_or_default(),
+            trusted_proxy_networks: parse_trusted_networks(
+                &env::var("TRUSTED_PROXY_NETWORKS").unwrap_or_default(),
+            )
+            .unwrap_or_default(),
+            auth_proxy_user_creation: env::var("AUTH_PROXY_USER_CREATION")
+                .map(|v| v.to_lowercase() == "true" || v == "1")
+                .unwrap_or(false),
+            disable_local_auth: env::var("DISABLE_LOCAL_AUTH")
+                .map(|v| v.to_lowercase() == "true" || v == "1")
+                .unwrap_or(false),
+            auth_proxy_groups_header: env::var("AUTH_PROXY_GROUPS_HEADER").unwrap_or_default(),
+            auth_proxy_admin_group: env::var("AUTH_PROXY_ADMIN_GROUP").unwrap_or_default(),
         }
     }
 
@@ -70,6 +119,46 @@ impl Config {
         let mut secret = vec![0u8; 32];
         rand::rng().fill_bytes(&mut secret);
         (secret, true)
+    }
+
+    /// Whether forward-auth (trusted-header) login is enabled.
+    pub fn auth_proxy_enabled(&self) -> bool {
+        !self.auth_proxy_header.is_empty()
+    }
+
+    /// Whether group → role mapping is active (both header and admin group set).
+    pub fn group_mapping_enabled(&self) -> bool {
+        !self.auth_proxy_groups_header.is_empty() && !self.auth_proxy_admin_group.is_empty()
+    }
+
+    /// Whether `ip` (the TCP peer) falls inside a trusted proxy network.
+    pub fn is_trusted_peer(&self, ip: IpAddr) -> bool {
+        self.trusted_proxy_networks
+            .iter()
+            .any(|net| net.contains(&ip))
+    }
+
+    /// Validate cross-field invariants at startup. Returns the first problem.
+    pub fn validate(&self) -> Result<(), String> {
+        // Surface CIDR parse errors with the offending entry.
+        if let Ok(raw) = std::env::var("TRUSTED_PROXY_NETWORKS") {
+            parse_trusted_networks(&raw)?;
+        }
+        if self.auth_proxy_enabled() && self.trusted_proxy_networks.is_empty() {
+            return Err(
+                "AUTH_PROXY_HEADER is set but TRUSTED_PROXY_NETWORKS is empty. \
+                 Refusing to trust an identity header without a trusted-source check."
+                    .to_string(),
+            );
+        }
+        if self.disable_local_auth && !self.auth_proxy_enabled() {
+            return Err(
+                "DISABLE_LOCAL_AUTH is set but AUTH_PROXY_HEADER is not configured. \
+                 This would leave no way to log in via the browser."
+                    .to_string(),
+            );
+        }
+        Ok(())
     }
 
     /// Whether a new account may be registered given the current user count.
@@ -124,6 +213,12 @@ mod tests {
             webauthn_rp_origin: "http://localhost:3000".to_string(),
             webauthn_rp_name: "rdrs".to_string(),
             public_base_url: None,
+            auth_proxy_header: String::new(),
+            trusted_proxy_networks: Vec::new(),
+            auth_proxy_user_creation: false,
+            disable_local_auth: false,
+            auth_proxy_groups_header: String::new(),
+            auth_proxy_admin_group: String::new(),
         }
     }
 
@@ -150,6 +245,65 @@ mod tests {
         };
         assert!(config_disabled.can_register(0));
         assert!(!config_disabled.can_register(1));
+    }
+
+    #[test]
+    fn test_parse_trusted_networks() {
+        let nets = parse_trusted_networks("10.0.0.0/8, 192.168.1.0/24 , 127.0.0.1").unwrap();
+        assert_eq!(nets.len(), 3);
+        assert!(parse_trusted_networks("").unwrap().is_empty());
+        assert!(parse_trusted_networks("not-an-ip").is_err());
+    }
+
+    #[test]
+    fn test_is_trusted_peer() {
+        let cfg = Config {
+            trusted_proxy_networks: parse_trusted_networks("10.0.0.0/8").unwrap(),
+            ..test_config()
+        };
+        assert!(cfg.is_trusted_peer("10.1.2.3".parse().unwrap()));
+        assert!(!cfg.is_trusted_peer("192.168.0.1".parse().unwrap()));
+    }
+
+    #[test]
+    fn test_validate_header_requires_trusted_networks() {
+        // Header set, no trusted networks → error.
+        let bad = Config {
+            auth_proxy_header: "Remote-User".to_string(),
+            trusted_proxy_networks: Vec::new(),
+            ..test_config()
+        };
+        assert!(bad.validate().is_err());
+
+        // Header set with trusted networks → ok.
+        let good = Config {
+            auth_proxy_header: "Remote-User".to_string(),
+            trusted_proxy_networks: parse_trusted_networks("10.0.0.0/8").unwrap(),
+            ..test_config()
+        };
+        assert!(good.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_disable_local_auth_requires_header() {
+        let bad = Config {
+            disable_local_auth: true,
+            auth_proxy_header: String::new(),
+            ..test_config()
+        };
+        assert!(bad.validate().is_err());
+    }
+
+    #[test]
+    fn test_group_mapping_enabled() {
+        let off = test_config();
+        assert!(!off.group_mapping_enabled());
+        let on = Config {
+            auth_proxy_groups_header: "Remote-Groups".to_string(),
+            auth_proxy_admin_group: "admins".to_string(),
+            ..test_config()
+        };
+        assert!(on.group_mapping_enabled());
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -61,14 +61,17 @@ pub fn parse_trusted_networks(raw: &str) -> Result<Vec<IpNet>, String> {
 }
 
 impl Config {
-    pub fn from_env() -> Self {
+    pub fn from_env() -> Result<Self, String> {
         let (image_proxy_secret, image_proxy_secret_generated) = Self::load_image_proxy_secret();
         let server_port = env::var("SERVER_PORT")
             .ok()
             .and_then(|p| p.parse().ok())
             .unwrap_or(3000);
 
-        Self {
+        let trusted_proxy_networks =
+            parse_trusted_networks(&env::var("TRUSTED_PROXY_NETWORKS").unwrap_or_default())?;
+
+        Ok(Self {
             database_url: env::var("DATABASE_URL").unwrap_or_else(|_| "rdrs.sqlite3".to_string()),
             server_port,
             signup_enabled: env::var("SIGNUP_ENABLED")
@@ -86,10 +89,7 @@ impl Config {
             webauthn_rp_name: env::var("WEBAUTHN_RP_NAME").unwrap_or_else(|_| "rdrs".to_string()),
             public_base_url: env::var("PUBLIC_BASE_URL").ok().filter(|s| !s.is_empty()),
             auth_proxy_header: env::var("AUTH_PROXY_HEADER").unwrap_or_default(),
-            trusted_proxy_networks: parse_trusted_networks(
-                &env::var("TRUSTED_PROXY_NETWORKS").unwrap_or_default(),
-            )
-            .unwrap_or_default(),
+            trusted_proxy_networks,
             auth_proxy_user_creation: env::var("AUTH_PROXY_USER_CREATION")
                 .map(|v| v.to_lowercase() == "true" || v == "1")
                 .unwrap_or(false),
@@ -98,7 +98,7 @@ impl Config {
                 .unwrap_or(false),
             auth_proxy_groups_header: env::var("AUTH_PROXY_GROUPS_HEADER").unwrap_or_default(),
             auth_proxy_admin_group: env::var("AUTH_PROXY_ADMIN_GROUP").unwrap_or_default(),
-        }
+        })
     }
 
     fn load_image_proxy_secret() -> (Vec<u8>, bool) {
@@ -140,10 +140,6 @@ impl Config {
 
     /// Validate cross-field invariants at startup. Returns the first problem.
     pub fn validate(&self) -> Result<(), String> {
-        // Surface CIDR parse errors with the offending entry.
-        if let Ok(raw) = std::env::var("TRUSTED_PROXY_NETWORKS") {
-            parse_trusted_networks(&raw)?;
-        }
         if self.auth_proxy_enabled() && self.trusted_proxy_networks.is_empty() {
             return Err(
                 "AUTH_PROXY_HEADER is set but TRUSTED_PROXY_NETWORKS is empty. \

--- a/src/handlers/auth.rs
+++ b/src/handlers/auth.rs
@@ -98,6 +98,9 @@ pub async fn login(
     jar: CookieJar,
     Json(req): Json<LoginRequest>,
 ) -> AppResult<(CookieJar, Json<LoginResponse>)> {
+    if state.config.disable_local_auth {
+        return Err(AppError::Forbidden);
+    }
     let (user, new_session) = state
         .db
         .user(move |conn| {

--- a/src/handlers/pages/mod.rs
+++ b/src/handlers/pages/mod.rs
@@ -461,6 +461,7 @@ pub struct LoginTemplate {
     pub signup_enabled: bool,
     pub flash_messages: Vec<FlashMessage>,
     pub git_version: &'static str,
+    pub local_auth_enabled: bool,
 }
 
 impl IntoResponse for LoginTemplate {
@@ -488,6 +489,7 @@ pub async fn login_page(State(state): State<AppState>, flash: Flash) -> (Flash, 
             signup_enabled,
             flash_messages: flash.messages,
             git_version: crate::GIT_VERSION,
+            local_auth_enabled: !state.config.disable_local_auth,
         },
     )
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -302,6 +302,10 @@ pub fn create_router(state: AppState) -> Router {
         .layer(TimeoutLayer::with_status_code(
             axum::http::StatusCode::REQUEST_TIMEOUT,
             SERVER_REQUEST_TIMEOUT,
+        ))
+        .layer(axum::middleware::from_fn_with_state(
+            state.clone(),
+            middleware::forward_auth::forward_auth,
         ));
 
     Router::new()

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -132,13 +133,16 @@ async fn main() {
     // the shutdown future ends every in-flight SSE stream so the server does
     // not hang waiting on long-lived connections.
     let shutdown_token = cancel_token.clone();
-    axum::serve(listener, app)
-        .with_graceful_shutdown(async move {
-            shutdown_signal().await;
-            shutdown_token.cancel();
-        })
-        .await
-        .expect("Server failed");
+    axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<SocketAddr>(),
+    )
+    .with_graceful_shutdown(async move {
+        shutdown_signal().await;
+        shutdown_token.cancel();
+    })
+    .await
+    .expect("Server failed");
 
     tracing::info!("Server stopped, initiating graceful shutdown...");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,10 @@ async fn main() {
         .with(tracing_subscriber::EnvFilter::from_default_env())
         .init();
 
-    let config = Config::from_env();
+    let config = Config::from_env().unwrap_or_else(|msg| {
+        eprintln!("Configuration error: {msg}");
+        std::process::exit(1);
+    });
 
     if let Err(msg) = config.validate() {
         eprintln!("Configuration error: {msg}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,11 @@ async fn main() {
 
     let config = Config::from_env();
 
+    if let Err(msg) = config.validate() {
+        eprintln!("Configuration error: {msg}");
+        std::process::exit(1);
+    }
+
     if config.image_proxy_secret_generated {
         tracing::warn!(
             "IMAGE_PROXY_SECRET not set, using temporary key. Proxy URLs will be invalidated on restart."

--- a/src/middleware/forward_auth.rs
+++ b/src/middleware/forward_auth.rs
@@ -1,0 +1,196 @@
+use std::net::SocketAddr;
+
+use axum::{
+    extract::{ConnectInfo, Request, State},
+    middleware::Next,
+    response::{IntoResponse, Redirect, Response},
+};
+use axum_extra::extract::cookie::{Cookie, CookieJar, SameSite};
+use time::Duration;
+
+use crate::error::AppError;
+use crate::middleware::{FlashRedirect, SESSION_COOKIE_NAME};
+use crate::models::user::{self, Role};
+use crate::models::{category, session};
+use crate::AppState;
+
+/// Path prefixes that must never trigger forward-auth auto-login: machine
+/// endpoints (GReader native clients, JSON/passkey APIs, SSE, static assets)
+/// authenticate by their own means.
+const SKIP_PREFIXES: &[&str] = &[
+    "/api",
+    "/reader",
+    "/accounts",
+    "/events",
+    "/static",
+    "/favicon",
+    "/health",
+];
+
+/// Parse a comma-separated groups header into trimmed, non-empty names.
+pub fn parse_groups(raw: &str) -> Vec<String> {
+    raw.split(',')
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+/// Map groups to a role: `Admin` iff `admin_group` is present, else `User`.
+pub fn role_from_groups(groups: &[String], admin_group: &str) -> Role {
+    if groups.iter().any(|g| g == admin_group) {
+        Role::Admin
+    } else {
+        Role::User
+    }
+}
+
+pub async fn forward_auth(
+    State(state): State<AppState>,
+    jar: CookieJar,
+    req: Request,
+    next: Next,
+) -> Response {
+    let config = &state.config;
+
+    // Feature off, or already carrying a session cookie → nothing to do.
+    if !config.auth_proxy_enabled() || jar.get(SESSION_COOKIE_NAME).is_some() {
+        return next.run(req).await;
+    }
+
+    // Only engage for browser page routes.
+    if SKIP_PREFIXES
+        .iter()
+        .any(|p| req.uri().path().starts_with(p))
+    {
+        return next.run(req).await;
+    }
+
+    // Fail closed: without a known peer IP we cannot trust the header.
+    let Some(peer_ip) = req
+        .extensions()
+        .get::<ConnectInfo<SocketAddr>>()
+        .map(|c| c.0.ip())
+    else {
+        return next.run(req).await;
+    };
+    if !config.is_trusted_peer(peer_ip) {
+        return next.run(req).await;
+    }
+
+    // Read the identity header.
+    let Some(username) = req
+        .headers()
+        .get(config.auth_proxy_header.as_str())
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+    else {
+        return next.run(req).await;
+    };
+
+    // Optional group → role mapping (recomputed on every login when enabled).
+    let desired_role = if config.group_mapping_enabled() {
+        let groups = req
+            .headers()
+            .get(config.auth_proxy_groups_header.as_str())
+            .and_then(|v| v.to_str().ok())
+            .map(parse_groups)
+            .unwrap_or_default();
+        Some(role_from_groups(&groups, &config.auth_proxy_admin_group))
+    } else {
+        None
+    };
+
+    let allow_creation = config.auth_proxy_user_creation;
+
+    // Resolve (or JIT-create) the account and open a session. `None` means
+    // "reject" (unknown user with creation off, or a disabled account).
+    let outcome = state
+        .db
+        .user(move |conn| {
+            let user = match user::find_by_username(conn, &username)? {
+                Some(u) => {
+                    if u.is_disabled() {
+                        return Ok::<Option<String>, AppError>(None);
+                    }
+                    if let Some(role) = desired_role {
+                        if u.role != role {
+                            user::update_role(conn, u.id, role)?;
+                        }
+                    }
+                    u
+                }
+                None => {
+                    if !allow_creation {
+                        return Ok(None);
+                    }
+                    let role = match desired_role {
+                        Some(r) => r,
+                        None if user::count(conn)? == 0 => Role::Admin,
+                        None => Role::User,
+                    };
+                    // Sentinel hash never verifies, so local password login is
+                    // impossible for forward-auth-provisioned accounts.
+                    let created = user::create_user(conn, &username, "!", role)?;
+                    category::create_category(conn, created.id, "Uncategorized")?;
+                    created
+                }
+            };
+            let new_session = session::create_session(conn, user.id)?;
+            Ok(Some(new_session.session_token))
+        })
+        .await;
+
+    let token = match outcome {
+        Ok(Ok(Some(token))) => token,
+        Ok(Ok(None)) => {
+            return FlashRedirect::warning(
+                "/login",
+                "You are not authorized to access this instance.",
+            )
+            .into_response();
+        }
+        // DB/join error → fail closed: fall back to the normal (cookie) flow.
+        _ => return next.run(req).await,
+    };
+
+    let cookie = Cookie::build((SESSION_COOKIE_NAME, token))
+        .path("/")
+        .http_only(true)
+        .same_site(SameSite::Lax)
+        .max_age(Duration::days(session::SESSION_ABSOLUTE_MAX_DAYS))
+        .build();
+
+    // Redirect to the same URL; the just-set cookie authenticates the retry.
+    let location = req
+        .uri()
+        .path_and_query()
+        .map(|pq| pq.as_str().to_string())
+        .unwrap_or_else(|| "/".to_string());
+
+    (jar.add(cookie), Redirect::to(&location)).into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::user::Role;
+
+    #[test]
+    fn test_parse_groups() {
+        assert_eq!(
+            parse_groups("admins, users ,, dev"),
+            vec!["admins".to_string(), "users".to_string(), "dev".to_string()]
+        );
+        assert!(parse_groups("   ").is_empty());
+    }
+
+    #[test]
+    fn test_role_from_groups() {
+        let groups = vec!["users".to_string(), "admins".to_string()];
+        assert_eq!(role_from_groups(&groups, "admins"), Role::Admin);
+        assert_eq!(role_from_groups(&groups, "superadmins"), Role::User);
+        assert_eq!(role_from_groups(&[], "admins"), Role::User);
+    }
+}

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -2,6 +2,7 @@ pub mod auth;
 pub mod date_header;
 pub mod etag;
 pub mod flash;
+pub mod forward_auth;
 
 pub use auth::{AdminUser, AuthUser, PageAdminUser, PageAuthUser, SESSION_COOKIE_NAME};
 pub use date_header::DateHeaderLayer;

--- a/templates/login.html
+++ b/templates/login.html
@@ -14,9 +14,12 @@
             <button type="button" id="passkey-login-btn" class="btn-primary auth-passkey-btn">
                 Login with Passkey
             </button>
+            {% if local_auth_enabled %}
             <p class="muted auth-divider">or use password</p>
+            {% endif %}
         </div>
 
+        {% if local_auth_enabled %}
         <form id="login-form" data-testid="login-form">
             <div class="form-group">
                 <label for="username">Username</label>
@@ -28,6 +31,7 @@
             </div>
             <button type="submit" class="btn-block" data-testid="login-submit">Sign In</button>
         </form>
+        {% endif %}
         {% if signup_enabled %}
         <div class="link">
             <a href="/register">Create an account</a>
@@ -62,7 +66,8 @@
         return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
     }
 
-    document.getElementById('login-form').addEventListener('submit', async (e) => {
+    const loginForm = document.getElementById('login-form');
+    if (loginForm) loginForm.addEventListener('submit', async (e) => {
         e.preventDefault();
         const errorDiv = document.getElementById('error');
         errorDiv.style.display = 'none';

--- a/tests/auth_test.rs
+++ b/tests/auth_test.rs
@@ -852,6 +852,29 @@ async fn test_page_request_slides_session_expiry_forward() {
 }
 
 #[tokio::test]
+async fn test_disable_local_auth_blocks_password_login() {
+    let mut config = default_test_config();
+    config.disable_local_auth = true;
+    config.auth_proxy_header = "Remote-User".to_string();
+    config.trusted_proxy_networks = rdrs::config::parse_trusted_networks("127.0.0.0/8").unwrap();
+    let server = create_test_server(config);
+
+    // Seed a normal password user.
+    server
+        .post("/api/register")
+        .json(&json!({ "username": "u", "password": "password123" }))
+        .await
+        .assert_status(StatusCode::CREATED);
+
+    // Password login is now forbidden.
+    let res = server
+        .post("/api/session")
+        .json(&json!({ "username": "u", "password": "password123" }))
+        .await;
+    res.assert_status(StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
 async fn test_fresh_session_is_not_refreshed() {
     let server = create_test_server(default_test_config());
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -21,5 +21,11 @@ pub fn default_test_config() -> Config {
         webauthn_rp_origin: "http://localhost:3000".to_string(),
         webauthn_rp_name: "rdrs-test".to_string(),
         public_base_url: None,
+        auth_proxy_header: String::new(),
+        trusted_proxy_networks: Vec::new(),
+        auth_proxy_user_creation: false,
+        disable_local_auth: false,
+        auth_proxy_groups_header: String::new(),
+        auth_proxy_admin_group: String::new(),
     }
 }

--- a/tests/forward_auth_test.rs
+++ b/tests/forward_auth_test.rs
@@ -1,0 +1,150 @@
+mod common;
+use common::default_test_config;
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use axum_test::TestServer;
+use rdrs::{
+    auth, config::parse_trusted_networks, create_router, db, services, AppState, Config, DbPool,
+};
+use rusqlite::Connection;
+
+fn open_shared_memory(name: &str) -> Connection {
+    let uri = format!("file:{}?mode=memory&cache=shared", name);
+    Connection::open_with_flags(
+        uri,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_WRITE
+            | rusqlite::OpenFlags::SQLITE_OPEN_CREATE
+            | rusqlite::OpenFlags::SQLITE_OPEN_URI,
+    )
+    .unwrap()
+}
+
+/// Build a server over a real loopback HTTP transport so the middleware sees a
+/// genuine `ConnectInfo` peer (127.0.0.1). `trusted` controls whether loopback
+/// is inside the trusted network. Each caller passes a unique `db_name` to
+/// avoid cross-test interference when tests run in parallel.
+fn create_server(db_name: &str, mut mutate: impl FnMut(&mut Config)) -> TestServer {
+    let write_conn = open_shared_memory(db_name);
+    db::init_db(&write_conn).unwrap();
+    let read_conn = open_shared_memory(db_name);
+
+    let mut config = default_test_config();
+    config.auth_proxy_header = "Remote-User".to_string();
+    config.auth_proxy_groups_header = "Remote-Groups".to_string();
+    config.auth_proxy_admin_group = "admins".to_string();
+    mutate(&mut config);
+
+    let webauthn = auth::create_webauthn(&config).unwrap();
+    let summary_cache = services::create_summary_cache(100, 24);
+    let (summary_tx, _rx) = services::create_summary_channel(10);
+    let (pool, _handle) = DbPool::new(write_conn, read_conn);
+    let state = AppState {
+        db: pool,
+        config: Arc::new(config),
+        webauthn: Arc::new(webauthn),
+        summary_cache,
+        summary_tx,
+        sidebar_cache: Arc::new(services::SidebarCache::default()),
+        summary_cancels: Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
+        events: services::EventBus::new(16),
+        shutdown: tokio_util::sync::CancellationToken::new(),
+    };
+    let app = create_router(state).into_make_service_with_connect_info::<SocketAddr>();
+    TestServer::builder()
+        .http_transport()
+        .save_cookies()
+        .build(app)
+}
+
+fn seed_user(db_name: &str, name: &str, role: rdrs::models::user::Role) {
+    let conn = open_shared_memory(db_name);
+    rdrs::models::user::create_user(&conn, name, "$argon2id$invalid", role).unwrap();
+}
+
+#[tokio::test]
+async fn test_trusted_existing_user_gets_session() {
+    let db_name = "fa_test_trusted_existing";
+    let server = create_server(db_name, |c| {
+        c.trusted_proxy_networks = parse_trusted_networks("127.0.0.0/8").unwrap();
+    });
+    seed_user(db_name, "alice", rdrs::models::user::Role::User);
+
+    let res = server.get("/").add_header("Remote-User", "alice").await;
+
+    // Redirect carrying a freshly-minted session cookie.
+    assert!(res.status_code().is_redirection());
+    assert!(res.maybe_cookie("session_token").is_some());
+}
+
+#[tokio::test]
+async fn test_untrusted_peer_ignores_header() {
+    let db_name = "fa_test_untrusted_peer";
+    let server = create_server(db_name, |c| {
+        // Loopback is NOT in this network → header must be ignored.
+        c.trusted_proxy_networks = parse_trusted_networks("10.0.0.0/8").unwrap();
+    });
+    seed_user(db_name, "alice", rdrs::models::user::Role::User);
+
+    let res = server.get("/").add_header("Remote-User", "alice").await;
+
+    assert!(res.maybe_cookie("session_token").is_none());
+}
+
+#[tokio::test]
+async fn test_unknown_user_creation_disabled_rejected() {
+    let db_name = "fa_test_creation_disabled";
+    let server = create_server(db_name, |c| {
+        c.trusted_proxy_networks = parse_trusted_networks("127.0.0.0/8").unwrap();
+        c.auth_proxy_user_creation = false;
+    });
+
+    let res = server.get("/").add_header("Remote-User", "ghost").await;
+
+    assert!(res.maybe_cookie("session_token").is_none());
+    assert_eq!(res.header("location"), "/login");
+}
+
+#[tokio::test]
+async fn test_unknown_user_jit_created_as_admin_via_groups() {
+    let db_name = "fa_test_jit_admin_groups";
+    let server = create_server(db_name, |c| {
+        c.trusted_proxy_networks = parse_trusted_networks("127.0.0.0/8").unwrap();
+        c.auth_proxy_user_creation = true;
+    });
+
+    let res = server
+        .get("/")
+        .add_header("Remote-User", "bob")
+        .add_header("Remote-Groups", "users,admins")
+        .await;
+
+    assert!(res.status_code().is_redirection());
+    assert!(res.maybe_cookie("session_token").is_some());
+
+    // Account was created with Admin role from the groups header.
+    let conn = open_shared_memory(db_name);
+    let created = rdrs::models::user::find_by_username(&conn, "bob")
+        .unwrap()
+        .unwrap();
+    assert_eq!(created.role, rdrs::models::user::Role::Admin);
+}
+
+#[tokio::test]
+async fn test_disabled_user_rejected() {
+    let db_name = "fa_test_disabled_user";
+    let server = create_server(db_name, |c| {
+        c.trusted_proxy_networks = parse_trusted_networks("127.0.0.0/8").unwrap();
+    });
+    seed_user(db_name, "carol", rdrs::models::user::Role::User);
+    let conn = open_shared_memory(db_name);
+    let u = rdrs::models::user::find_by_username(&conn, "carol")
+        .unwrap()
+        .unwrap();
+    rdrs::models::user::disable_user(&conn, u.id).unwrap();
+
+    let res = server.get("/").add_header("Remote-User", "carol").await;
+
+    assert!(res.maybe_cookie("session_token").is_none());
+}

--- a/tests/forward_auth_test.rs
+++ b/tests/forward_auth_test.rs
@@ -60,7 +60,7 @@ fn create_server(db_name: &str, mut mutate: impl FnMut(&mut Config)) -> TestServ
 
 fn seed_user(db_name: &str, name: &str, role: rdrs::models::user::Role) {
     let conn = open_shared_memory(db_name);
-    rdrs::models::user::create_user(&conn, name, "$argon2id$invalid", role).unwrap();
+    rdrs::models::user::create_user(&conn, name, "!", role).unwrap();
 }
 
 #[tokio::test]
@@ -147,4 +147,32 @@ async fn test_disabled_user_rejected() {
     let res = server.get("/").add_header("Remote-User", "carol").await;
 
     assert!(res.maybe_cookie("session_token").is_none());
+    assert_eq!(res.header("location"), "/login");
+}
+
+#[tokio::test]
+async fn test_existing_user_role_recomputed_on_login() {
+    let db_name = "fa_test_role_recompute";
+    let server = create_server(db_name, |c| {
+        c.trusted_proxy_networks = parse_trusted_networks("127.0.0.0/8").unwrap();
+    });
+    // Seed the user as Admin; the groups header will NOT include "admins".
+    seed_user(db_name, "dave", rdrs::models::user::Role::Admin);
+
+    let res = server
+        .get("/")
+        .add_header("Remote-User", "dave")
+        .add_header("Remote-Groups", "users")
+        .await;
+
+    // Login must succeed with a session cookie.
+    assert!(res.status_code().is_redirection());
+    assert!(res.maybe_cookie("session_token").is_some());
+
+    // Role must have been demoted from Admin → User.
+    let conn = open_shared_memory(db_name);
+    let user = rdrs::models::user::find_by_username(&conn, "dave")
+        .unwrap()
+        .unwrap();
+    assert_eq!(user.role, rdrs::models::user::Role::User);
 }

--- a/tests/statistics_test.rs
+++ b/tests/statistics_test.rs
@@ -43,6 +43,12 @@ fn create_test_app(name: &str) -> TestApp {
         webauthn_rp_origin: "http://localhost:3000".to_string(),
         webauthn_rp_name: "rdrs-test".to_string(),
         public_base_url: None,
+        auth_proxy_header: String::new(),
+        trusted_proxy_networks: Vec::new(),
+        auth_proxy_user_creation: false,
+        disable_local_auth: false,
+        auth_proxy_groups_header: String::new(),
+        auth_proxy_admin_group: String::new(),
     };
     let webauthn = auth::create_webauthn(&config).unwrap();
     let summary_cache = services::create_summary_cache(100, 24);


### PR DESCRIPTION
## Summary

Adds **forward-auth (trusted-header) login** so users can sign in through an upstream identity provider (Authelia, authentik, oauth2-proxy, Vouch, Pomerium, Cloudflare Access, Tailscale, …) that injects a trusted identity header. A tower middleware reads a **configurable** header — but only when the request's TCP peer IP is inside a configured trusted CIDR list — maps it to an existing account **by username**, optionally JIT-creates it, establishes a normal session cookie, and redirects.

Existing password, passkey, and GReader `ClientLogin` authentication are untouched. **No database schema change / migration** — existing password accounts migrate transparently when their username matches the proxy-provided one.

## Configuration

| Variable | Default | Behavior |
|---|---|---|
| `AUTH_PROXY_HEADER` | unset (off) | Header carrying the username (e.g. `Remote-User`). Empty disables the feature. |
| `TRUSTED_PROXY_NETWORKS` | unset | Comma-separated CIDRs/IPs; the TCP peer IP (not `X-Forwarded-For`) must match. Required when `AUTH_PROXY_HEADER` is set. |
| `AUTH_PROXY_USER_CREATION` | `false` | JIT-create unknown users instead of rejecting. |
| `AUTH_PROXY_GROUPS_HEADER` | unset | Header with comma-separated groups (e.g. `Remote-Groups`). |
| `AUTH_PROXY_ADMIN_GROUP` | unset | Membership grants admin; role is recomputed on every forward-auth login (active only when both group vars are set). |
| `DISABLE_LOCAL_AUTH` | `false` | Hides the browser password form and returns 403 for `POST /api/session`. Does not affect GReader API or passkeys. Requires `AUTH_PROXY_HEADER`. |

## Security model

- Peer IP comes from the real TCP connection (`ConnectInfo<SocketAddr>`), never a spoofable header.
- The middleware **fails closed**: untrusted peer, missing/empty header, missing connection info, or DB error → normal cookie login flow, no auto-login.
- Engages only when there is no existing session cookie, and never on API/machine prefixes (`/api`, `/reader`, `/accounts`, `/events`, `/static`, `/favicon`, `/health`).
- Startup validation: `AUTH_PROXY_HEADER` requires `TRUSTED_PROXY_NETWORKS`; `DISABLE_LOCAL_AUTH` requires `AUTH_PROXY_HEADER`; invalid CIDR refuses to start.
- JIT accounts get an unusable sentinel password hash, so local password login is impossible for them.

**Operator notes (documented):** the proxy must authoritatively set/strip the identity & groups headers, and must bypass forward-auth for `/accounts/ClientLogin` and `/reader/api/...` so native GReader clients keep working.

## Implementation

- `src/config.rs` — six env vars, CIDR parsing (`ipnet`), trust/role helpers, startup validation; `from_env` is now fallible.
- `src/middleware/forward_auth.rs` — the middleware plus pure `parse_groups` / `role_from_groups` helpers.
- `src/main.rs` — wires `into_make_service_with_connect_info::<SocketAddr>()`.
- `src/lib.rs` — adds the `from_fn_with_state` layer.
- `src/handlers/auth.rs`, `src/handlers/pages/mod.rs`, `templates/login.html` — `DISABLE_LOCAL_AUTH` enforcement.
- `ARCHITECTURE.md`, `README.md` — docs.

## Testing

- New unit tests: config parsing/validation, CIDR membership, group→role mapping.
- New integration tests (`tests/forward_auth_test.rs`, real loopback HTTP transport): trusted existing user → session; untrusted peer → header ignored; unknown user reject vs JIT-create-as-admin; existing-user role recomputation/demotion; disabled-user reject.
- `DISABLE_LOCAL_AUTH` blocks `POST /api/session` while GReader auth stays functional.
- Full suite green: 967/967 passing, `cargo fmt` and `cargo clippy -- -D warnings` clean.

Design spec and implementation plan are included under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)