### PR TITLE
feat(ui): show auth mode (SSO pill) and group App config table

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -266,6 +266,10 @@ Forward-auth, local password, and passkey authentication all work simultaneously
 
 Sign Out always clears the local `session_token` cookie (with `Path=/`) and deletes the server-side session. The forward-auth middleware re-authenticates whenever there is no *valid* session cookie — a stale or expired cookie no longer blocks re-authentication. This means that under forward-auth, a local Sign Out normally bounces the user straight back in via the proxy header (matching the linkding/Miniflux behavior). If `AUTH_PROXY_LOGOUT_URL` is set, Sign Out instead redirects the browser there (e.g. the Authelia logout URL) so the IdP/SSO session is also terminated. Additionally, `/login` redirects an already-authenticated user to `/` rather than rendering the login form again.
 
+**Auth-mode indicator:**
+
+The sidebar shows an **SSO** pill when the current request is served through forward-auth — computed per request from the trusted proxy header (no stored state), surfaced via `via_forward_auth` on the auth extractors and the sidebar payload. The App page (`/settings`) lists the forward-auth configuration under a grouped Configuration table.
+
 ## Services
 
 ### Feed Synchronization

--- a/docs/superpowers/plans/2026-06-25-auth-mode-indicator.md
+++ b/docs/superpowers/plans/2026-06-25-auth-mode-indicator.md
@@ -1,0 +1,721 @@
+# Auth-Mode Indicator + App Config Grouping Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show an "SSO" pill in the sidebar when the current request is served through forward-auth, and surface the forward-auth config on the App page in a regrouped, reordered Configuration table.
+
+**Architecture:** Forward-auth state is computed dynamically per request (no persistence) via a shared `forward_auth_identity` helper, exposed on the `AuthUser`/`PageAuthUser` extractors as `via_forward_auth`, carried through `SidebarResponse` to the SSR bootstrap and `/api/sidebar`, and rendered as a pill by the sidebar web component. Separately, the `/settings` table is reorganized into labeled groups with columns reordered to Variable · Current · Default · Description, including the forward-auth vars.
+
+**Tech Stack:** Rust, axum 0.8, axum-extra, rusqlite, axum-test, Askama templates, vanilla ES module web component, CSS.
+
+## Global Constraints
+
+- Run tests with `cargo nextest run` (never `cargo test`); prefix local runs with `RDRS_FAST_HASH=1`.
+- `cargo fmt` before every commit; `cargo clippy -- -D warnings` must pass.
+- Commits GPG-signed (default git config); end messages with `Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`.
+- Stage files explicitly by name — never `git add -A` / `git add .`.
+- **No schema change** — forward-auth state is computed per request. The forward-auth `Config` fields already exist from prior work; this plan only reads them.
+- Static JS / templates / CSS are embedded at compile time; run `cargo build` after editing `static/**` or `templates/**` before any manual/e2e/screenshot check.
+- `rdrs::middleware::forward_auth` and `rdrs::config` are public; integration tests may call `forward_auth_identity` and `parse_trusted_networks` directly and build configs via `common::default_test_config()`.
+- The pill label is the static string `SSO`. Local (non-forward-auth) requests render no pill.
+
+---
+
+### Task 1: `forward_auth_identity` shared helper + middleware reuse
+
+A pure helper that decides whether a request carries a trusted forward-auth identity. The existing middleware is refactored to use it (DRY), guarded by the existing forward-auth integration tests.
+
+**Files:**
+- Modify: `src/middleware/forward_auth.rs` (add helper; refactor middleware to call it)
+- Test: `tests/forward_auth_test.rs`
+
+**Interfaces:**
+- Produces: `pub fn forward_auth_identity(config: &crate::config::Config, peer_ip: Option<std::net::IpAddr>, headers: &axum::http::HeaderMap) -> Option<String>`
+
+- [ ] **Step 1: Write the failing helper tests**
+
+Add to `tests/forward_auth_test.rs` (it already has `mod common; use common::default_test_config;`):
+
+```rust
+use axum::http::{HeaderMap, HeaderName};
+use rdrs::config::parse_trusted_networks;
+use rdrs::middleware::forward_auth::forward_auth_identity;
+
+fn header_map(pairs: &[(&str, &str)]) -> HeaderMap {
+    let mut h = HeaderMap::new();
+    for (k, v) in pairs {
+        h.insert(
+            HeaderName::from_bytes(k.as_bytes()).unwrap(),
+            v.parse().unwrap(),
+        );
+    }
+    h
+}
+
+#[test]
+fn test_forward_auth_identity() {
+    let mut cfg = default_test_config();
+    cfg.auth_proxy_header = "Remote-User".to_string();
+    cfg.trusted_proxy_networks = parse_trusted_networks("10.0.0.0/8").unwrap();
+
+    let trusted: std::net::IpAddr = "10.1.2.3".parse().unwrap();
+    let untrusted: std::net::IpAddr = "192.168.0.1".parse().unwrap();
+    let with_header = header_map(&[("Remote-User", "alice")]);
+
+    // trusted peer + header present → identity
+    assert_eq!(
+        forward_auth_identity(&cfg, Some(trusted), &with_header),
+        Some("alice".to_string())
+    );
+    // untrusted peer → None
+    assert_eq!(forward_auth_identity(&cfg, Some(untrusted), &with_header), None);
+    // no peer IP → None
+    assert_eq!(forward_auth_identity(&cfg, None, &with_header), None);
+    // header missing → None
+    assert_eq!(forward_auth_identity(&cfg, Some(trusted), &HeaderMap::new()), None);
+    // header empty → None
+    assert_eq!(
+        forward_auth_identity(&cfg, Some(trusted), &header_map(&[("Remote-User", "  ")])),
+        None
+    );
+
+    // feature off (empty header name) → None
+    let mut off = cfg.clone();
+    off.auth_proxy_header = String::new();
+    assert_eq!(forward_auth_identity(&off, Some(trusted), &with_header), None);
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `RDRS_FAST_HASH=1 cargo nextest run -p rdrs --test forward_auth_test test_forward_auth_identity`
+Expected: FAIL — `forward_auth_identity` does not exist.
+
+- [ ] **Step 3: Add the helper**
+
+In `src/middleware/forward_auth.rs`, add imports near the top:
+
+```rust
+use std::net::IpAddr;
+
+use axum::http::HeaderMap;
+
+use crate::config::Config;
+```
+
+Add the helper (above the `forward_auth` function):
+
+```rust
+/// The identity supplied by a trusted forward-auth proxy on this request, if
+/// any. Returns `None` when the feature is off, the peer IP is missing or not
+/// in `TRUSTED_PROXY_NETWORKS`, or the identity header is absent/empty. Shared
+/// by the middleware and the `AuthUser`/`PageAuthUser` extractors so the
+/// trust logic lives in one place.
+pub fn forward_auth_identity(
+    config: &Config,
+    peer_ip: Option<IpAddr>,
+    headers: &HeaderMap,
+) -> Option<String> {
+    if !config.auth_proxy_enabled() {
+        return None;
+    }
+    let ip = peer_ip?;
+    if !config.is_trusted_peer(ip) {
+        return None;
+    }
+    headers
+        .get(config.auth_proxy_header.as_str())
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+```
+
+- [ ] **Step 4: Refactor the middleware to use the helper**
+
+In `forward_auth`, replace the inline peer-IP trust check and identity-header read (the block that starts with the `// Fail closed: without a known peer IP` comment and ends with the `let Some(username) = req.headers()...else { return next.run(req).await; };` block) with:
+
+```rust
+    // Trusted-peer + identity-header check (shared with the auth extractors).
+    let peer_ip = req
+        .extensions()
+        .get::<ConnectInfo<SocketAddr>>()
+        .map(|c| c.0.ip());
+    let Some(username) = forward_auth_identity(config, peer_ip, req.headers()) else {
+        return next.run(req).await;
+    };
+```
+
+Leave everything before it (the `auth_proxy_enabled` early return, the `SKIP_PREFIXES` check, the valid-session-cookie short-circuit) and after it (group mapping, session creation, redirect) unchanged.
+
+- [ ] **Step 5: Run helper test + full forward-auth suite**
+
+Run: `cargo fmt && RDRS_FAST_HASH=1 cargo nextest run -p rdrs --test forward_auth_test && cargo clippy -- -D warnings`
+Expected: PASS — the new helper test plus all existing forward_auth integration tests (the refactor is behavior-preserving).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/middleware/forward_auth.rs tests/forward_auth_test.rs
+git commit -m "refactor(auth): extract forward_auth_identity helper for reuse
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: `via_forward_auth` on the extractors and `SidebarResponse`
+
+Compute the flag in the `AuthUser`/`PageAuthUser` extractors and thread it into the SSR sidebar bootstrap and `GET /api/sidebar`.
+
+**Files:**
+- Modify: `src/middleware/auth.rs` (`AuthUser`, `PageAuthUser` structs + `from_request_parts`)
+- Modify: `src/handlers/user.rs` (`SidebarResponse` field; `build_sidebar_response` param; `get_sidebar`)
+- Modify: `src/handlers/pages/mod.rs` (`build_app_layout` inline `SidebarResponse`)
+- Test: `tests/forward_auth_test.rs`
+
+**Interfaces:**
+- Consumes: `forward_auth_identity` (Task 1).
+- Produces: `AuthUser.via_forward_auth: bool`, `PageAuthUser.via_forward_auth: bool`, `SidebarResponse.via_forward_auth: bool`, `build_sidebar_response(state, user, session, via_forward_auth)`.
+
+- [ ] **Step 1: Write the failing integration test**
+
+Add to `tests/forward_auth_test.rs` (uses the file's `create_server`, `seed_user`, `.http_transport().save_cookies()` harness):
+
+```rust
+#[tokio::test]
+async fn test_sidebar_reports_via_forward_auth_dynamically() {
+    let server = create_server(|c| {
+        c.trusted_proxy_networks = parse_trusted_networks("127.0.0.0/8").unwrap();
+    });
+    seed_user("grace", rdrs::models::user::Role::User);
+
+    // Establish a session via forward-auth (page route mints the cookie).
+    server.get("/").add_header("Remote-User", "grace").await;
+
+    // With the proxy header present → via_forward_auth true.
+    let with = server.get("/api/sidebar").add_header("Remote-User", "grace").await;
+    with.assert_status_ok();
+    assert_eq!(with.json::<serde_json::Value>()["via_forward_auth"], true);
+
+    // Same valid session, but no proxy header on this request → false (dynamic).
+    let without = server.get("/api/sidebar").await;
+    without.assert_status_ok();
+    assert_eq!(without.json::<serde_json::Value>()["via_forward_auth"], false);
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `RDRS_FAST_HASH=1 cargo nextest run -p rdrs --test forward_auth_test test_sidebar_reports_via_forward_auth_dynamically`
+Expected: FAIL — `via_forward_auth` is not a field in the JSON / does not compile.
+
+- [ ] **Step 3: Add `via_forward_auth` to the extractors**
+
+In `src/middleware/auth.rs`, add imports:
+
+```rust
+use std::net::SocketAddr;
+
+use axum::extract::ConnectInfo;
+```
+
+Add the field to both structs:
+
+```rust
+#[derive(Debug, Clone)]
+pub struct AuthUser {
+    pub user: User,
+    pub session: Session,
+    pub via_forward_auth: bool,
+}
+```
+
+```rust
+#[derive(Debug, Clone)]
+pub struct PageAuthUser {
+    pub user: User,
+    pub session: Session,
+    pub via_forward_auth: bool,
+}
+```
+
+In `AuthUser::from_request_parts`, just before `Ok(AuthUser { user, session })`, compute and include the flag:
+
+```rust
+        let peer_ip = parts
+            .extensions
+            .get::<ConnectInfo<SocketAddr>>()
+            .map(|c| c.0.ip());
+        let via_forward_auth =
+            crate::middleware::forward_auth::forward_auth_identity(&state.config, peer_ip, &parts.headers)
+                .is_some();
+
+        Ok(AuthUser {
+            user,
+            session,
+            via_forward_auth,
+        })
+```
+
+Do the same in `PageAuthUser::from_request_parts`, returning `Ok(PageAuthUser { user, session, via_forward_auth })`. (`AdminUser`/`PageAdminUser` build from these and only read `user`/`session`, so they need no change.)
+
+- [ ] **Step 4: Thread the flag through `SidebarResponse`**
+
+In `src/handlers/user.rs`, add the field to `SidebarResponse`:
+
+```rust
+    pub via_forward_auth: bool,
+```
+
+Change `build_sidebar_response` to accept and set it:
+
+```rust
+pub async fn build_sidebar_response(
+    state: &AppState,
+    user: &crate::models::User,
+    session: &crate::models::session::Session,
+    via_forward_auth: bool,
+) -> AppResult<SidebarResponse> {
+    // ... existing body unchanged ...
+    Ok(SidebarResponse {
+        username: user.username.clone(),
+        is_admin,
+        is_masquerading,
+        categories: chrome.categories,
+        total_unread: chrome.total_unread,
+        total_summarized: chrome.total_summarized,
+        via_forward_auth,
+    })
+}
+```
+
+Update `get_sidebar` to pass it:
+
+```rust
+    let payload =
+        build_sidebar_response(&state, &auth_user.user, &auth_user.session, auth_user.via_forward_auth)
+            .await?;
+```
+
+- [ ] **Step 5: Set the flag in the SSR bootstrap**
+
+In `src/handlers/pages/mod.rs`, in `build_app_layout`, add to the inline `SidebarResponse { ... }` construction:
+
+```rust
+        via_forward_auth: auth_user.via_forward_auth,
+```
+
+- [ ] **Step 6: Run the test + full suite**
+
+Run: `cargo fmt && RDRS_FAST_HASH=1 cargo nextest run -p rdrs --test forward_auth_test && cargo clippy -- -D warnings && RDRS_FAST_HASH=1 cargo nextest run`
+Expected: the new test PASSES; whole suite green (the new struct field compiles everywhere it's built).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/middleware/auth.rs src/handlers/user.rs src/handlers/pages/mod.rs tests/forward_auth_test.rs
+git commit -m "feat(auth): expose via_forward_auth on extractors and sidebar payload
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Sidebar SSO pill (frontend)
+
+Render the pill next to the username when `via_forward_auth` is true, and treat the flag as a structural change for live updates.
+
+**Files:**
+- Modify: `static/js/components/rdrs-sidebar.js`
+- Modify: `static/css/app.css`
+
+**Interfaces:**
+- Consumes: `data.via_forward_auth` (Task 2).
+
+- [ ] **Step 1: Read the flag in `render()`**
+
+In `static/js/components/rdrs-sidebar.js`, after the existing destructuring (around lines 154–158, after `const isMasq = ...`), add:
+
+```javascript
+        const viaForwardAuth = data ? !!data.via_forward_auth : false;
+```
+
+- [ ] **Step 2: Render the pill in the footer**
+
+Replace the `.sidebar-footer` markup (currently the `<span class="sidebar-user">…</span>` + Sign Out link) with:
+
+```javascript
+    <div class="sidebar-footer">
+        <span class="sidebar-id">
+            <span class="sidebar-user">${escapeHtml(username)}</span>
+            ${viaForwardAuth ? '<span class="sidebar-auth-pill" data-testid="auth-pill">SSO</span>' : ''}
+        </span>
+        <a href="#" data-testid="logout-btn" data-rdrs-logout>Sign Out</a>
+    </div>`;
+```
+
+- [ ] **Step 3: Treat the flag as a structural change**
+
+In `isStructuralChange(prev, next)`, add alongside the existing checks:
+
+```javascript
+    if (!!prev.via_forward_auth !== !!next.via_forward_auth) return true;
+```
+
+- [ ] **Step 4: Add CSS**
+
+In `static/css/app.css`, near the existing `.sidebar-footer` / `.sidebar-user` rules, add:
+
+```css
+.sidebar-id {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    min-width: 0;
+    overflow: hidden;
+}
+.sidebar-auth-pill {
+    flex: none;
+    font-size: var(--font-xs);
+    font-weight: 600;
+    color: var(--color-accent);
+    background: var(--color-accent-subtle);
+    padding: 0.1em 0.5em;
+    border-radius: var(--radius-lg);
+}
+```
+
+- [ ] **Step 5: Rebuild and verify it compiles into the binary**
+
+Run: `cargo build && cargo fmt && cargo clippy -- -D warnings && RDRS_FAST_HASH=1 cargo nextest run`
+Expected: builds (embedded assets refresh), clippy clean, suite green. (The pill itself is verified by Task 2's data assertion plus a manual check; there is no JS unit-test harness — note this in the report.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add static/js/components/rdrs-sidebar.js static/css/app.css
+git commit -m "feat(ui): show SSO pill in sidebar for forward-auth sessions
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: App page — grouped, reordered config table with forward-auth rows
+
+Reorganize the `/settings` Configuration table into 5 labeled groups, reorder columns to Variable · Current · Default · Description, and add the 7 forward-auth rows.
+
+**Files:**
+- Modify: `src/handlers/pages/mod.rs` (`SettingsTemplate` fields + `settings_page` population)
+- Modify: `templates/settings.html`
+- Modify: `static/css/app.css`
+- Test: `tests/pages_test.rs`
+
+**Interfaces:**
+- Consumes: `state.config` forward-auth fields (already exist).
+
+- [ ] **Step 1: Write the failing integration test**
+
+Add to `tests/pages_test.rs` (follow that file's existing harness for an authenticated page GET — register the first user, then GET the page with the saved cookie; mirror an existing `/settings` or authenticated-page test in the file). The server config sets forward-auth values so the Current column reflects them:
+
+```rust
+#[tokio::test]
+async fn test_settings_page_groups_and_forward_auth() {
+    let mut config = default_test_config();
+    config.auth_proxy_header = "Remote-User".to_string();
+    config.trusted_proxy_networks = rdrs::config::parse_trusted_networks("10.0.0.0/8").unwrap();
+    config.auth_proxy_admin_group = "admins".to_string();
+    let server = create_test_server(config);
+
+    server
+        .post("/api/register")
+        .json(&serde_json::json!({ "username": "admin", "password": "password123" }))
+        .await
+        .assert_status(StatusCode::CREATED);
+    server
+        .post("/api/session")
+        .json(&serde_json::json!({ "username": "admin", "password": "password123" }))
+        .await
+        .assert_status_ok();
+
+    let res = server.get("/settings").await;
+    res.assert_status_ok();
+    let body = res.text();
+    // group headers present
+    assert!(body.contains("Authentication &mdash; Forward-Auth") || body.contains("Forward-Auth"));
+    assert!(body.contains("Accounts"));
+    // forward-auth rows present with current values reflected
+    assert!(body.contains("AUTH_PROXY_HEADER"));
+    assert!(body.contains("Remote-User"));
+    assert!(body.contains("AUTH_PROXY_LOGOUT_URL"));
+}
+```
+
+Match `create_test_server` / `default_test_config` / imports to whatever `tests/pages_test.rs` already uses (it has its own server builder). If `pages_test.rs` lacks a cookie-saving server builder, model it on `tests/auth_test.rs::create_test_server` (which uses `.save_cookies()`).
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `RDRS_FAST_HASH=1 cargo nextest run -p rdrs --test pages_test test_settings_page_groups_and_forward_auth`
+Expected: FAIL — forward-auth rows / group headers are not in the template yet.
+
+- [ ] **Step 3: Add forward-auth fields to `SettingsTemplate`**
+
+In `src/handlers/pages/mod.rs`, add to `struct SettingsTemplate` (after `webauthn_rp_name`):
+
+```rust
+    pub auth_proxy_header: String,
+    pub trusted_proxy_networks: String,
+    pub auth_proxy_user_creation: bool,
+    pub auth_proxy_groups_header: String,
+    pub auth_proxy_admin_group: String,
+    pub disable_local_auth: bool,
+    pub auth_proxy_logout_url: String,
+```
+
+- [ ] **Step 4: Populate them in `settings_page`**
+
+In the `settings_page` handler, where `SettingsTemplate { ... }` is constructed, add:
+
+```rust
+        auth_proxy_header: state.config.auth_proxy_header.clone(),
+        trusted_proxy_networks: state
+            .config
+            .trusted_proxy_networks
+            .iter()
+            .map(|n| n.to_string())
+            .collect::<Vec<_>>()
+            .join(", "),
+        auth_proxy_user_creation: state.config.auth_proxy_user_creation,
+        auth_proxy_groups_header: state.config.auth_proxy_groups_header.clone(),
+        auth_proxy_admin_group: state.config.auth_proxy_admin_group.clone(),
+        disable_local_auth: state.config.disable_local_auth,
+        auth_proxy_logout_url: state.config.auth_proxy_logout_url.clone().unwrap_or_default(),
+```
+
+- [ ] **Step 5: Rewrite the Configuration table in `templates/settings.html`**
+
+Replace the `<table class="mobile-cards-settings">…</table>` block with the grouped, reordered table below. Column order is **Variable · Current · Default · Description**; group header rows use `<tr class="grouphdr">`; the Current `<td>`/`<th>` carry class `settings-col-current`. A small macro keeps the "set or muted" rendering consistent:
+
+```html
+{% macro current_text(value) %}{% if value.is_empty() %}<span class="muted">Not set</span>{% else %}<code>{{ value }}</code>{% endif %}{% endmacro %}
+
+<table class="mobile-cards-settings">
+    <thead>
+        <tr>
+            <th class="settings-th">Variable</th>
+            <th class="settings-th settings-col-current">Current</th>
+            <th class="settings-th">Default</th>
+            <th class="settings-th">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr class="grouphdr"><td colspan="4">Server</td></tr>
+        <tr>
+            <td><code>DATABASE_URL</code></td>
+            <td class="settings-col-current" data-label="Current"><code>{{ database_url }}</code></td>
+            <td data-label="Default"><code>rdrs.sqlite3</code></td>
+            <td data-label="Description">SQLite database file path</td>
+        </tr>
+        <tr>
+            <td><code>SERVER_PORT</code></td>
+            <td class="settings-col-current" data-label="Current"><code>{{ server_port }}</code></td>
+            <td data-label="Default"><code>3000</code></td>
+            <td data-label="Description">HTTP server port</td>
+        </tr>
+
+        <tr class="grouphdr"><td colspan="4">Accounts &amp; Registration</td></tr>
+        <tr>
+            <td><code>SIGNUP_ENABLED</code></td>
+            <td class="settings-col-current" data-label="Current">{% if signup_enabled %}<span class="success-text">Yes</span>{% else %}<span class="muted">No</span>{% endif %}</td>
+            <td data-label="Default"><code>false</code></td>
+            <td data-label="Description">Allow new user registration</td>
+        </tr>
+        <tr>
+            <td><code>MULTI_USER_ENABLED</code></td>
+            <td class="settings-col-current" data-label="Current">{% if multi_user_enabled %}<span class="success-text">Yes</span>{% else %}<span class="muted">No</span>{% endif %}</td>
+            <td data-label="Default"><code>false</code></td>
+            <td data-label="Description">Allow multiple users</td>
+        </tr>
+
+        <tr class="grouphdr"><td colspan="4">Authentication &mdash; Passkeys (WebAuthn)</td></tr>
+        <tr>
+            <td><code>WEBAUTHN_RP_ID</code></td>
+            <td class="settings-col-current" data-label="Current"><code data-testid="webauthn-rp-id">{{ webauthn_rp_id }}</code></td>
+            <td data-label="Default"><code>localhost</code></td>
+            <td data-label="Description">Relying Party ID for passkeys</td>
+        </tr>
+        <tr>
+            <td><code>WEBAUTHN_RP_ORIGIN</code></td>
+            <td class="settings-col-current" data-label="Current"><code data-testid="webauthn-rp-origin">{{ webauthn_rp_origin }}</code></td>
+            <td data-label="Default"><code>http://localhost:{port}</code></td>
+            <td data-label="Description">Relying Party origin URL (must match the URL you deploy at)</td>
+        </tr>
+        <tr>
+            <td><code>WEBAUTHN_RP_NAME</code></td>
+            <td class="settings-col-current" data-label="Current"><code data-testid="webauthn-rp-name">{{ webauthn_rp_name }}</code></td>
+            <td data-label="Default"><code>rdrs</code></td>
+            <td data-label="Description">Relying Party display name</td>
+        </tr>
+
+        <tr class="grouphdr"><td colspan="4">Authentication &mdash; Forward-Auth</td></tr>
+        <tr>
+            <td><code>AUTH_PROXY_HEADER</code></td>
+            <td class="settings-col-current" data-label="Current">{% call current_text(auth_proxy_header) %}</td>
+            <td data-label="Default"><em>(unset)</em></td>
+            <td data-label="Description">Username header from the forward-auth proxy</td>
+        </tr>
+        <tr>
+            <td><code>TRUSTED_PROXY_NETWORKS</code></td>
+            <td class="settings-col-current" data-label="Current">{% call current_text(trusted_proxy_networks) %}</td>
+            <td data-label="Default"><em>(unset)</em></td>
+            <td data-label="Description">CIDRs the TCP peer must match</td>
+        </tr>
+        <tr>
+            <td><code>AUTH_PROXY_USER_CREATION</code></td>
+            <td class="settings-col-current" data-label="Current">{% if auth_proxy_user_creation %}<span class="success-text">Yes</span>{% else %}<span class="muted">No</span>{% endif %}</td>
+            <td data-label="Default"><code>false</code></td>
+            <td data-label="Description">JIT-create unknown users</td>
+        </tr>
+        <tr>
+            <td><code>AUTH_PROXY_GROUPS_HEADER</code></td>
+            <td class="settings-col-current" data-label="Current">{% call current_text(auth_proxy_groups_header) %}</td>
+            <td data-label="Default"><em>(unset)</em></td>
+            <td data-label="Description">Groups header from the forward-auth proxy</td>
+        </tr>
+        <tr>
+            <td><code>AUTH_PROXY_ADMIN_GROUP</code></td>
+            <td class="settings-col-current" data-label="Current">{% call current_text(auth_proxy_admin_group) %}</td>
+            <td data-label="Default"><em>(unset)</em></td>
+            <td data-label="Description">Group membership that grants admin</td>
+        </tr>
+        <tr>
+            <td><code>DISABLE_LOCAL_AUTH</code></td>
+            <td class="settings-col-current" data-label="Current">{% if disable_local_auth %}<span class="success-text">Yes</span>{% else %}<span class="muted">No</span>{% endif %}</td>
+            <td data-label="Default"><code>false</code></td>
+            <td data-label="Description">Hide the browser password login form</td>
+        </tr>
+        <tr>
+            <td><code>AUTH_PROXY_LOGOUT_URL</code></td>
+            <td class="settings-col-current" data-label="Current">{% call current_text(auth_proxy_logout_url) %}</td>
+            <td data-label="Default"><em>(unset)</em></td>
+            <td data-label="Description">Sign Out redirects here to end the SSO session</td>
+        </tr>
+
+        <tr class="grouphdr"><td colspan="4">Content &amp; Media</td></tr>
+        <tr>
+            <td><code>USER_AGENT</code></td>
+            <td class="settings-col-current" data-label="Current"><code>{{ user_agent }}</code> <span class="muted">({% if user_agent_is_default %}default{% else %}custom{% endif %})</span></td>
+            <td data-label="Default"><code>RDRS/{version} (...)</code></td>
+            <td data-label="Description">User agent for HTTP requests</td>
+        </tr>
+        <tr>
+            <td><code>IMAGE_PROXY_SECRET</code></td>
+            <td class="settings-col-current" data-label="Current">{% if image_proxy_secret_generated %}<span class="muted">Auto-generated</span>{% else %}<span class="success-text">Configured</span>{% endif %}</td>
+            <td data-label="Default"><em>(auto-generated)</em></td>
+            <td data-label="Description">Secret key for image proxy URLs</td>
+        </tr>
+    </tbody>
+</table>
+```
+
+If Askama rejects the `{% macro %}` placement inside the block, define it via an `{% import %}` of an existing macros file or inline the "Not set" conditional per row instead — keep the rendered output identical.
+
+- [ ] **Step 6: Add CSS for group headers, balanced header padding, and the Current column**
+
+In `static/css/app.css`:
+
+```css
+/* App settings: balanced vertical padding so the header reads even under the tint */
+.settings-th {
+    padding-top: var(--space-2);
+    padding-bottom: var(--space-2);
+}
+/* group label rows in the configuration table */
+.grouphdr td {
+    background: var(--color-accent-subtle);
+    color: var(--color-accent);
+    font-size: var(--font-xs);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    padding: var(--space-2) var(--space-8) var(--space-2) 0;
+}
+/* anchor the eye on the running value; keep its top/bottom spacing even */
+.settings-col-current {
+    background: var(--color-accent-subtle);
+    vertical-align: middle;
+}
+```
+
+Verify the existing responsive `mobile-cards-settings` rules render `.grouphdr` acceptably in card view (the `<td colspan="4">` becomes a block). If it looks wrong, add inside the existing mobile `@media` block:
+
+```css
+    .page-content table.mobile-cards-settings .grouphdr td {
+        display: block;
+        width: 100%;
+    }
+```
+
+- [ ] **Step 7: Rebuild, run the test + full suite**
+
+Run: `cargo build && cargo fmt && RDRS_FAST_HASH=1 cargo nextest run -p rdrs --test pages_test test_settings_page_groups_and_forward_auth && cargo clippy -- -D warnings && RDRS_FAST_HASH=1 cargo nextest run`
+Expected: the new test PASSES (template compiles with the new fields; rows + group headers present); whole suite green.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/handlers/pages/mod.rs templates/settings.html static/css/app.css tests/pages_test.rs
+git commit -m "feat(ui): group App config table and surface forward-auth settings
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Documentation + screenshot check
+
+**Files:**
+- Modify: `ARCHITECTURE.md`
+
+- [ ] **Step 1: Update `ARCHITECTURE.md`**
+
+In the "Forward-Auth (Trusted-Header) Login" section, add a short note (do not re-document the env vars):
+
+> The sidebar shows an **SSO** pill when the current request is served through forward-auth — computed per request from the trusted proxy header (no stored state), surfaced via `via_forward_auth` on the auth extractors and the sidebar payload. The App page (`/settings`) lists the forward-auth configuration under a grouped Configuration table.
+
+- [ ] **Step 2: Confirm screenshots are unaffected**
+
+Run: `cargo build && cd e2e && npm run screenshots && cd .. && git status --short screenshots/`
+Expected: no changes under `screenshots/` — the demo data uses default (local) config, so no SSO pill renders and the sidebar footer is unchanged; `/settings` is not screenshotted. If (unexpectedly) a screenshot changed, investigate before committing; only stage regenerated images if the change is intended.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add ARCHITECTURE.md
+git commit -m "docs: note the sidebar SSO pill and App forward-auth config
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Dynamic detection helper + middleware reuse → Task 1. ✓
+- `via_forward_auth` on `AuthUser`/`PageAuthUser` + `SidebarResponse` + `build_app_layout`/`get_sidebar` → Task 2. ✓
+- Sidebar SSO pill (hugging username, badge style, local = no pill) + rerender trigger → Task 3. ✓
+- App page 5 groups + column order Variable·Current·Default·Description + forward-auth rows + balanced header padding + Current tint/centering + mobile card view → Task 4. ✓
+- Docs note + screenshot confirmation → Task 5. ✓
+- No schema change / no persistence → honored (Task 1/2 compute per request). ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows full code. The two "if Askama/CSS behaves differently" fallbacks name the concrete alternative, not a vague placeholder. ✓
+
+**Type consistency:** `forward_auth_identity(&Config, Option<IpAddr>, &HeaderMap) -> Option<String>`; `via_forward_auth: bool` on `AuthUser`, `PageAuthUser`, `SidebarResponse`; `build_sidebar_response(state, user, session, via_forward_auth)`; JS reads `data.via_forward_auth`; CSS classes `.sidebar-id`, `.sidebar-auth-pill`, `.grouphdr`, `.settings-col-current` used consistently across tasks. ✓
+
+## Notes / risks
+
+- The `forward_auth_identity` test and the via_forward_auth integration test both rely on `tests/forward_auth_test.rs`'s `.http_transport()` server (real loopback `ConnectInfo`). The extractors read `ConnectInfo` from request extensions — present under that transport.
+- `tests/pages_test.rs` may not currently save cookies; if its server builder lacks `.save_cookies()`, add a local builder modeled on `tests/auth_test.rs::create_test_server` rather than weakening the test.
+- Adding `via_forward_auth` to `AuthUser`/`PageAuthUser` only requires updating the two literal constructions in `src/middleware/auth.rs` (no other literal constructions exist in the codebase).

--- a/docs/superpowers/specs/2026-06-25-auth-mode-indicator-design.md
+++ b/docs/superpowers/specs/2026-06-25-auth-mode-indicator-design.md
@@ -1,0 +1,182 @@
+# Auth-Mode Indicator + App Config Grouping — Design
+
+Date: 2026-06-25
+Status: Approved for planning
+
+## Goal
+
+Make it obvious how a user is authenticated and what auth-related configuration
+the instance runs:
+
+1. **Sidebar SSO pill** — when the current session was established via
+   forward-auth, show a small "SSO" pill hugging the username in the sidebar
+   footer. Local (password/passkey) sessions show no pill.
+2. **App page forward-auth config** — the `/settings` ("App") Configuration
+   table lists the forward-auth env vars, and the whole table is reorganized
+   into labeled groups with the columns reordered to **Variable · Current ·
+   Default · Description**.
+
+## Why a schema change is needed
+
+The pill must reflect *how the current session authenticated*. The `session`
+row does not record that today, and it cannot be inferred after the fact. So we
+persist the auth method on the session at creation time.
+
+## Components
+
+### 1. `session.auth_method` (schema migration)
+
+- Add column `auth_method TEXT NOT NULL DEFAULT 'local'` to `session` via a new
+  `PRAGMA user_version` migration in `db/schema.rs`.
+- `Session` struct gains `pub auth_method: String`; `row_to_session` reads it;
+  every `SELECT` of session columns (`find_by_token`, `find_by_id`, any others)
+  includes it.
+- `create_session(conn, user_id)` becomes
+  `create_session(conn, user_id, auth_method: &str)`; the `INSERT` writes the
+  column. Update all four call sites:
+  - `src/middleware/forward_auth.rs` → `"forward_auth"`
+  - `src/handlers/auth.rs` (password login) → `"local"`
+  - `src/handlers/passkey.rs` (passkey) → `"local"`
+  - `src/handlers/greader/auth.rs` (ClientLogin) → `"local"`
+- Values are limited to `"local"` and `"forward_auth"` (distinguishing
+  password vs passkey is out of scope — the UI only needs forward-auth vs not).
+  Masquerade does not call `create_session` (it mutates an existing session), so
+  it is unaffected.
+
+### 2. `SidebarResponse.via_forward_auth` (backend exposure)
+
+- Add `pub via_forward_auth: bool` to `crate::handlers::user::SidebarResponse`
+  (used by BOTH the SSR sidebar bootstrap and the `GET /api/sidebar` endpoint).
+- `build_app_layout` (`handlers/pages/mod.rs`) sets it from the current session:
+  `via_forward_auth: auth_user.session.auth_method == "forward_auth"`.
+- `get_sidebar` (`handlers/user.rs`, the `/api/sidebar` handler) sets the same
+  field from its `AuthUser`'s session, so a live refresh keeps the pill correct.
+- `serialize_sidebar_for_script` serializes the struct as-is, so the bootstrap
+  JSON gains the field automatically.
+
+### 3. Sidebar SSO pill (frontend)
+
+- In `static/js/components/rdrs-sidebar.js`, read `via_forward_auth` from the
+  bootstrap/sidebar data and, when true, render a pill immediately after the
+  username in `.sidebar-footer`:
+
+  ```html
+  <div class="sidebar-footer">
+    <span class="sidebar-id">
+      <span class="sidebar-user">alice</span>
+      <span class="sidebar-auth-pill">SSO</span>   <!-- only when via_forward_auth -->
+    </span>
+    <a ... data-rdrs-logout>Sign Out</a>
+  </div>
+  ```
+
+- The full-rerender trigger (`needsFullRerender`) must treat a change in
+  `via_forward_auth` as requiring a rerender (add it alongside the existing
+  `username` check) so a live `/api/sidebar` update can add/remove the pill.
+- CSS (`static/css/app.css`): `.sidebar-id` is a tight flex row
+  (`display:flex; align-items:center; gap:6px; min-width:0`) so the name can
+  ellipsize and the pill stays put. `.sidebar-auth-pill` reuses the
+  `.sidebar-badge` look — `font-size: var(--font-xs); font-weight: 600;
+  color: var(--color-accent); background: var(--color-accent-subtle);
+  padding: 0.1em 0.5em; border-radius: var(--radius-lg); flex: none;`. Local
+  sessions render no pill (no neutral "Local" pill).
+
+### 4. App page: grouped config table, reordered columns, forward-auth rows
+
+- `SettingsTemplate` (`handlers/pages/mod.rs`) gains the forward-auth config
+  fields, read from `state.config`: `auth_proxy_header: String`,
+  `trusted_proxy_networks: String` (rendered, e.g. comma-joined), 
+  `auth_proxy_user_creation: bool`, `auth_proxy_groups_header: String`,
+  `auth_proxy_admin_group: String`, `disable_local_auth: bool`,
+  `auth_proxy_logout_url: String`. Empty/unset values render as a muted
+  "Not set" / boolean as Yes/No, matching the existing rows' conventions.
+- `templates/settings.html` Configuration table is rewritten:
+  - **Column order:** `Variable · Current · Default · Description` (Current
+    second, next to the name; Description prose last).
+  - **Groups** (a `.grouphdr` row — `<tr class="grouphdr"><td colspan="4">…`):
+    1. **Server** — `DATABASE_URL`, `SERVER_PORT`
+    2. **Accounts & Registration** — `SIGNUP_ENABLED`, `MULTI_USER_ENABLED`
+    3. **Authentication — Passkeys (WebAuthn)** — `WEBAUTHN_RP_ID`,
+       `WEBAUTHN_RP_ORIGIN`, `WEBAUTHN_RP_NAME`
+    4. **Authentication — Forward-Auth** — `AUTH_PROXY_HEADER`,
+       `TRUSTED_PROXY_NETWORKS`, `AUTH_PROXY_USER_CREATION`,
+       `AUTH_PROXY_GROUPS_HEADER`, `AUTH_PROXY_ADMIN_GROUP`,
+       `DISABLE_LOCAL_AUTH`, `AUTH_PROXY_LOGOUT_URL`
+    5. **Content & Media** — `USER_AGENT`, `IMAGE_PROXY_SECRET`
+  - Keep `data-label` attributes on each `<td>` for the responsive
+    `mobile-cards-settings` card view; verify card view still reads sensibly
+    after the reorder (the group header `<tr>` must render acceptably or be
+    hidden in card view).
+- CSS additions (`static/css/app.css`):
+  - `.settings-th` (the header cells) get **symmetric vertical padding** so the
+    header reads balanced (the current rule that yields `0` top padding is the
+    cause of the unbalanced look once a column is tinted).
+  - `.grouphdr td` — accent-tinted, uppercase, small label row.
+  - The Current column gets a faint tint and `vertical-align: middle` so its
+    top/bottom spacing stays even across single- and multi-line rows. (Header
+    + body Current cells share a class, e.g. `.settings-col-current`.)
+
+### 5. Documentation
+
+- `ARCHITECTURE.md` forward-auth section: add ~2 sentences — the sidebar shows
+  an **SSO** pill when the current session authenticated via forward-auth
+  (backed by the new `session.auth_method`), and the App page surfaces the
+  forward-auth configuration. The six/seven env vars are already documented; do
+  not duplicate them.
+
+## Data flow
+
+login/forward-auth/passkey/ClientLogin → `create_session(..., auth_method)` →
+`session.auth_method` persisted → `AuthUser`/`PageAuthUser` carries the session
+→ `build_app_layout` / `get_sidebar` compute `via_forward_auth` →
+bootstrap JSON / `/api/sidebar` → `rdrs-sidebar.js` renders the pill.
+
+## Testing
+
+- **Schema/model:** migration adds the column with default `'local'`;
+  `create_session` persists the passed method; `find_by_token`/`find_by_id`
+  round-trip `auth_method`. An existing-DB row (pre-migration) reads back as
+  `'local'`.
+- **Backend exposure (integration):** a forward-auth login yields a sidebar
+  bootstrap / `/api/sidebar` with `via_forward_auth: true`; a password login
+  yields `false`.
+- **App page (integration):** `GET /settings` contains the four group headers
+  and the seven forward-auth variable names, with the configured "Current"
+  values reflected (e.g. `AUTH_PROXY_HEADER` shows the set header name).
+- **Frontend:** covered by the integration data assertions plus a manual/e2e
+  check that the pill appears only under forward-auth.
+
+## Screenshots
+
+The four README screenshots are the unread list (+ reading pane) and the
+keyboard-help overlay, captured with demo data under default (local) config —
+no forward-auth, so **no SSO pill renders** and the sidebar footer is visually
+unchanged. `/settings` is not screenshotted. Therefore no screenshot
+regeneration is expected; confirm via `cd e2e && npm run screenshots` showing no
+diff, and only commit regenerated images if a diff actually appears.
+
+## Affected files
+
+- `src/db/schema.rs` — migration.
+- `src/models/session.rs` — `Session.auth_method`, `create_session` signature,
+  row mapping, SELECT/INSERT columns; tests.
+- `src/middleware/forward_auth.rs`, `src/handlers/auth.rs`,
+  `src/handlers/passkey.rs`, `src/handlers/greader/auth.rs` — pass the method.
+- `src/handlers/user.rs` — `SidebarResponse.via_forward_auth` + `get_sidebar`.
+- `src/handlers/pages/mod.rs` — `build_app_layout` flag; `SettingsTemplate`
+  forward-auth fields + population.
+- `static/js/components/rdrs-sidebar.js` — pill rendering + rerender trigger.
+- `templates/settings.html` — grouped, reordered table.
+- `static/css/app.css` — `.sidebar-id`, `.sidebar-auth-pill`, `.grouphdr`,
+  Current-column tint + balanced header padding.
+- `ARCHITECTURE.md` — short note.
+- Tests: `tests/auth_test.rs` / `tests/forward_auth_test.rs` / `tests/pages_test.rs`
+  as appropriate; `src/models/session.rs` unit tests.
+
+## Out-of-scope follow-ups
+
+- Distinguishing password vs passkey in `auth_method` (only `local` vs
+  `forward_auth` now).
+- A "Sign-in method" row on the User Settings page (rejected option C).
+- Per-provider pill label from a configured provider name (label is the static
+  "SSO").

--- a/docs/superpowers/specs/2026-06-25-auth-mode-indicator-design.md
+++ b/docs/superpowers/specs/2026-06-25-auth-mode-indicator-design.md
@@ -16,41 +16,73 @@ the instance runs:
    into labeled groups with the columns reordered to **Variable · Current ·
    Default · Description**.
 
-## Why a schema change is needed
+## Why persistence is not needed
 
-The pill must reflect *how the current session authenticated*. The `session`
-row does not record that today, and it cannot be inferred after the fact. So we
-persist the auth method on the session at creation time.
+In a forward-auth deployment the proxy injects the identity header
+(`Remote-User`) on *every* request — the model linkding/Miniflux rely on. So
+whether the current request arrives through forward-auth is decidable at request
+time from the config + the TCP peer + the header, with no stored state. This
+avoids a schema migration entirely and reflects the live state (per request)
+rather than how the session was originally created.
 
 ## Components
 
-### 1. `session.auth_method` (schema migration)
+### 1. Determine forward-auth dynamically (no persistence, no schema change)
 
-- Add column `auth_method TEXT NOT NULL DEFAULT 'local'` to `session` via a new
-  `PRAGMA user_version` migration in `db/schema.rs`.
-- `Session` struct gains `pub auth_method: String`; `row_to_session` reads it;
-  every `SELECT` of session columns (`find_by_token`, `find_by_id`, any others)
-  includes it.
-- `create_session(conn, user_id)` becomes
-  `create_session(conn, user_id, auth_method: &str)`; the `INSERT` writes the
-  column. Update all four call sites:
-  - `src/middleware/forward_auth.rs` → `"forward_auth"`
-  - `src/handlers/auth.rs` (password login) → `"local"`
-  - `src/handlers/passkey.rs` (passkey) → `"local"`
-  - `src/handlers/greader/auth.rs` (ClientLogin) → `"local"`
-- Values are limited to `"local"` and `"forward_auth"` (distinguishing
-  password vs passkey is out of scope — the UI only needs forward-auth vs not).
-  Masquerade does not call `create_session` (it mutates an existing session), so
-  it is unaffected.
+- Add a shared helper in `src/middleware/forward_auth.rs`:
+
+  ```rust
+  /// The identity supplied by a trusted forward-auth proxy on this request, if
+  /// any. `None` when the feature is off, the peer is untrusted/unknown, or the
+  /// header is missing/empty. Shared by the middleware and the auth extractors.
+  pub fn forward_auth_identity(
+      config: &Config,
+      peer_ip: Option<std::net::IpAddr>,
+      headers: &axum::http::HeaderMap,
+  ) -> Option<String> {
+      if !config.auth_proxy_enabled() {
+          return None;
+      }
+      let ip = peer_ip?;
+      if !config.is_trusted_peer(ip) {
+          return None;
+      }
+      headers
+          .get(config.auth_proxy_header.as_str())
+          .and_then(|v| v.to_str().ok())
+          .map(|s| s.trim().to_string())
+          .filter(|s| !s.is_empty())
+  }
+  ```
+
+- The `forward_auth` middleware reuses this helper for its own peer-trust +
+  identity-header extraction (replacing its inline checks) so the logic lives in
+  one place.
+- `AuthUser` and `PageAuthUser` (`src/middleware/auth.rs`) gain a computed field
+  `pub via_forward_auth: bool`, set in their `from_request_parts` from
+  `forward_auth_identity(&state.config, peer_ip, &parts.headers).is_some()`,
+  where `peer_ip` comes from
+  `parts.extensions.get::<ConnectInfo<SocketAddr>>().map(|c| c.0.ip())`.
+- No schema change, no `session` table change, no `create_session` change.
+
+**Semantic note:** this reflects "this request is arriving through forward-auth
+right now," not "the session was created via forward-auth." Under
+`DISABLE_LOCAL_AUTH` (pure SSO) the two coincide. In a mixed deployment a
+password user who is also behind the proxy would show the pill — acceptable,
+since they are in fact being served through the SSO proxy.
 
 ### 2. `SidebarResponse.via_forward_auth` (backend exposure)
 
 - Add `pub via_forward_auth: bool` to `crate::handlers::user::SidebarResponse`
   (used by BOTH the SSR sidebar bootstrap and the `GET /api/sidebar` endpoint).
-- `build_app_layout` (`handlers/pages/mod.rs`) sets it from the current session:
-  `via_forward_auth: auth_user.session.auth_method == "forward_auth"`.
+- `build_app_layout` (`handlers/pages/mod.rs`) sets it from the extractor:
+  `via_forward_auth: auth_user.via_forward_auth` (its `auth_user` is a
+  `PageAuthUser`).
 - `get_sidebar` (`handlers/user.rs`, the `/api/sidebar` handler) sets the same
-  field from its `AuthUser`'s session, so a live refresh keeps the pill correct.
+  field from its `AuthUser`'s computed `via_forward_auth`, so a live refresh
+  keeps the pill correct. The proxy injects the identity header on `/api/sidebar`
+  too (it is in the middleware's SKIP_PREFIXES for auto-login, but the header is
+  still present for the extractor to read).
 - `serialize_sidebar_for_script` serializes the struct as-is, so the bootstrap
   JSON gains the field automatically.
 
@@ -119,24 +151,25 @@ persist the auth method on the session at creation time.
 ### 5. Documentation
 
 - `ARCHITECTURE.md` forward-auth section: add ~2 sentences — the sidebar shows
-  an **SSO** pill when the current session authenticated via forward-auth
-  (backed by the new `session.auth_method`), and the App page surfaces the
+  an **SSO** pill when the current request is served through forward-auth
+  (computed per request, no stored state), and the App page surfaces the
   forward-auth configuration. The six/seven env vars are already documented; do
   not duplicate them.
 
 ## Data flow
 
-login/forward-auth/passkey/ClientLogin → `create_session(..., auth_method)` →
-`session.auth_method` persisted → `AuthUser`/`PageAuthUser` carries the session
-→ `build_app_layout` / `get_sidebar` compute `via_forward_auth` →
-bootstrap JSON / `/api/sidebar` → `rdrs-sidebar.js` renders the pill.
+request arrives (proxy injects `Remote-User` when forward-authed) →
+`AuthUser`/`PageAuthUser` extractor computes `via_forward_auth` via
+`forward_auth_identity` (config + peer IP + header) → `build_app_layout` /
+`get_sidebar` copy it into `SidebarResponse` → bootstrap JSON / `/api/sidebar`
+→ `rdrs-sidebar.js` renders the pill.
 
 ## Testing
 
-- **Schema/model:** migration adds the column with default `'local'`;
-  `create_session` persists the passed method; `find_by_token`/`find_by_id`
-  round-trip `auth_method`. An existing-DB row (pre-migration) reads back as
-  `'local'`.
+- **Helper (unit):** `forward_auth_identity` returns `Some(user)` only when the
+  feature is enabled, the peer IP is trusted, and a non-empty header is present;
+  `None` otherwise (feature off / untrusted peer / missing peer IP / empty
+  header).
 - **Backend exposure (integration):** a forward-auth login yields a sidebar
   bootstrap / `/api/sidebar` with `via_forward_auth: true`; a password login
   yields `false`.
@@ -157,26 +190,28 @@ diff, and only commit regenerated images if a diff actually appears.
 
 ## Affected files
 
-- `src/db/schema.rs` — migration.
-- `src/models/session.rs` — `Session.auth_method`, `create_session` signature,
-  row mapping, SELECT/INSERT columns; tests.
-- `src/middleware/forward_auth.rs`, `src/handlers/auth.rs`,
-  `src/handlers/passkey.rs`, `src/handlers/greader/auth.rs` — pass the method.
-- `src/handlers/user.rs` — `SidebarResponse.via_forward_auth` + `get_sidebar`.
-- `src/handlers/pages/mod.rs` — `build_app_layout` flag; `SettingsTemplate`
-  forward-auth fields + population.
+- `src/middleware/forward_auth.rs` — `forward_auth_identity` helper; middleware
+  reuses it.
+- `src/middleware/auth.rs` — `AuthUser`/`PageAuthUser` gain computed
+  `via_forward_auth`.
+- `src/handlers/user.rs` — `SidebarResponse.via_forward_auth` + `get_sidebar`
+  populates it.
+- `src/handlers/pages/mod.rs` — `build_app_layout` copies the flag;
+  `SettingsTemplate` forward-auth fields + population.
 - `static/js/components/rdrs-sidebar.js` — pill rendering + rerender trigger.
 - `templates/settings.html` — grouped, reordered table.
 - `static/css/app.css` — `.sidebar-id`, `.sidebar-auth-pill`, `.grouphdr`,
   Current-column tint + balanced header padding.
 - `ARCHITECTURE.md` — short note.
-- Tests: `tests/auth_test.rs` / `tests/forward_auth_test.rs` / `tests/pages_test.rs`
-  as appropriate; `src/models/session.rs` unit tests.
+- Tests: `forward_auth.rs` unit tests for `forward_auth_identity`;
+  `tests/forward_auth_test.rs` / `tests/auth_test.rs` / `tests/pages_test.rs` as
+  appropriate for the integration assertions.
 
 ## Out-of-scope follow-ups
 
-- Distinguishing password vs passkey in `auth_method` (only `local` vs
-  `forward_auth` now).
+- Distinguishing password vs passkey (the indicator is forward-auth vs not).
+- Persisting the auth method on the session (decided against — computed
+  dynamically per request).
 - A "Sign-in method" row on the User Settings page (rejected option C).
 - Per-provider pill label from a configured provider name (label is the static
   "SSO").

--- a/src/handlers/pages/mod.rs
+++ b/src/handlers/pages/mod.rs
@@ -662,7 +662,7 @@ pub async fn admin_page(
     let auth_user = PageAuthUser {
         user: admin.user.clone(),
         session: admin.session.clone(),
-        via_forward_auth: false,
+        via_forward_auth: admin.via_forward_auth,
     };
     let layout = build_app_layout(&state, &auth_user, &flash).await;
 

--- a/src/handlers/pages/mod.rs
+++ b/src/handlers/pages/mod.rs
@@ -662,6 +662,7 @@ pub async fn admin_page(
     let auth_user = PageAuthUser {
         user: admin.user.clone(),
         session: admin.session.clone(),
+        via_forward_auth: false,
     };
     let layout = build_app_layout(&state, &auth_user, &flash).await;
 
@@ -2031,6 +2032,7 @@ pub async fn build_app_layout(
         categories: chrome.categories,
         total_unread: chrome.total_unread,
         total_summarized: chrome.total_summarized,
+        via_forward_auth: auth_user.via_forward_auth,
     };
     let sidebar_bootstrap_json = serialize_sidebar_for_script(&sidebar);
     let flash_bootstrap_json = flash_bootstrap_json(&flash.messages);

--- a/src/handlers/pages/mod.rs
+++ b/src/handlers/pages/mod.rs
@@ -1233,6 +1233,23 @@ pub async fn settings_page(
             webauthn_rp_id: state.config.webauthn_rp_id.clone(),
             webauthn_rp_origin: state.config.webauthn_rp_origin.clone(),
             webauthn_rp_name: state.config.webauthn_rp_name.clone(),
+            auth_proxy_header: state.config.auth_proxy_header.clone(),
+            trusted_proxy_networks: state
+                .config
+                .trusted_proxy_networks
+                .iter()
+                .map(|n| n.to_string())
+                .collect::<Vec<_>>()
+                .join(", "),
+            auth_proxy_user_creation: state.config.auth_proxy_user_creation,
+            auth_proxy_groups_header: state.config.auth_proxy_groups_header.clone(),
+            auth_proxy_admin_group: state.config.auth_proxy_admin_group.clone(),
+            disable_local_auth: state.config.disable_local_auth,
+            auth_proxy_logout_url: state
+                .config
+                .auth_proxy_logout_url
+                .clone()
+                .unwrap_or_default(),
         },
     )
 }
@@ -2069,6 +2086,13 @@ pub struct SettingsTemplate {
     pub webauthn_rp_id: String,
     pub webauthn_rp_origin: String,
     pub webauthn_rp_name: String,
+    pub auth_proxy_header: String,
+    pub trusted_proxy_networks: String,
+    pub auth_proxy_user_creation: bool,
+    pub auth_proxy_groups_header: String,
+    pub auth_proxy_admin_group: String,
+    pub disable_local_auth: bool,
+    pub auth_proxy_logout_url: String,
 }
 
 impl IntoResponse for SettingsTemplate {

--- a/src/handlers/user.rs
+++ b/src/handlers/user.rs
@@ -135,6 +135,7 @@ pub struct SidebarResponse {
     pub categories: Vec<SidebarCategoryDto>,
     pub total_unread: i64,
     pub total_summarized: i64,
+    pub via_forward_auth: bool,
 }
 
 /// Raw chrome data needed for every authenticated page render: theme,
@@ -253,6 +254,7 @@ pub async fn build_sidebar_response(
     state: &AppState,
     user: &crate::models::User,
     session: &crate::models::session::Session,
+    via_forward_auth: bool,
 ) -> AppResult<SidebarResponse> {
     let is_masquerading = session.is_masquerading();
     let chrome = read_chrome_data(
@@ -279,6 +281,7 @@ pub async fn build_sidebar_response(
         categories: chrome.categories,
         total_unread: chrome.total_unread,
         total_summarized: chrome.total_summarized,
+        via_forward_auth,
     })
 }
 
@@ -288,7 +291,13 @@ pub async fn get_sidebar(
     State(state): State<AppState>,
     auth_user: AuthUser,
 ) -> AppResult<Json<SidebarResponse>> {
-    let payload = build_sidebar_response(&state, &auth_user.user, &auth_user.session).await?;
+    let payload = build_sidebar_response(
+        &state,
+        &auth_user.user,
+        &auth_user.session,
+        auth_user.via_forward_auth,
+    )
+    .await?;
     Ok(Json(payload))
 }
 

--- a/src/middleware/auth.rs
+++ b/src/middleware/auth.rs
@@ -1,5 +1,7 @@
+use std::net::SocketAddr;
+
 use axum::{
-    extract::{FromRequestParts, OptionalFromRequestParts},
+    extract::{ConnectInfo, FromRequestParts, OptionalFromRequestParts},
     http::request::Parts,
     response::{IntoResponse, Response},
 };
@@ -17,6 +19,7 @@ pub const SESSION_COOKIE_NAME: &str = "session_token";
 pub struct AuthUser {
     pub user: User,
     pub session: Session,
+    pub via_forward_auth: bool,
 }
 
 impl FromRequestParts<AppState> for AuthUser {
@@ -66,7 +69,22 @@ impl FromRequestParts<AppState> for AuthUser {
             return Err(AppError::UserDisabled);
         }
 
-        Ok(AuthUser { user, session })
+        let peer_ip = parts
+            .extensions
+            .get::<ConnectInfo<SocketAddr>>()
+            .map(|c| c.0.ip());
+        let via_forward_auth = crate::middleware::forward_auth::forward_auth_identity(
+            &state.config,
+            peer_ip,
+            &parts.headers,
+        )
+        .is_some();
+
+        Ok(AuthUser {
+            user,
+            session,
+            via_forward_auth,
+        })
     }
 }
 
@@ -75,6 +93,7 @@ impl FromRequestParts<AppState> for AuthUser {
 pub struct PageAuthUser {
     pub user: User,
     pub session: Session,
+    pub via_forward_auth: bool,
 }
 
 /// Redirect response for unauthorized page access
@@ -129,7 +148,22 @@ impl FromRequestParts<AppState> for PageAuthUser {
 
         let (user, session) = result.map_err(|_| LoginRedirect)?;
 
-        Ok(PageAuthUser { user, session })
+        let peer_ip = parts
+            .extensions
+            .get::<ConnectInfo<SocketAddr>>()
+            .map(|c| c.0.ip());
+        let via_forward_auth = crate::middleware::forward_auth::forward_auth_identity(
+            &state.config,
+            peer_ip,
+            &parts.headers,
+        )
+        .is_some();
+
+        Ok(PageAuthUser {
+            user,
+            session,
+            via_forward_auth,
+        })
     }
 }
 

--- a/src/middleware/auth.rs
+++ b/src/middleware/auth.rs
@@ -226,6 +226,7 @@ impl FromRequestParts<AppState> for AdminUser {
 pub struct PageAdminUser {
     pub user: User,
     pub session: Session,
+    pub via_forward_auth: bool,
 }
 
 impl FromRequestParts<AppState> for PageAdminUser {
@@ -263,6 +264,7 @@ impl FromRequestParts<AppState> for PageAdminUser {
         Ok(PageAdminUser {
             user: page_auth_user.user,
             session: page_auth_user.session,
+            via_forward_auth: page_auth_user.via_forward_auth,
         })
     }
 }

--- a/src/middleware/forward_auth.rs
+++ b/src/middleware/forward_auth.rs
@@ -1,13 +1,15 @@
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 
 use axum::{
     extract::{ConnectInfo, Request, State},
+    http::HeaderMap,
     middleware::Next,
     response::{IntoResponse, Redirect, Response},
 };
 use axum_extra::extract::cookie::{Cookie, CookieJar, SameSite};
 use time::Duration;
 
+use crate::config::Config;
 use crate::error::AppError;
 use crate::middleware::{FlashRedirect, SESSION_COOKIE_NAME};
 use crate::models::user::{self, Role};
@@ -43,6 +45,30 @@ pub fn role_from_groups(groups: &[String], admin_group: &str) -> Role {
     } else {
         Role::User
     }
+}
+
+/// The identity supplied by a trusted forward-auth proxy on this request, if
+/// any. Returns `None` when the feature is off, the peer IP is missing or not
+/// in `TRUSTED_PROXY_NETWORKS`, or the identity header is absent/empty. Shared
+/// by the middleware and the `AuthUser`/`PageAuthUser` extractors so the
+/// trust logic lives in one place.
+pub fn forward_auth_identity(
+    config: &Config,
+    peer_ip: Option<IpAddr>,
+    headers: &HeaderMap,
+) -> Option<String> {
+    if !config.auth_proxy_enabled() {
+        return None;
+    }
+    let ip = peer_ip?;
+    if !config.is_trusted_peer(ip) {
+        return None;
+    }
+    headers
+        .get(config.auth_proxy_header.as_str())
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
 }
 
 pub async fn forward_auth(
@@ -89,26 +115,12 @@ pub async fn forward_auth(
         }
     }
 
-    // Fail closed: without a known peer IP we cannot trust the header.
-    let Some(peer_ip) = req
+    // Trusted-peer + identity-header check (shared with the auth extractors).
+    let peer_ip = req
         .extensions()
         .get::<ConnectInfo<SocketAddr>>()
-        .map(|c| c.0.ip())
-    else {
-        return next.run(req).await;
-    };
-    if !config.is_trusted_peer(peer_ip) {
-        return next.run(req).await;
-    }
-
-    // Read the identity header.
-    let Some(username) = req
-        .headers()
-        .get(config.auth_proxy_header.as_str())
-        .and_then(|v| v.to_str().ok())
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-    else {
+        .map(|c| c.0.ip());
+    let Some(username) = forward_auth_identity(config, peer_ip, req.headers()) else {
         return next.run(req).await;
     };
 

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -1017,12 +1017,31 @@ td input[type="text"] {
 .settings-th {
     text-align: left;
     padding-right: var(--space-8);
+    padding-top: var(--space-2);
+    padding-bottom: var(--space-2);
     width: 200px;
     font-weight: 600;
     color: var(--color-text-secondary);
     text-transform: none;
     letter-spacing: normal;
     font-size: var(--font-sm);
+}
+
+/* group label rows in the configuration table */
+.grouphdr td {
+    background: var(--color-accent-subtle);
+    color: var(--color-accent);
+    font-size: var(--font-xs);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    padding: var(--space-2) var(--space-8) var(--space-2) 0;
+}
+
+/* anchor the eye on the running value; keep its top/bottom spacing even */
+.settings-col-current {
+    background: var(--color-accent-subtle);
+    vertical-align: middle;
 }
 
 /* ===== Banner Stack (accessible flash messages) =====
@@ -2323,6 +2342,11 @@ summary {
         width: auto;
         min-width: 100px;
         padding-right: var(--space-3);
+    }
+
+    .page-content table.mobile-cards-settings .grouphdr td {
+        display: block;
+        width: 100%;
     }
 
     /* Stack action links */

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -331,6 +331,24 @@ code {
     white-space: nowrap;
 }
 
+.sidebar-id {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    min-width: 0;
+    overflow: hidden;
+}
+
+.sidebar-auth-pill {
+    flex: none;
+    font-size: var(--font-xs);
+    font-weight: 600;
+    color: var(--color-accent);
+    background: var(--color-accent-subtle);
+    padding: 0.1em 0.5em;
+    border-radius: var(--radius-lg);
+}
+
 .sidebar-footer a {
     color: var(--color-text-muted);
     font-size: var(--font-xs);

--- a/static/js/components/rdrs-sidebar.js
+++ b/static/js/components/rdrs-sidebar.js
@@ -70,6 +70,7 @@ function isStructuralChange(prev, next) {
     if (prev.username !== next.username) return true;
     if (!!prev.is_admin !== !!next.is_admin) return true;
     if (!!prev.is_masquerading !== !!next.is_masquerading) return true;
+    if (!!prev.via_forward_auth !== !!next.via_forward_auth) return true;
     const key = (cats) => (cats || []).map((c) => `${c.id}:${c.name}`).join('|');
     return key(prev.categories) !== key(next.categories);
 }
@@ -154,6 +155,7 @@ class RdrsSidebar extends HTMLElement {
         const username = data ? data.username : '';
         const isAdmin = data ? !!data.is_admin : false;
         const isMasq = data ? !!data.is_masquerading : false;
+        const viaForwardAuth = data ? !!data.via_forward_auth : false;
         const cats = data ? data.categories : [];
         const totalUnread = data ? data.total_unread : 0;
         const totalSummarized = data ? data.total_summarized : 0;
@@ -246,7 +248,10 @@ class RdrsSidebar extends HTMLElement {
         </div>
     </nav>
     <div class="sidebar-footer">
-        <span class="sidebar-user">${escapeHtml(username)}</span>
+        <span class="sidebar-id">
+            <span class="sidebar-user">${escapeHtml(username)}</span>
+            ${viaForwardAuth ? '<span class="sidebar-auth-pill" data-testid="auth-pill">SSO</span>' : ''}
+        </span>
         <a href="#" data-testid="logout-btn" data-rdrs-logout>Sign Out</a>
     </div>
 </aside>`;

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -1,4 +1,5 @@
 {%- import "_icons.html" as icons -%}
+{% macro current_text(value) %}{% if value.is_empty() %}<span class="muted">Not set</span>{% else %}<code>{{ value }}</code>{% endif %}{% endmacro %}
 {% macro flash(messages) %}
 {% if !messages.is_empty() %}
 <div class="banner-stack" role="region" aria-label="Notifications" tabindex="-1">

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -1,4 +1,5 @@
 {% extends "app_layout.html" %}
+{% import "macros.html" as macros %}
 
 {% block page %}
     <div class="app-layout">
@@ -16,68 +17,116 @@
                         <thead>
                             <tr>
                                 <th class="settings-th">Variable</th>
-                                <th class="settings-th">Description</th>
+                                <th class="settings-th settings-col-current">Current</th>
                                 <th class="settings-th">Default</th>
-                                <th class="settings-th">Current</th>
+                                <th class="settings-th">Description</th>
                             </tr>
                         </thead>
                         <tbody>
+                            <tr class="grouphdr"><td colspan="4">Server</td></tr>
                             <tr>
                                 <td><code>DATABASE_URL</code></td>
-                                <td data-label="Description">SQLite database file path</td>
+                                <td class="settings-col-current" data-label="Current"><code>{{ database_url }}</code></td>
                                 <td data-label="Default"><code>rdrs.sqlite3</code></td>
-                                <td data-label="Current"><code>{{ database_url }}</code></td>
+                                <td data-label="Description">SQLite database file path</td>
                             </tr>
                             <tr>
                                 <td><code>SERVER_PORT</code></td>
-                                <td data-label="Description">HTTP server port</td>
+                                <td class="settings-col-current" data-label="Current"><code>{{ server_port }}</code></td>
                                 <td data-label="Default"><code>3000</code></td>
-                                <td data-label="Current"><code>{{ server_port }}</code></td>
+                                <td data-label="Description">HTTP server port</td>
                             </tr>
-                            <tr>
-                                <td><code>USER_AGENT</code></td>
-                                <td data-label="Description">User agent for HTTP requests</td>
-                                <td data-label="Default"><code>RDRS/{version} (...)</code></td>
-                                <td data-label="Current">
-                                    <code>{{ user_agent }}</code>
-                                    <span class="muted">({% if user_agent_is_default %}default{% else %}custom{% endif %})</span>
-                                </td>
-                            </tr>
+
+                            <tr class="grouphdr"><td colspan="4">Accounts &amp; Registration</td></tr>
                             <tr>
                                 <td><code>SIGNUP_ENABLED</code></td>
-                                <td data-label="Description">Allow new user registration</td>
+                                <td class="settings-col-current" data-label="Current">{% if signup_enabled %}<span class="success-text">Yes</span>{% else %}<span class="muted">No</span>{% endif %}</td>
                                 <td data-label="Default"><code>false</code></td>
-                                <td data-label="Current">{% if signup_enabled %}<span class="success-text">Yes</span>{% else %}<span class="muted">No</span>{% endif %}</td>
+                                <td data-label="Description">Allow new user registration</td>
                             </tr>
                             <tr>
                                 <td><code>MULTI_USER_ENABLED</code></td>
-                                <td data-label="Description">Allow multiple users</td>
+                                <td class="settings-col-current" data-label="Current">{% if multi_user_enabled %}<span class="success-text">Yes</span>{% else %}<span class="muted">No</span>{% endif %}</td>
                                 <td data-label="Default"><code>false</code></td>
-                                <td data-label="Current">{% if multi_user_enabled %}<span class="success-text">Yes</span>{% else %}<span class="muted">No</span>{% endif %}</td>
+                                <td data-label="Description">Allow multiple users</td>
                             </tr>
-                            <tr>
-                                <td><code>IMAGE_PROXY_SECRET</code></td>
-                                <td data-label="Description">Secret key for image proxy URLs</td>
-                                <td data-label="Default"><em>(auto-generated)</em></td>
-                                <td data-label="Current">{% if image_proxy_secret_generated %}<span class="muted">Auto-generated</span>{% else %}<span class="success-text">Configured</span>{% endif %}</td>
-                            </tr>
+
+                            <tr class="grouphdr"><td colspan="4">Authentication &mdash; Passkeys (WebAuthn)</td></tr>
                             <tr>
                                 <td><code>WEBAUTHN_RP_ID</code></td>
-                                <td data-label="Description">WebAuthn Relying Party ID for passkeys</td>
+                                <td class="settings-col-current" data-label="Current"><code data-testid="webauthn-rp-id">{{ webauthn_rp_id }}</code></td>
                                 <td data-label="Default"><code>localhost</code></td>
-                                <td data-label="Current"><code data-testid="webauthn-rp-id">{{ webauthn_rp_id }}</code></td>
+                                <td data-label="Description">Relying Party ID for passkeys</td>
                             </tr>
                             <tr>
                                 <td><code>WEBAUTHN_RP_ORIGIN</code></td>
-                                <td data-label="Description">WebAuthn Relying Party origin URL (must match the URL you deploy at)</td>
+                                <td class="settings-col-current" data-label="Current"><code data-testid="webauthn-rp-origin">{{ webauthn_rp_origin }}</code></td>
                                 <td data-label="Default"><code>http://localhost:{port}</code></td>
-                                <td data-label="Current"><code data-testid="webauthn-rp-origin">{{ webauthn_rp_origin }}</code></td>
+                                <td data-label="Description">Relying Party origin URL (must match the URL you deploy at)</td>
                             </tr>
                             <tr>
                                 <td><code>WEBAUTHN_RP_NAME</code></td>
-                                <td data-label="Description">WebAuthn Relying Party display name</td>
+                                <td class="settings-col-current" data-label="Current"><code data-testid="webauthn-rp-name">{{ webauthn_rp_name }}</code></td>
                                 <td data-label="Default"><code>rdrs</code></td>
-                                <td data-label="Current"><code data-testid="webauthn-rp-name">{{ webauthn_rp_name }}</code></td>
+                                <td data-label="Description">Relying Party display name</td>
+                            </tr>
+
+                            <tr class="grouphdr"><td colspan="4">Authentication &mdash; Forward-Auth</td></tr>
+                            <tr>
+                                <td><code>AUTH_PROXY_HEADER</code></td>
+                                <td class="settings-col-current" data-label="Current">{% call macros::current_text(auth_proxy_header) %}{% endcall %}</td>
+                                <td data-label="Default"><em>(unset)</em></td>
+                                <td data-label="Description">Username header from the forward-auth proxy</td>
+                            </tr>
+                            <tr>
+                                <td><code>TRUSTED_PROXY_NETWORKS</code></td>
+                                <td class="settings-col-current" data-label="Current">{% call macros::current_text(trusted_proxy_networks) %}{% endcall %}</td>
+                                <td data-label="Default"><em>(unset)</em></td>
+                                <td data-label="Description">CIDRs the TCP peer must match</td>
+                            </tr>
+                            <tr>
+                                <td><code>AUTH_PROXY_USER_CREATION</code></td>
+                                <td class="settings-col-current" data-label="Current">{% if auth_proxy_user_creation %}<span class="success-text">Yes</span>{% else %}<span class="muted">No</span>{% endif %}</td>
+                                <td data-label="Default"><code>false</code></td>
+                                <td data-label="Description">JIT-create unknown users</td>
+                            </tr>
+                            <tr>
+                                <td><code>AUTH_PROXY_GROUPS_HEADER</code></td>
+                                <td class="settings-col-current" data-label="Current">{% call macros::current_text(auth_proxy_groups_header) %}{% endcall %}</td>
+                                <td data-label="Default"><em>(unset)</em></td>
+                                <td data-label="Description">Groups header from the forward-auth proxy</td>
+                            </tr>
+                            <tr>
+                                <td><code>AUTH_PROXY_ADMIN_GROUP</code></td>
+                                <td class="settings-col-current" data-label="Current">{% call macros::current_text(auth_proxy_admin_group) %}{% endcall %}</td>
+                                <td data-label="Default"><em>(unset)</em></td>
+                                <td data-label="Description">Group membership that grants admin</td>
+                            </tr>
+                            <tr>
+                                <td><code>DISABLE_LOCAL_AUTH</code></td>
+                                <td class="settings-col-current" data-label="Current">{% if disable_local_auth %}<span class="success-text">Yes</span>{% else %}<span class="muted">No</span>{% endif %}</td>
+                                <td data-label="Default"><code>false</code></td>
+                                <td data-label="Description">Hide the browser password login form</td>
+                            </tr>
+                            <tr>
+                                <td><code>AUTH_PROXY_LOGOUT_URL</code></td>
+                                <td class="settings-col-current" data-label="Current">{% call macros::current_text(auth_proxy_logout_url) %}{% endcall %}</td>
+                                <td data-label="Default"><em>(unset)</em></td>
+                                <td data-label="Description">Sign Out redirects here to end the SSO session</td>
+                            </tr>
+
+                            <tr class="grouphdr"><td colspan="4">Content &amp; Media</td></tr>
+                            <tr>
+                                <td><code>USER_AGENT</code></td>
+                                <td class="settings-col-current" data-label="Current"><code>{{ user_agent }}</code> <span class="muted">({% if user_agent_is_default %}default{% else %}custom{% endif %})</span></td>
+                                <td data-label="Default"><code>RDRS/{version} (...)</code></td>
+                                <td data-label="Description">User agent for HTTP requests</td>
+                            </tr>
+                            <tr>
+                                <td><code>IMAGE_PROXY_SECRET</code></td>
+                                <td class="settings-col-current" data-label="Current">{% if image_proxy_secret_generated %}<span class="muted">Auto-generated</span>{% else %}<span class="success-text">Configured</span>{% endif %}</td>
+                                <td data-label="Default"><em>(auto-generated)</em></td>
+                                <td data-label="Description">Secret key for image proxy URLs</td>
                             </tr>
                         </tbody>
                     </table>

--- a/tests/forward_auth_test.rs
+++ b/tests/forward_auth_test.rs
@@ -284,6 +284,39 @@ async fn test_sidebar_reports_via_forward_auth_dynamically() {
 }
 
 #[tokio::test]
+async fn test_admin_page_sidebar_bootstrap_reports_via_forward_auth() {
+    let db_name = "fa_test_admin_sidebar_bootstrap";
+    let server = create_server(db_name, |c| {
+        c.trusted_proxy_networks = parse_trusted_networks("127.0.0.0/8").unwrap();
+    });
+    seed_user(db_name, "heidi", rdrs::models::user::Role::Admin);
+
+    // Establish session via forward-auth; include the admin group so the role
+    // is not demoted (create_server sets group_mapping_enabled with "admins").
+    server
+        .get("/")
+        .add_header("Remote-User", "heidi")
+        .add_header("Remote-Groups", "admins")
+        .await;
+
+    // Fetch /admin with the proxy header present.
+    let res = server
+        .get("/admin")
+        .add_header("Remote-User", "heidi")
+        .add_header("Remote-Groups", "admins")
+        .await;
+    res.assert_status_ok();
+
+    // The embedded rdrs-sidebar-bootstrap JSON must reflect via_forward_auth: true.
+    let body = res.text();
+    assert!(
+        body.contains("\"via_forward_auth\":true"),
+        "expected via_forward_auth:true in sidebar bootstrap JSON, got body snippet: {:?}",
+        body.get(0..500).unwrap_or(&body)
+    );
+}
+
+#[tokio::test]
 async fn test_valid_session_cookie_not_reminted() {
     let db_name = "fa_test_valid_cookie_not_reminted";
     let server = create_server(db_name, |c| {

--- a/tests/forward_auth_test.rs
+++ b/tests/forward_auth_test.rs
@@ -256,6 +256,34 @@ async fn test_invalid_session_cookie_still_forward_auths() {
 }
 
 #[tokio::test]
+async fn test_sidebar_reports_via_forward_auth_dynamically() {
+    let db_name = "fa_test_sidebar_via_forward_auth";
+    let server = create_server(db_name, |c| {
+        c.trusted_proxy_networks = parse_trusted_networks("127.0.0.0/8").unwrap();
+    });
+    seed_user(db_name, "grace", rdrs::models::user::Role::User);
+
+    // Establish a session via forward-auth (page route mints the cookie).
+    server.get("/").add_header("Remote-User", "grace").await;
+
+    // With the proxy header present → via_forward_auth true.
+    let with = server
+        .get("/api/sidebar")
+        .add_header("Remote-User", "grace")
+        .await;
+    with.assert_status_ok();
+    assert_eq!(with.json::<serde_json::Value>()["via_forward_auth"], true);
+
+    // Same valid session, but no proxy header on this request → false (dynamic).
+    let without = server.get("/api/sidebar").await;
+    without.assert_status_ok();
+    assert_eq!(
+        without.json::<serde_json::Value>()["via_forward_auth"],
+        false
+    );
+}
+
+#[tokio::test]
 async fn test_valid_session_cookie_not_reminted() {
     let db_name = "fa_test_valid_cookie_not_reminted";
     let server = create_server(db_name, |c| {

--- a/tests/forward_auth_test.rs
+++ b/tests/forward_auth_test.rs
@@ -4,11 +4,66 @@ use common::default_test_config;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
+use axum::http::{HeaderMap, HeaderName};
 use axum_test::TestServer;
 use rdrs::{
-    auth, config::parse_trusted_networks, create_router, db, services, AppState, Config, DbPool,
+    auth, config::parse_trusted_networks, create_router, db,
+    middleware::forward_auth::forward_auth_identity, services, AppState, Config, DbPool,
 };
 use rusqlite::Connection;
+
+fn header_map(pairs: &[(&str, &str)]) -> HeaderMap {
+    let mut h = HeaderMap::new();
+    for (k, v) in pairs {
+        h.insert(
+            HeaderName::from_bytes(k.as_bytes()).unwrap(),
+            v.parse().unwrap(),
+        );
+    }
+    h
+}
+
+#[test]
+fn test_forward_auth_identity() {
+    let mut cfg = default_test_config();
+    cfg.auth_proxy_header = "Remote-User".to_string();
+    cfg.trusted_proxy_networks = parse_trusted_networks("10.0.0.0/8").unwrap();
+
+    let trusted: std::net::IpAddr = "10.1.2.3".parse().unwrap();
+    let untrusted: std::net::IpAddr = "192.168.0.1".parse().unwrap();
+    let with_header = header_map(&[("Remote-User", "alice")]);
+
+    // trusted peer + header present → identity
+    assert_eq!(
+        forward_auth_identity(&cfg, Some(trusted), &with_header),
+        Some("alice".to_string())
+    );
+    // untrusted peer → None
+    assert_eq!(
+        forward_auth_identity(&cfg, Some(untrusted), &with_header),
+        None
+    );
+    // no peer IP → None
+    assert_eq!(forward_auth_identity(&cfg, None, &with_header), None);
+    // header missing → None
+    assert_eq!(
+        forward_auth_identity(&cfg, Some(trusted), &HeaderMap::new()),
+        None
+    );
+    // header empty → None
+    assert_eq!(
+        forward_auth_identity(&cfg, Some(trusted), &header_map(&[("Remote-User", "  ")])),
+        None
+    );
+
+    // feature off (empty header name) → None
+    let mut off = cfg.clone();
+    off.auth_proxy_header = String::new();
+    assert_eq!(
+        forward_auth_identity(&off, Some(trusted), &with_header),
+        None
+    );
+}
 
 fn open_shared_memory(name: &str) -> Connection {
     let uri = format!("file:{}?mode=memory&cache=shared", name);

--- a/tests/pages_test.rs
+++ b/tests/pages_test.rs
@@ -2883,3 +2883,46 @@ fn extract_after_value(html: &str) -> Option<String> {
     let j = rest.find('"')?;
     Some(rest[..j].to_string())
 }
+
+#[tokio::test]
+async fn test_settings_page_groups_and_forward_auth() {
+    let mut config = default_test_config();
+    config.auth_proxy_header = "Remote-User".to_string();
+    config.trusted_proxy_networks = rdrs::config::parse_trusted_networks("10.0.0.0/8").unwrap();
+    config.auth_proxy_admin_group = "admins".to_string();
+    let app = create_test_app_named(config, "test_settings_groups_fa");
+
+    app.server
+        .post("/api/register")
+        .json(&serde_json::json!({ "username": "admin", "password": "password123" }))
+        .await
+        .assert_status(StatusCode::CREATED);
+    app.server
+        .post("/api/session")
+        .json(&serde_json::json!({ "username": "admin", "password": "password123" }))
+        .await
+        .assert_status_ok();
+
+    let res = app.server.get("/settings").await;
+    res.assert_status_ok();
+    let body = res.text();
+    // group headers present
+    assert!(
+        body.contains("Authentication") && body.contains("Forward-Auth"),
+        "expected 'Authentication' and 'Forward-Auth' in body"
+    );
+    assert!(body.contains("Accounts"), "expected 'Accounts' in body");
+    // forward-auth rows present with current values reflected
+    assert!(
+        body.contains("AUTH_PROXY_HEADER"),
+        "expected AUTH_PROXY_HEADER in body"
+    );
+    assert!(
+        body.contains("Remote-User"),
+        "expected 'Remote-User' in body"
+    );
+    assert!(
+        body.contains("AUTH_PROXY_LOGOUT_URL"),
+        "expected AUTH_PROXY_LOGOUT_URL in body"
+    );
+}


### PR DESCRIPTION
## Summary

Surfaces how a user is authenticated and what auth-related configuration the instance runs:

1. **Sidebar SSO pill** — when the current request is served through forward-auth, a small `SSO` pill appears next to the username in the sidebar footer. Local (password/passkey) sessions show no pill.
2. **App page forward-auth config** — the `/settings` ("App") Configuration table is reorganized into labeled groups, with columns reordered to **Variable · Current · Default · Description**, and now lists the forward-auth env vars.

## How the pill is determined

Forward-auth state is computed **dynamically per request** — no persistence, no schema change. A forward-auth proxy injects the identity header on every request (the model linkding/Miniflux rely on), so a shared `forward_auth_identity(config, peer_ip, headers)` helper decides it from: feature enabled + the **TCP peer IP** (`ConnectInfo`) in `TRUSTED_PROXY_NETWORKS` + a non-empty identity header. The flag is exposed as `via_forward_auth` on the `AuthUser`/`PageAuthUser`/`PageAdminUser` extractors, carried through `SidebarResponse` to both the SSR bootstrap and `GET /api/sidebar`, and rendered by the sidebar web component (a live `/api/sidebar` refresh adds/removes it).

Semantics: the pill reflects "this request is via forward-auth." Under `DISABLE_LOCAL_AUTH` (pure SSO) this coincides with the session origin; in a mixed deployment a password user behind the proxy would show the pill — acceptable, since they are in fact served through the SSO proxy.

## Security

- `via_forward_auth` is gated by the trusted-peer check (real TCP `ConnectInfo`, not a spoofable header) and is **fail-closed** (empty trusted-network list → false). A direct client sending `Remote-User` from an untrusted source gets `false`.
- The pill is **purely cosmetic** — it grants no privilege; role/admin determination is unchanged.
- Pill label is a static literal; the username stays HTML-escaped. The App-page values shown (header names, CIDRs, group names, logout URL) are non-secret, consistent with the existing `WEBAUTHN_RP_*` rows.

## App page table

Reordered to Variable · Current · Default · Description (current value next to the name for a status page; description prose last), grouped into: **Server**, **Accounts & Registration**, **Authentication — Passkeys (WebAuthn)**, **Authentication — Forward-Auth** (the 7 forward-auth vars), **Content & Media**. Balanced header padding; the Current column is tinted and vertically centered. `data-label` attributes and the mobile card view are preserved.

## Implementation

- `src/middleware/forward_auth.rs` — `forward_auth_identity` helper; the middleware reuses it (DRY).
- `src/middleware/auth.rs` — `via_forward_auth` computed on `AuthUser`/`PageAuthUser`; propagated through `PageAdminUser` so `/admin` SSR matches.
- `src/handlers/user.rs`, `src/handlers/pages/mod.rs` — thread the flag into `SidebarResponse` (`/api/sidebar` + SSR bootstrap); `SettingsTemplate` forward-auth fields.
- `static/js/components/rdrs-sidebar.js`, `static/css/app.css` — pill render + structural-change trigger + styles.
- `templates/settings.html`, `templates/macros.html` — grouped/reordered table.
- `ARCHITECTURE.md` — short note.

## Testing

- Unit: `forward_auth_identity` covers all branches (enabled/disabled, trusted/untrusted/missing peer, present/empty header).
- Integration: `/api/sidebar` reports `via_forward_auth` dynamically (same session: header present → true, absent → false); `/admin` SSR bootstrap reflects the flag; `/settings` renders the group headers + forward-auth vars + configured values.
- Full suite green: 978/978, `cargo fmt` and `cargo clippy -- -D warnings` clean.
- README screenshots verified unchanged (default/local demo config → no pill; `/settings` not screenshotted).

Design spec and implementation plan are included under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)