### PR TITLE
fix(ui): align App config group headers with variable column

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -1035,7 +1035,7 @@ td input[type="text"] {
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.04em;
-    padding: var(--space-2) var(--space-8) var(--space-2) 0;
+    padding: var(--space-2) var(--space-8) var(--space-2) var(--space-4);
 }
 
 /* anchor the eye on the running value; keep its top/bottom spacing even */


### PR DESCRIPTION
## Summary

The App `/settings` configuration table's group-label rows (`.grouphdr td`) had `padding-left: 0`, so each group label (e.g. **Server**, **Authentication — Forward-Auth**) sat flush against the table's left edge while the variable names in the rows below were indented by `var(--space-4)`. This left the group headers visually misaligned with the column they introduce.

Set the group-header left padding to `var(--space-4)` to match the data cells, so each label lines up with its variable column.

## Scope

- CSS-only, single value (`static/css/app.css`).
- The `/settings` page is not part of the README screenshot set, so no screenshot regeneration is required.
- Mobile card view (`.mobile-cards-settings .grouphdr td`) only overrides `display`/`width` and inherits the same padding — no separate change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)