### PR TITLE
fix(auth): make Sign Out work under forward-auth (+ AUTH_PROXY_LOGOUT_URL)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -133,6 +133,7 @@ Loads settings from environment variables:
 - `AUTH_PROXY_GROUPS_HEADER` - Header name carrying comma-separated group names from the proxy
 - `AUTH_PROXY_ADMIN_GROUP` - Group membership grants the admin role; active only when both this and `AUTH_PROXY_GROUPS_HEADER` are set
 - `DISABLE_LOCAL_AUTH` - Hides the browser password form and makes `POST /api/session` return 403; does not affect GReader `ClientLogin` or passkey auth; startup refuses if set without `AUTH_PROXY_HEADER`
+- `AUTH_PROXY_LOGOUT_URL` - When set, Sign Out redirects the browser here to end the IdP/SSO session (e.g. Authelia's logout URL); when unset, Sign Out clears the local session and the proxy header re-authenticates on the next request
 
 ### Error Handling (`error.rs`)
 
@@ -260,6 +261,10 @@ Forward-auth, local password, and passkey authentication all work simultaneously
 
 1. The reverse proxy **must** authoritatively set (and strip any client-supplied copy of) the identity and groups headers on every request before forwarding to RDRS. A downstream client that can inject these headers bypasses the trust model entirely.
 2. The reverse proxy **must** be configured to bypass forward-auth for `/accounts/ClientLogin` and `/reader/api/...` so native GReader clients (FeedMe, Read You, etc.) can still authenticate with their stored username and password.
+
+**Logout under forward-auth:**
+
+Sign Out always clears the local `session_token` cookie (with `Path=/`) and deletes the server-side session. The forward-auth middleware re-authenticates whenever there is no *valid* session cookie — a stale or expired cookie no longer blocks re-authentication. This means that under forward-auth, a local Sign Out normally bounces the user straight back in via the proxy header (matching the linkding/Miniflux behavior). If `AUTH_PROXY_LOGOUT_URL` is set, Sign Out instead redirects the browser there (e.g. the Authelia logout URL) so the IdP/SSO session is also terminated. Additionally, `/login` redirects an already-authenticated user to `/` rather than rendering the login form again.
 
 ## Services
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ All configuration is done via environment variables:
 | `AUTH_PROXY_GROUPS_HEADER` | - | Header carrying comma-separated group names from the proxy (e.g. `Remote-Groups`). |
 | `AUTH_PROXY_ADMIN_GROUP` | - | Membership in this group grants the admin role, synced on every forward-auth login. Active only when `AUTH_PROXY_GROUPS_HEADER` is also set. |
 | `DISABLE_LOCAL_AUTH` | `false` | Hides the browser password form and rejects `POST /api/session` with 403. Does not affect GReader API or passkey auth. Requires `AUTH_PROXY_HEADER`. |
+| `AUTH_PROXY_LOGOUT_URL` | (unset) | When set, Sign Out redirects the browser here (e.g. the Authelia logout URL) to end the SSO session. When unset, Sign Out clears the local session and the proxy header re-authenticates on the next request (you return to the app). |
 
 > **Deploying behind a domain?** `WEBAUTHN_RP_ID` and `WEBAUTHN_RP_ORIGIN`
 > default to `localhost` and **must** be overridden to your public host (e.g.

--- a/docs/superpowers/plans/2026-06-25-forward-auth-logout.md
+++ b/docs/superpowers/plans/2026-06-25-forward-auth-logout.md
@@ -1,0 +1,522 @@
+# Forward-Auth Logout Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Sign Out work under forward-auth — clear the cookie properly, let forward-auth re-authenticate past a stale/invalid cookie, forward `/login` to `/` for authenticated users, and add `AUTH_PROXY_LOGOUT_URL` for real IdP logout.
+
+**Architecture:** Four targeted changes — logout cookie clearing + a JSON redirect target (Bug 1 / Item 4), a forward-auth session-validity check replacing the cookie-presence short-circuit (Bug 2), an authenticated `/login → /` redirect (Item 3), and docs. Behavior matches linkding/Miniflux (Option A): local logout bounces back in via the proxy header unless `AUTH_PROXY_LOGOUT_URL` ends the SSO session.
+
+**Tech Stack:** Rust, axum 0.8, axum-extra cookies, rusqlite, axum-test, vanilla ES module (sidebar web component).
+
+## Global Constraints
+
+- Run tests with `cargo nextest run` (never `cargo test`); prefix local runs with `RDRS_FAST_HASH=1`.
+- `cargo fmt` before every commit; `cargo clippy -- -D warnings` must pass.
+- Commits GPG-signed (default git config); end messages with the `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>` trailer.
+- Stage files explicitly by name — never `git add -A` / `git add .`.
+- No database schema change.
+- The `Config` struct has FOUR literal construction sites that must all stay in sync when a field is added: `src/config.rs` (`test_config`), `src/auth/webauthn.rs` (`test_config`), `tests/common/mod.rs` (`default_test_config`), `tests/statistics_test.rs`.
+- Static JS is embedded at compile time; run `cargo build` after editing `static/js/**` before any manual/e2e check. (No e2e logout test exists, so no e2e gate here.)
+- The session cookie is set with `.path("/")` (login handler + forward-auth middleware); any removal MUST match that path.
+
+---
+
+### Task 1: Logout cookie clearing + `AUTH_PROXY_LOGOUT_URL` + Sign Out JS
+
+Fixes Bug 1 (cookie never cleared) and adds Item 4 (configurable IdP logout redirect). The config field's only consumer is the logout handler, so it lives here.
+
+**Files:**
+- Modify: `src/config.rs` (new field + parse; update `test_config` literal)
+- Modify: `src/auth/webauthn.rs` (`test_config` literal)
+- Modify: `tests/common/mod.rs` (`default_test_config` literal)
+- Modify: `tests/statistics_test.rs` (Config literal)
+- Modify: `src/handlers/auth.rs` (`logout` handler + `LogoutResponse`)
+- Modify: `static/js/components/rdrs-sidebar.js` (Sign Out handler)
+- Test: `tests/auth_test.rs`
+
+**Interfaces:**
+- Produces:
+  - `Config.auth_proxy_logout_url: Option<String>` (env `AUTH_PROXY_LOGOUT_URL`)
+  - `handlers::auth::LogoutResponse { redirect_to: String }`
+  - `logout(...) -> AppResult<(CookieJar, Json<LogoutResponse>)>`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/auth_test.rs` (uses the file's existing `create_test_server` / `default_test_config` / `json!` / `StatusCode`):
+
+```rust
+/// Collect raw Set-Cookie header values from a response.
+fn set_cookie_headers(res: &axum_test::TestResponse) -> Vec<String> {
+    res.headers()
+        .get_all("set-cookie")
+        .iter()
+        .filter_map(|v| v.to_str().ok().map(|s| s.to_string()))
+        .collect()
+}
+
+#[tokio::test]
+async fn test_logout_clears_cookie_with_path() {
+    let server = create_test_server(default_test_config());
+    server
+        .post("/api/register")
+        .json(&json!({ "username": "u", "password": "password123" }))
+        .await
+        .assert_status(StatusCode::CREATED);
+    server
+        .post("/api/session")
+        .json(&json!({ "username": "u", "password": "password123" }))
+        .await
+        .assert_status_ok();
+
+    let res = server.delete("/api/session").await;
+    res.assert_status_ok();
+
+    let removal = set_cookie_headers(&res)
+        .into_iter()
+        .find(|s| s.starts_with("session_token="))
+        .expect("logout must emit a session_token Set-Cookie");
+    assert!(
+        removal.contains("Path=/"),
+        "removal cookie must carry Path=/ to actually delete the session cookie: {removal}"
+    );
+}
+
+#[tokio::test]
+async fn test_logout_redirect_default_is_login() {
+    let server = create_test_server(default_test_config());
+    server
+        .post("/api/register")
+        .json(&json!({ "username": "u", "password": "password123" }))
+        .await
+        .assert_status(StatusCode::CREATED);
+    server
+        .post("/api/session")
+        .json(&json!({ "username": "u", "password": "password123" }))
+        .await
+        .assert_status_ok();
+
+    let res = server.delete("/api/session").await;
+    let body: serde_json::Value = res.json();
+    assert_eq!(body["redirect_to"], "/login");
+}
+
+#[tokio::test]
+async fn test_logout_redirect_uses_configured_url() {
+    let mut config = default_test_config();
+    config.auth_proxy_logout_url = Some("https://auth.example.com/logout".to_string());
+    let server = create_test_server(config);
+    server
+        .post("/api/register")
+        .json(&json!({ "username": "u", "password": "password123" }))
+        .await
+        .assert_status(StatusCode::CREATED);
+    server
+        .post("/api/session")
+        .json(&json!({ "username": "u", "password": "password123" }))
+        .await
+        .assert_status_ok();
+
+    let res = server.delete("/api/session").await;
+    let body: serde_json::Value = res.json();
+    assert_eq!(body["redirect_to"], "https://auth.example.com/logout");
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `RDRS_FAST_HASH=1 cargo nextest run -p rdrs --test auth_test test_logout_`
+Expected: FAIL — `auth_proxy_logout_url` field doesn't exist / response has no `redirect_to`.
+
+- [ ] **Step 3: Add the config field**
+
+In `src/config.rs`, add to `struct Config` after `auth_proxy_admin_group`:
+
+```rust
+    pub auth_proxy_logout_url: Option<String>,
+```
+
+In `from_env`, add (mirror the `public_base_url` style):
+
+```rust
+            auth_proxy_logout_url: env::var("AUTH_PROXY_LOGOUT_URL").ok().filter(|s| !s.is_empty()),
+```
+
+Add `auth_proxy_logout_url: None,` to the `test_config()` literal in `src/config.rs`.
+
+- [ ] **Step 4: Update the other three Config literals**
+
+Add `auth_proxy_logout_url: None,` to the `Config { ... }` literal in each of:
+- `src/auth/webauthn.rs` (`test_config`)
+- `tests/common/mod.rs` (`default_test_config`)
+- `tests/statistics_test.rs`
+
+- [ ] **Step 5: Rewrite the logout handler**
+
+In `src/handlers/auth.rs`, replace the `logout` function with:
+
+```rust
+#[derive(Debug, Serialize)]
+pub struct LogoutResponse {
+    pub redirect_to: String,
+}
+
+pub async fn logout(
+    State(state): State<AppState>,
+    jar: CookieJar,
+    auth_user: AuthUser,
+) -> AppResult<(CookieJar, Json<LogoutResponse>)> {
+    let token = auth_user.session.session_token.clone();
+    state
+        .db
+        .user(move |conn| session::delete_session(conn, &token))
+        .await??;
+
+    // Removal must match the Path=/ the cookie was set with, or the browser
+    // keeps the (now-invalid) session_token cookie. Mirrors flash.rs.
+    let removal = Cookie::build((SESSION_COOKIE_NAME, "")).path("/").build();
+
+    let redirect_to = state
+        .config
+        .auth_proxy_logout_url
+        .clone()
+        .unwrap_or_else(|| "/login".to_string());
+
+    Ok((jar.remove(removal), Json(LogoutResponse { redirect_to })))
+}
+```
+
+(`Cookie`, `Json`, `Serialize`, `SESSION_COOKIE_NAME` are already imported in this file.)
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `RDRS_FAST_HASH=1 cargo nextest run -p rdrs --test auth_test test_logout`
+Expected: PASS (including the existing `test_logout`, whose `assert_status_ok` + `/api/user` 401 still hold).
+
+- [ ] **Step 7: Update the Sign Out JS**
+
+In `static/js/components/rdrs-sidebar.js`, in the `[data-rdrs-logout]` click handler, replace the success branch so it uses the server-provided target (preserve the flash for local paths; navigate directly for an external IdP URL):
+
+```js
+const r = await fetch('/api/session', { method: 'DELETE' });
+if (r.ok) {
+    const d = await r.json();
+    if (d.redirect_to.startsWith('/')) {
+        window.flash.redirect(d.redirect_to, 'info', 'You have been logged out.');
+    } else {
+        window.location.href = d.redirect_to;
+    }
+} else {
+    window.flash.error('Logout failed');
+}
+```
+
+- [ ] **Step 8: Rebuild (embedded asset) + full check**
+
+Run: `cargo build && cargo fmt && cargo clippy -- -D warnings && RDRS_FAST_HASH=1 cargo nextest run`
+Expected: builds, clippy clean, full suite green.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/config.rs src/auth/webauthn.rs tests/common/mod.rs tests/statistics_test.rs src/handlers/auth.rs static/js/components/rdrs-sidebar.js tests/auth_test.rs
+git commit -m "fix(auth): clear session cookie on logout and add AUTH_PROXY_LOGOUT_URL
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: forward-auth re-authenticates past an invalid cookie
+
+Fixes Bug 2 — the middleware short-circuits on cookie *presence*, so a stale/expired `session_token` (e.g. after logout, or on session expiry) permanently blocks forward-auth. Change it to short-circuit only on a *valid* session.
+
+**Files:**
+- Modify: `src/middleware/forward_auth.rs` (the cookie short-circuit)
+- Test: `tests/forward_auth_test.rs`
+
+**Interfaces:**
+- Consumes: `session::find_by_token`, `Session::is_expired`, `DbPool::read_user` (existing).
+- Produces: no new public API.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/forward_auth_test.rs` (follow the file's existing helpers: `create_server`, `seed_user`, `open_shared_memory`, per-test unique DB name, `parse_trusted_networks`, `add_header`; the server is built with `.http_transport()`):
+
+```rust
+#[tokio::test]
+async fn test_invalid_session_cookie_still_forward_auths() {
+    let server = create_server(|c| {
+        c.trusted_proxy_networks = parse_trusted_networks("127.0.0.0/8").unwrap();
+    });
+    seed_user("erin", rdrs::models::user::Role::User);
+
+    // A stale/garbage session_token cookie must NOT block forward-auth.
+    let res = server
+        .get("/")
+        .add_header("Remote-User", "erin")
+        .add_cookie(cookie::Cookie::new("session_token", "stale-invalid"))
+        .await;
+
+    assert!(res.status_code().is_redirection());
+    let fresh = res
+        .maybe_cookie("session_token")
+        .expect("a fresh session cookie should be minted");
+    assert_ne!(fresh.value(), "stale-invalid");
+    assert!(!fresh.value().is_empty());
+}
+
+#[tokio::test]
+async fn test_valid_session_cookie_not_reminted() {
+    let server = create_server(|c| {
+        c.trusted_proxy_networks = parse_trusted_networks("127.0.0.0/8").unwrap();
+    });
+    seed_user("frank", rdrs::models::user::Role::User);
+
+    // First login mints a valid session (saved by the client jar).
+    server.get("/").add_header("Remote-User", "frank").await;
+
+    // Second request carries the now-valid cookie: middleware must pass through
+    // and NOT mint a new session_token.
+    let res = server.get("/").add_header("Remote-User", "frank").await;
+    let reminted = res
+        .headers()
+        .get_all("set-cookie")
+        .iter()
+        .filter_map(|v| v.to_str().ok())
+        .any(|s| s.starts_with("session_token="));
+    assert!(!reminted, "a valid session must not be re-minted on every request");
+}
+```
+
+Note: `create_server` uses `.save_cookies()`, so the first request's cookie is reused on the second.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `RDRS_FAST_HASH=1 cargo nextest run -p rdrs --test forward_auth_test test_invalid_session test_valid_session`
+Expected: FAIL — `test_invalid_session_cookie_still_forward_auths` fails because the present cookie currently short-circuits forward-auth (no fresh cookie, not a redirect).
+
+- [ ] **Step 3: Replace the cookie short-circuit**
+
+In `src/middleware/forward_auth.rs`, find:
+
+```rust
+    // Feature off, or already carrying a session cookie → nothing to do.
+    if !config.auth_proxy_enabled() || jar.get(SESSION_COOKIE_NAME).is_some() {
+        return next.run(req).await;
+    }
+```
+
+Replace with:
+
+```rust
+    // Feature off → nothing to do.
+    if !config.auth_proxy_enabled() {
+        return next.run(req).await;
+    }
+
+    // Already carrying a VALID (non-expired) session → leave it to the normal
+    // flow. A present-but-invalid cookie (e.g. after logout or expiry) must NOT
+    // block forward-auth, or the user is locked out.
+    if let Some(token) = jar.get(SESSION_COOKIE_NAME).map(|c| c.value().to_string()) {
+        let valid = state
+            .db
+            .read_user(move |conn| {
+                Ok::<bool, AppError>(
+                    session::find_by_token(conn, &token)?
+                        .map(|s| !s.is_expired())
+                        .unwrap_or(false),
+                )
+            })
+            .await
+            .ok()
+            .and_then(|r| r.ok())
+            .unwrap_or(false);
+        if valid {
+            return next.run(req).await;
+        }
+    }
+```
+
+(`session`, `AppError` are already imported in this file; `read_user` exists on `DbPool`.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `RDRS_FAST_HASH=1 cargo nextest run -p rdrs --test forward_auth_test`
+Expected: PASS — all forward_auth tests, including the two new ones and the existing 6.
+
+- [ ] **Step 5: Lint + commit**
+
+```bash
+cargo fmt && cargo clippy -- -D warnings
+git add src/middleware/forward_auth.rs tests/forward_auth_test.rs
+git commit -m "fix(auth): forward-auth re-authenticates past an invalid session cookie
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: `/login` redirects authenticated users to `/`
+
+Item 3 — so that after forward-auth re-authenticates on `/login`, the user lands in the app instead of staring at the login form (matches Django's login view).
+
+**Files:**
+- Modify: `src/handlers/pages/mod.rs` (`login_page`)
+- Test: `tests/auth_test.rs`
+
+**Interfaces:**
+- Consumes: `PageAuthUser` (already imported), `Redirect`, `Response` (already imported).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/auth_test.rs`:
+
+```rust
+#[tokio::test]
+async fn test_login_page_redirects_authenticated_to_root() {
+    let server = create_test_server(default_test_config());
+    server
+        .post("/api/register")
+        .json(&json!({ "username": "u", "password": "password123" }))
+        .await
+        .assert_status(StatusCode::CREATED);
+    server
+        .post("/api/session")
+        .json(&json!({ "username": "u", "password": "password123" }))
+        .await
+        .assert_status_ok();
+
+    let res = server.get("/login").await;
+    assert!(res.status_code().is_redirection());
+    assert_eq!(res.header("location"), "/");
+}
+
+#[tokio::test]
+async fn test_login_page_renders_when_anonymous() {
+    let server = create_test_server(default_test_config());
+    let res = server.get("/login").await;
+    res.assert_status_ok();
+    assert!(res.text().contains("login-form") || res.text().contains("rdrs"));
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `RDRS_FAST_HASH=1 cargo nextest run -p rdrs --test auth_test test_login_page`
+Expected: FAIL — `test_login_page_redirects_authenticated_to_root` gets 200 (form), not a redirect.
+
+- [ ] **Step 3: Add the authenticated redirect**
+
+In `src/handlers/pages/mod.rs`, replace the `login_page` signature and body so it redirects authenticated users:
+
+```rust
+pub async fn login_page(
+    State(state): State<AppState>,
+    auth: Option<PageAuthUser>,
+    flash: Flash,
+) -> Response {
+    if auth.is_some() {
+        return Redirect::to("/").into_response();
+    }
+
+    let signup_enabled = state
+        .db
+        .read_user(|c| crate::models::user::count(c).ok())
+        .await
+        .ok()
+        .flatten()
+        .map(|count| state.config.can_register(count))
+        .unwrap_or(false);
+
+    (
+        flash.clone(),
+        LoginTemplate {
+            signup_enabled,
+            flash_messages: flash.messages,
+            git_version: crate::GIT_VERSION,
+            local_auth_enabled: !state.config.disable_local_auth,
+        },
+    )
+        .into_response()
+}
+```
+
+(`Option<PageAuthUser>` returns `None` when there is no valid session — axum implements `FromRequestParts` for `Option<T>`. The return type changes from `(Flash, LoginTemplate)` to `Response`; `(Flash, LoginTemplate)` implements `IntoResponse`, so `.into_response()` is valid.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `RDRS_FAST_HASH=1 cargo nextest run -p rdrs --test auth_test test_login_page`
+Expected: PASS.
+
+- [ ] **Step 5: Full check + commit**
+
+```bash
+cargo fmt && cargo clippy -- -D warnings && RDRS_FAST_HASH=1 cargo nextest run
+git add src/handlers/pages/mod.rs tests/auth_test.rs
+git commit -m "fix(auth): redirect authenticated users away from /login to /
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Documentation
+
+Document `AUTH_PROXY_LOGOUT_URL` and the forward-auth logout behavior.
+
+**Files:**
+- Modify: `ARCHITECTURE.md`
+- Modify: `README.md`
+
+**Interfaces:** none.
+
+- [ ] **Step 1: Update `README.md`**
+
+Add a row to the environment-variable table:
+
+| Variable | Default | Description |
+|---|---|---|
+| `AUTH_PROXY_LOGOUT_URL` | (unset) | When set, Sign Out redirects the browser here (e.g. the Authelia logout URL) to end the SSO session. When unset, Sign Out clears the local session and the proxy header re-authenticates on the next request (you return to the app). |
+
+- [ ] **Step 2: Update `ARCHITECTURE.md`**
+
+In the "Forward-Auth (Trusted-Header) Login" section, add a short "Logout" note:
+
+- Sign Out clears the local `session_token` cookie (with `Path=/`) and deletes the server-side session.
+- Forward-auth re-authenticates whenever there is no *valid* session cookie (a stale/expired cookie does not block it), so under forward-auth a local Sign Out bounces the user back in via the proxy header (matches linkding/Miniflux) — unless `AUTH_PROXY_LOGOUT_URL` is set, in which case Sign Out redirects to that URL to end the IdP/SSO session.
+- `/login` redirects an already-authenticated user to `/`.
+
+Also add `AUTH_PROXY_LOGOUT_URL` to the configuration variable list in this document.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add ARCHITECTURE.md README.md
+git commit -m "docs: document AUTH_PROXY_LOGOUT_URL and forward-auth logout behavior
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Item 1 (Bug 1, cookie clearing) → Task 1 (Step 5, `.path("/")` removal). ✓
+- Item 2 (Bug 2, validity check) → Task 2. ✓
+- Item 3 (`/login` → `/`) → Task 3. ✓
+- Item 4 (`AUTH_PROXY_LOGOUT_URL` + JSON redirect + JS) → Task 1 (config, handler, JS). ✓
+- Resulting-behavior table → covered by Tasks 1–3 together; documented in Task 4. ✓
+- Testing bullets → Task 1 (cookie path, redirect default/configured), Task 2 (invalid/valid cookie), Task 3 (authed redirect, anon render). ✓
+- 4 Config literals kept in sync → Task 1 Steps 3–4. ✓
+- Docs → Task 4. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows full code. ✓
+
+**Type consistency:** `auth_proxy_logout_url: Option<String>`, `LogoutResponse { redirect_to: String }`, `logout -> AppResult<(CookieJar, Json<LogoutResponse>)>`, `login_page -> Response`, and the middleware validity block use consistent names/signatures across tasks and match the existing imports verified in the codebase. ✓
+
+## Notes / risks
+
+- `Option<PageAuthUser>` does its own DB lookup; combined with the forward-auth middleware's new validity lookup, an authenticated `/login` hit does two reads. Acceptable (single indexed `find_by_token` each; same lookup `PageAuthUser` already performs).
+- Use `cookie::Cookie::new(...)` with `.add_cookie(...)` and `res.maybe_cookie("session_token")` — exactly as `tests/auth_test.rs` (`cookie` is a dev-dependency, `cookie = "0.18"`) and `tests/forward_auth_test.rs` already do.
+- No e2e logout test exists, so the JS change is covered by the Rust handler tests + `cargo build`; verify manually if a browser is available.

--- a/docs/superpowers/specs/2026-06-25-forward-auth-logout-design.md
+++ b/docs/superpowers/specs/2026-06-25-forward-auth-logout-design.md
@@ -1,0 +1,209 @@
+# Forward-Auth Logout Fix — Design
+
+Date: 2026-06-25
+Status: Approved for planning
+
+## Problem
+
+Under forward-auth, clicking **Sign Out** strands the user: they land on the
+login form and cannot get back in — refreshing or visiting `/` keeps redirecting
+to `/login`. Manually deleting the `session_token` cookie immediately restores
+forward-auth login, which confirmed the root cause.
+
+### Root cause (confirmed)
+
+Two bugs combine into a hard lockout:
+
+1. **Bug 1 — logout never clears the cookie.** `logout` (`src/handlers/auth.rs`)
+   calls `jar.remove(SESSION_COOKIE_NAME)` with no path, but the cookie is set
+   with `Path=/` (login handler and the forward-auth middleware both use
+   `.path("/")`). A removal cookie must match the original path, so the browser
+   keeps the now-invalid `session_token`. The codebase's own `flash.rs:154`
+   shows the correct pattern (`Cookie::build((NAME, "")).path("/").build()`).
+2. **Bug 2 — forward-auth bails on cookie *presence*.** The middleware
+   short-circuits on `jar.get(SESSION_COOKIE_NAME).is_some()`, not on session
+   *validity*. So any stale/expired cookie permanently prevents forward-auth from
+   re-authenticating. (This also reproduces naturally on session expiry, not just
+   logout.)
+
+The server-side session *is* deleted on logout, so `PageAuthUser` rejects the
+stale cookie and redirects to `/login`; under `DISABLE_LOCAL_AUTH` the form is
+hidden, so there is no escape.
+
+### Why the reference apps don't have this
+
+- **Miniflux**: logout clears the server-side session; its auth-proxy middleware
+  re-auths on auth *state* (`IsAuthenticated`), not cookie presence.
+- **linkding**: Django's `LogoutView` clears the cookie correctly; its
+  `RemoteUserMiddleware` re-auths from the *header* on every request. linkding
+  also exposes `LD_AUTH_PROXY_LOGOUT_URL` — exactly the option below.
+
+Both converge on **Option A**: local logout clears the session, and the proxy
+header re-authenticates on the next request (you bounce back into the app),
+while an optional IdP-logout URL provides a real sign-out.
+
+## Goal
+
+Match the linkding/Miniflux behavior (Option A) and add the IdP-logout option:
+
+1. Fix Bug 1 — logout clears the cookie with the matching path.
+2. Fix Bug 2 — forward-auth engages when the session cookie is missing **or
+   invalid**, not merely absent.
+3. `/login` redirects an already-authenticated user to `/` (like Django's login
+   view), so post-re-login lands in the app, not on the form.
+4. Add `AUTH_PROXY_LOGOUT_URL` — when set, Sign Out redirects there (ends the
+   IdP/SSO session); when unset, Sign Out redirects to `/login` (Option A:
+   forward-auth bounces the user back in).
+
+## Non-goals
+
+- No "logged-out landing page" that suppresses auto-login (the rejected Option B;
+  neither reference app does it).
+- No change to GReader/passkey auth.
+- No schema change.
+
+## Design
+
+### Item 1 — logout clears the cookie (`src/handlers/auth.rs`)
+
+Follow the `flash.rs` pattern: build a removal cookie with `Path=/`.
+
+```rust
+let removal = Cookie::build((SESSION_COOKIE_NAME, "")).path("/").build();
+Ok(jar.remove(removal))
+```
+
+(Combined with Item 4, the handler returns this jar plus a JSON redirect target.)
+
+### Item 2 — forward-auth checks session validity (`src/middleware/forward_auth.rs`)
+
+Replace the presence-only short-circuit. When a `session_token` cookie is
+present, look it up on the **read** connection; pass through only if it is a
+valid (non-expired) session. Otherwise continue into the forward-auth logic so a
+stale cookie is overwritten with a fresh session.
+
+```rust
+// Already carrying a VALID session → leave it to the normal flow.
+if let Some(token) = jar.get(SESSION_COOKIE_NAME).map(|c| c.value().to_string()) {
+    let valid = state
+        .db
+        .read_user(move |conn| {
+            Ok::<bool, AppError>(
+                session::find_by_token(conn, &token)?
+                    .map(|s| !s.is_expired())
+                    .unwrap_or(false),
+            )
+        })
+        .await
+        .map(|r| r.unwrap_or(false))
+        .unwrap_or(false);
+    if valid {
+        return next.run(req).await;
+    }
+}
+```
+
+The `!config.auth_proxy_enabled()` early return stays ahead of this so the check
+only runs when forward-auth is on.
+
+### Item 3 — `/login` redirects authenticated users (`src/handlers/pages/mod.rs`)
+
+`login_page` gains an `Option<PageAuthUser>` extractor; when present, redirect to
+`/`. Return type becomes `Response`.
+
+```rust
+pub async fn login_page(
+    State(state): State<AppState>,
+    auth: Option<PageAuthUser>,
+    flash: Flash,
+) -> Response {
+    if auth.is_some() {
+        return Redirect::to("/").into_response();
+    }
+    // ... existing LoginTemplate render, returned via .into_response()
+}
+```
+
+### Item 4 — `AUTH_PROXY_LOGOUT_URL` (`config.rs`, `auth.rs`, sidebar JS)
+
+- **Config:** new field `auth_proxy_logout_url: Option<String>` (env
+  `AUTH_PROXY_LOGOUT_URL`, default `None`). No new startup-validation rule
+  (harmless if set without forward-auth). Update all four `Config` struct
+  literals (config.rs, webauthn.rs, tests/common, tests/statistics).
+- **Logout handler:** return the post-logout redirect target so the
+  fetch-based Sign Out can navigate to it.
+
+```rust
+#[derive(Serialize)]
+pub struct LogoutResponse { pub redirect_to: String }
+
+pub async fn logout(...) -> AppResult<(CookieJar, Json<LogoutResponse>)> {
+    // delete_session(...) as today
+    let removal = Cookie::build((SESSION_COOKIE_NAME, "")).path("/").build();
+    let redirect_to = state
+        .config
+        .auth_proxy_logout_url
+        .clone()
+        .unwrap_or_else(|| "/login".to_string());
+    Ok((jar.remove(removal), Json(LogoutResponse { redirect_to })))
+}
+```
+
+- **Sidebar JS** (`static/js/components/rdrs-sidebar.js`): use the returned
+  target. Preserve the existing "logged out" flash for local paths; navigate
+  directly for an external IdP URL.
+
+```js
+const r = await fetch('/api/session', { method: 'DELETE' });
+if (r.ok) {
+    const d = await r.json();
+    if (d.redirect_to.startsWith('/')) {
+        window.flash.redirect(d.redirect_to, 'info', 'You have been logged out.');
+    } else {
+        window.location.href = d.redirect_to;
+    }
+} else {
+    window.flash.error('Logout failed');
+}
+```
+
+## Resulting behavior
+
+| Deployment | Sign Out result |
+|---|---|
+| Password only (no forward-auth) | Cookie cleared, land on `/login`, log in again. |
+| Forward-auth, no `AUTH_PROXY_LOGOUT_URL` | Cookie cleared → `/login` → forward-auth re-auths from the still-valid IdP session → `/login` redirects to `/` → **back in the app** (Option A, matches linkding/Miniflux). |
+| Forward-auth + `AUTH_PROXY_LOGOUT_URL` | Cookie cleared → browser navigates to the IdP logout URL → **SSO session ends** → returning to rdrs requires a fresh IdP login. |
+
+## Testing
+
+- **Item 1:** logout response sets `session_token` deletion cookie with `Path=/`
+  (assert the `Set-Cookie` header path); after login+logout the test client no
+  longer holds a valid session.
+- **Item 2:** integration — with a present-but-invalid `session_token` cookie and
+  a trusted forward-auth header, the middleware still establishes a fresh
+  session (does not bounce to `/login`). Also: a present **valid** session cookie
+  is left untouched (no new session minted).
+- **Item 3:** `GET /login` with a valid session redirects to `/` (302); without a
+  session renders the form.
+- **Item 4:** logout `redirect_to` is `/login` by default and equals
+  `AUTH_PROXY_LOGOUT_URL` when configured; config parsing of the new var.
+- Existing `test_logout` updated for the new JSON response shape.
+- Check `e2e/` logout steps still pass (default redirect is `/login`).
+
+## Affected files
+
+- `src/config.rs` — `auth_proxy_logout_url` + parsing; 4 literals updated.
+- `src/handlers/auth.rs` — cookie clearing + `LogoutResponse`.
+- `src/middleware/forward_auth.rs` — validity check.
+- `src/handlers/pages/mod.rs` — `/login` authed redirect.
+- `static/js/components/rdrs-sidebar.js` — Sign Out redirect handling.
+- `ARCHITECTURE.md`, `README.md` — document `AUTH_PROXY_LOGOUT_URL` and the
+  logout behavior.
+- Tests: `tests/auth_test.rs`, `tests/forward_auth_test.rs`, the 4 Config
+  literals.
+
+## Out-of-scope follow-ups
+
+- Recording the auth method on the session (to tailor Sign Out per-method).
+- RP-initiated OIDC logout (not applicable to forward-auth).

--- a/src/auth/webauthn.rs
+++ b/src/auth/webauthn.rs
@@ -40,6 +40,7 @@ mod tests {
             disable_local_auth: false,
             auth_proxy_groups_header: String::new(),
             auth_proxy_admin_group: String::new(),
+            auth_proxy_logout_url: None,
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -30,6 +30,7 @@ pub struct Config {
     pub disable_local_auth: bool,
     pub auth_proxy_groups_header: String,
     pub auth_proxy_admin_group: String,
+    pub auth_proxy_logout_url: Option<String>,
 }
 
 /// Parse a comma-separated list of CIDR networks or bare IPs into `IpNet`s.
@@ -98,6 +99,9 @@ impl Config {
                 .unwrap_or(false),
             auth_proxy_groups_header: env::var("AUTH_PROXY_GROUPS_HEADER").unwrap_or_default(),
             auth_proxy_admin_group: env::var("AUTH_PROXY_ADMIN_GROUP").unwrap_or_default(),
+            auth_proxy_logout_url: env::var("AUTH_PROXY_LOGOUT_URL")
+                .ok()
+                .filter(|s| !s.is_empty()),
         })
     }
 
@@ -215,6 +219,7 @@ mod tests {
             disable_local_auth: false,
             auth_proxy_groups_header: String::new(),
             auth_proxy_admin_group: String::new(),
+            auth_proxy_logout_url: None,
         }
     }
 

--- a/src/handlers/auth.rs
+++ b/src/handlers/auth.rs
@@ -137,16 +137,31 @@ pub async fn login(
     ))
 }
 
+#[derive(Debug, Serialize)]
+pub struct LogoutResponse {
+    pub redirect_to: String,
+}
+
 pub async fn logout(
     State(state): State<AppState>,
     jar: CookieJar,
     auth_user: AuthUser,
-) -> AppResult<CookieJar> {
+) -> AppResult<(CookieJar, Json<LogoutResponse>)> {
     let token = auth_user.session.session_token.clone();
     state
         .db
         .user(move |conn| session::delete_session(conn, &token))
         .await??;
 
-    Ok(jar.remove(SESSION_COOKIE_NAME))
+    // Removal must match the Path=/ the cookie was set with, or the browser
+    // keeps the (now-invalid) session_token cookie. Mirrors flash.rs.
+    let removal = Cookie::build((SESSION_COOKIE_NAME, "")).path("/").build();
+
+    let redirect_to = state
+        .config
+        .auth_proxy_logout_url
+        .clone()
+        .unwrap_or_else(|| "/login".to_string());
+
+    Ok((jar.remove(removal), Json(LogoutResponse { redirect_to })))
 }

--- a/src/handlers/pages/mod.rs
+++ b/src/handlers/pages/mod.rs
@@ -473,7 +473,15 @@ impl IntoResponse for LoginTemplate {
     }
 }
 
-pub async fn login_page(State(state): State<AppState>, flash: Flash) -> (Flash, LoginTemplate) {
+pub async fn login_page(
+    auth: Option<PageAuthUser>,
+    State(state): State<AppState>,
+    flash: Flash,
+) -> Response {
+    if auth.is_some() {
+        return Redirect::to("/").into_response();
+    }
+
     let signup_enabled = state
         .db
         .read_user(|c| crate::models::user::count(c).ok())
@@ -492,6 +500,7 @@ pub async fn login_page(State(state): State<AppState>, flash: Flash) -> (Flash, 
             local_auth_enabled: !state.config.disable_local_auth,
         },
     )
+        .into_response()
 }
 
 #[derive(Template)]

--- a/src/middleware/auth.rs
+++ b/src/middleware/auth.rs
@@ -1,5 +1,5 @@
 use axum::{
-    extract::FromRequestParts,
+    extract::{FromRequestParts, OptionalFromRequestParts},
     http::request::Parts,
     response::{IntoResponse, Response},
 };
@@ -133,6 +133,20 @@ impl FromRequestParts<AppState> for PageAuthUser {
     }
 }
 
+impl OptionalFromRequestParts<AppState> for PageAuthUser {
+    type Rejection = std::convert::Infallible;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &AppState,
+    ) -> Result<Option<Self>, Self::Rejection> {
+        match <PageAuthUser as FromRequestParts<AppState>>::from_request_parts(parts, state).await {
+            Ok(user) => Ok(Some(user)),
+            Err(_) => Ok(None),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct AdminUser {
     pub user: User,
@@ -187,7 +201,8 @@ impl FromRequestParts<AppState> for PageAdminUser {
         parts: &mut Parts,
         state: &AppState,
     ) -> Result<Self, Self::Rejection> {
-        let page_auth_user = PageAuthUser::from_request_parts(parts, state).await?;
+        let page_auth_user =
+            <PageAuthUser as FromRequestParts<AppState>>::from_request_parts(parts, state).await?;
 
         if page_auth_user.session.is_masquerading() {
             if let Some(original_user_id) = page_auth_user.session.original_user_id {

--- a/src/middleware/forward_auth.rs
+++ b/src/middleware/forward_auth.rs
@@ -53,9 +53,31 @@ pub async fn forward_auth(
 ) -> Response {
     let config = &state.config;
 
-    // Feature off, or already carrying a session cookie → nothing to do.
-    if !config.auth_proxy_enabled() || jar.get(SESSION_COOKIE_NAME).is_some() {
+    // Feature off → nothing to do.
+    if !config.auth_proxy_enabled() {
         return next.run(req).await;
+    }
+
+    // Already carrying a VALID (non-expired) session → leave it to the normal
+    // flow. A present-but-invalid cookie (e.g. after logout or expiry) must NOT
+    // block forward-auth, or the user is locked out.
+    if let Some(token) = jar.get(SESSION_COOKIE_NAME).map(|c| c.value().to_string()) {
+        let valid = state
+            .db
+            .read_user(move |conn| {
+                Ok::<bool, AppError>(
+                    session::find_by_token(conn, &token)?
+                        .map(|s| !s.is_expired())
+                        .unwrap_or(false),
+                )
+            })
+            .await
+            .ok()
+            .and_then(|r| r.ok())
+            .unwrap_or(false);
+        if valid {
+            return next.run(req).await;
+        }
     }
 
     // Only engage for browser page routes.

--- a/src/middleware/forward_auth.rs
+++ b/src/middleware/forward_auth.rs
@@ -58,6 +58,15 @@ pub async fn forward_auth(
         return next.run(req).await;
     }
 
+    // Only engage for browser page routes; skip before any DB work so
+    // API/static requests with a session cookie don't pay a pointless lookup.
+    if SKIP_PREFIXES
+        .iter()
+        .any(|p| req.uri().path().starts_with(p))
+    {
+        return next.run(req).await;
+    }
+
     // Already carrying a VALID (non-expired) session → leave it to the normal
     // flow. A present-but-invalid cookie (e.g. after logout or expiry) must NOT
     // block forward-auth, or the user is locked out.
@@ -78,14 +87,6 @@ pub async fn forward_auth(
         if valid {
             return next.run(req).await;
         }
-    }
-
-    // Only engage for browser page routes.
-    if SKIP_PREFIXES
-        .iter()
-        .any(|p| req.uri().path().starts_with(p))
-    {
-        return next.run(req).await;
     }
 
     // Fail closed: without a known peer IP we cannot trust the header.

--- a/static/js/components/rdrs-sidebar.js
+++ b/static/js/components/rdrs-sidebar.js
@@ -256,7 +256,12 @@ class RdrsSidebar extends HTMLElement {
             try {
                 const r = await fetch('/api/session', { method: 'DELETE' });
                 if (r.ok) {
-                    window.flash.redirect('/login', 'info', 'You have been logged out.');
+                    const d = await r.json();
+                    if (d.redirect_to.startsWith('/')) {
+                        window.flash.redirect(d.redirect_to, 'info', 'You have been logged out.');
+                    } else {
+                        window.location.href = d.redirect_to;
+                    }
                 } else {
                     window.flash.error('Logout failed');
                 }

--- a/tests/auth_test.rs
+++ b/tests/auth_test.rs
@@ -951,6 +951,33 @@ async fn test_logout_redirect_uses_configured_url() {
 }
 
 #[tokio::test]
+async fn test_login_page_redirects_authenticated_to_root() {
+    let server = create_test_server(default_test_config());
+    server
+        .post("/api/register")
+        .json(&json!({ "username": "u", "password": "password123" }))
+        .await
+        .assert_status(StatusCode::CREATED);
+    server
+        .post("/api/session")
+        .json(&json!({ "username": "u", "password": "password123" }))
+        .await
+        .assert_status_ok();
+
+    let res = server.get("/login").await;
+    assert!(res.status_code().is_redirection());
+    assert_eq!(res.header("location"), "/");
+}
+
+#[tokio::test]
+async fn test_login_page_renders_when_anonymous() {
+    let server = create_test_server(default_test_config());
+    let res = server.get("/login").await;
+    res.assert_status_ok();
+    assert!(res.text().contains("login-form") || res.text().contains("rdrs"));
+}
+
+#[tokio::test]
 async fn test_fresh_session_is_not_refreshed() {
     let server = create_test_server(default_test_config());
 

--- a/tests/auth_test.rs
+++ b/tests/auth_test.rs
@@ -874,6 +874,82 @@ async fn test_disable_local_auth_blocks_password_login() {
     res.assert_status(StatusCode::FORBIDDEN);
 }
 
+/// Collect raw Set-Cookie header values from a response.
+fn set_cookie_headers(res: &axum_test::TestResponse) -> Vec<String> {
+    res.headers()
+        .get_all("set-cookie")
+        .iter()
+        .filter_map(|v| v.to_str().ok().map(|s| s.to_string()))
+        .collect()
+}
+
+#[tokio::test]
+async fn test_logout_clears_cookie_with_path() {
+    let server = create_test_server(default_test_config());
+    server
+        .post("/api/register")
+        .json(&json!({ "username": "u", "password": "password123" }))
+        .await
+        .assert_status(StatusCode::CREATED);
+    server
+        .post("/api/session")
+        .json(&json!({ "username": "u", "password": "password123" }))
+        .await
+        .assert_status_ok();
+
+    let res = server.delete("/api/session").await;
+    res.assert_status_ok();
+
+    let removal = set_cookie_headers(&res)
+        .into_iter()
+        .find(|s| s.starts_with("session_token="))
+        .expect("logout must emit a session_token Set-Cookie");
+    assert!(
+        removal.contains("Path=/"),
+        "removal cookie must carry Path=/ to actually delete the session cookie: {removal}"
+    );
+}
+
+#[tokio::test]
+async fn test_logout_redirect_default_is_login() {
+    let server = create_test_server(default_test_config());
+    server
+        .post("/api/register")
+        .json(&json!({ "username": "u", "password": "password123" }))
+        .await
+        .assert_status(StatusCode::CREATED);
+    server
+        .post("/api/session")
+        .json(&json!({ "username": "u", "password": "password123" }))
+        .await
+        .assert_status_ok();
+
+    let res = server.delete("/api/session").await;
+    let body: serde_json::Value = res.json();
+    assert_eq!(body["redirect_to"], "/login");
+}
+
+#[tokio::test]
+async fn test_logout_redirect_uses_configured_url() {
+    let mut config = default_test_config();
+    config.auth_proxy_logout_url = Some("https://auth.example.com/logout".to_string());
+    let server = create_test_server(config);
+    server
+        .post("/api/register")
+        .json(&json!({ "username": "u", "password": "password123" }))
+        .await
+        .assert_status(StatusCode::CREATED);
+    server
+        .post("/api/session")
+        .json(&json!({ "username": "u", "password": "password123" }))
+        .await
+        .assert_status_ok();
+
+    let res = server.delete("/api/session").await;
+    let body: serde_json::Value = res.json();
+    assert_eq!(body["redirect_to"], "https://auth.example.com/logout");
+}
+
 #[tokio::test]
 async fn test_fresh_session_is_not_refreshed() {
     let server = create_test_server(default_test_config());

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -27,5 +27,6 @@ pub fn default_test_config() -> Config {
         disable_local_auth: false,
         auth_proxy_groups_header: String::new(),
         auth_proxy_admin_group: String::new(),
+        auth_proxy_logout_url: None,
     }
 }

--- a/tests/forward_auth_test.rs
+++ b/tests/forward_auth_test.rs
@@ -211,9 +211,14 @@ async fn test_valid_session_cookie_not_reminted() {
     // First login mints a valid session (saved by the client jar).
     server.get("/").add_header("Remote-User", "frank").await;
 
-    // Second request carries the now-valid cookie: middleware must pass through
-    // and NOT mint a new session_token.
+    // Second request carries the now-valid cookie: the validity check must
+    // honour the existing session (pass through to the app) rather than
+    // treating it as invalid and re-minting.  Guards against a regression where
+    // the validity check wrongly rejects a good cookie, causing a redirect to
+    // /login and/or a new cookie to be issued.
     let res = server.get("/").add_header("Remote-User", "frank").await;
+
+    // The valid session must NOT be re-minted.
     let reminted = res
         .headers()
         .get_all("set-cookie")
@@ -223,5 +228,17 @@ async fn test_valid_session_cookie_not_reminted() {
     assert!(
         !reminted,
         "a valid session must not be re-minted on every request"
+    );
+
+    // The middleware must pass through to the app, not redirect to /login.
+    // (A logged-in GET / may itself redirect within the app, but it must never
+    // redirect to /login.)
+    let location = res
+        .maybe_header("location")
+        .and_then(|v| v.to_str().ok().map(|s| s.to_string()))
+        .unwrap_or_default();
+    assert_ne!(
+        location, "/login",
+        "a valid session must not be redirected to /login"
     );
 }

--- a/tests/forward_auth_test.rs
+++ b/tests/forward_auth_test.rs
@@ -176,3 +176,52 @@ async fn test_existing_user_role_recomputed_on_login() {
         .unwrap();
     assert_eq!(user.role, rdrs::models::user::Role::User);
 }
+
+#[tokio::test]
+async fn test_invalid_session_cookie_still_forward_auths() {
+    let db_name = "fa_test_invalid_cookie";
+    let server = create_server(db_name, |c| {
+        c.trusted_proxy_networks = parse_trusted_networks("127.0.0.0/8").unwrap();
+    });
+    seed_user(db_name, "erin", rdrs::models::user::Role::User);
+
+    // A stale/garbage session_token cookie must NOT block forward-auth.
+    let res = server
+        .get("/")
+        .add_header("Remote-User", "erin")
+        .add_cookie(cookie::Cookie::new("session_token", "stale-invalid"))
+        .await;
+
+    assert!(res.status_code().is_redirection());
+    let fresh = res
+        .maybe_cookie("session_token")
+        .expect("a fresh session cookie should be minted");
+    assert_ne!(fresh.value(), "stale-invalid");
+    assert!(!fresh.value().is_empty());
+}
+
+#[tokio::test]
+async fn test_valid_session_cookie_not_reminted() {
+    let db_name = "fa_test_valid_cookie_not_reminted";
+    let server = create_server(db_name, |c| {
+        c.trusted_proxy_networks = parse_trusted_networks("127.0.0.0/8").unwrap();
+    });
+    seed_user(db_name, "frank", rdrs::models::user::Role::User);
+
+    // First login mints a valid session (saved by the client jar).
+    server.get("/").add_header("Remote-User", "frank").await;
+
+    // Second request carries the now-valid cookie: middleware must pass through
+    // and NOT mint a new session_token.
+    let res = server.get("/").add_header("Remote-User", "frank").await;
+    let reminted = res
+        .headers()
+        .get_all("set-cookie")
+        .iter()
+        .filter_map(|v| v.to_str().ok())
+        .any(|s| s.starts_with("session_token="));
+    assert!(
+        !reminted,
+        "a valid session must not be re-minted on every request"
+    );
+}

--- a/tests/statistics_test.rs
+++ b/tests/statistics_test.rs
@@ -49,6 +49,7 @@ fn create_test_app(name: &str) -> TestApp {
         disable_local_auth: false,
         auth_proxy_groups_header: String::new(),
         auth_proxy_admin_group: String::new(),
+        auth_proxy_logout_url: None,
     };
     let webauthn = auth::create_webauthn(&config).unwrap();
     let summary_cache = services::create_summary_cache(100, 24);


### PR DESCRIPTION
## Summary

Fixes a lockout where, under forward-auth, **Sign Out** stranded the user on the login form — unrecoverable even by refreshing or visiting `/` — and adds `AUTH_PROXY_LOGOUT_URL` for real IdP logout.

### Root cause (two bugs)

1. **Logout never cleared the cookie.** `logout` removed the `session_token` cookie without the `Path=/` it was set with, so the browser kept a stale cookie. (The codebase's own `flash.rs` already does it correctly.)
2. **Forward-auth short-circuited on cookie *presence*, not validity.** Any stale/expired cookie permanently blocked re-authentication, so the user could never get back in (and under `DISABLE_LOCAL_AUTH` there is no password form to fall back to).

Verified by manually deleting the `session_token` cookie, which immediately restored forward-auth login.

### Behavior after this change (Option A — matches linkding & Miniflux)

| Deployment | Sign Out result |
|---|---|
| Password only | Cookie cleared, land on `/login`, log in again. |
| Forward-auth, `AUTH_PROXY_LOGOUT_URL` unset | Cookie cleared → the proxy header re-authenticates on the next request → back in the app. |
| Forward-auth + `AUTH_PROXY_LOGOUT_URL` | Browser redirects to the IdP logout URL → SSO session ends. |

This mirrors linkding's `LD_AUTH_PROXY_LOGOUT_URL` and Miniflux's auth-proxy logout behavior.

## Changes

1. **Logout clears the cookie** with the matching `Path=/`, and returns a JSON `{ redirect_to }` the Sign Out JS navigates to. New `AUTH_PROXY_LOGOUT_URL` (default unset) sets that target; otherwise `/login`. The Sign Out handler branches local (flash + redirect) vs external (direct navigation).
2. **Forward-auth re-authenticates past an invalid cookie**: the middleware now passes through only on a *valid* (non-expired) session, looked up on the read connection and fail-closed (any error → treat as not-valid → continue). `SKIP_PREFIXES` was hoisted above the lookup so API/static requests skip the DB read.
3. **`/login` redirects an authenticated user to `/`** (mirrors Django's login view), so post-re-login lands in the app, not on the form. Required adding `OptionalFromRequestParts for PageAuthUser` (axum 0.8), which delegates to the existing extractor — protected-page auth is unchanged.
4. **Docs**: `AUTH_PROXY_LOGOUT_URL` + the logout behavior in `README.md` and `ARCHITECTURE.md`.

## Security

- Removal cookie now actually clears the `Path=/` session cookie.
- The new validity check is fail-closed: it only ever *passes through* on a confirmed-valid session and never mints a session; the minting path stays gated by the TCP peer-IP trust check + identity header (unchanged). Early-return order: `auth_proxy_enabled → SKIP_PREFIXES → valid-session lookup → trusted-peer/header`.
- `AUTH_PROXY_LOGOUT_URL` is operator-configured (no open-redirect concern). GReader `ClientLogin` and passkey auth are untouched.

## Testing

- Logout: removal cookie carries `Path=/`; `redirect_to` is `/login` by default and the configured URL when set.
- Forward-auth: a present-but-invalid cookie still re-authenticates (fresh session minted); a valid cookie is not re-minted.
- `/login`: authenticated → 302 to `/`; anonymous → renders the form.
- Full suite green: 974/974 passing, `cargo fmt` and `cargo clippy -- -D warnings` clean.

Design spec and implementation plan are included under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)