### PR TITLE
chore(dependabot): group all updates per ecosystem into single PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,9 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      cargo:
+        patterns: ["*"]
 
   - package-ecosystem: "docker"
     directory: "/"
@@ -13,6 +16,9 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      docker:
+        patterns: ["*"]
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -20,6 +26,9 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      actions:
+        patterns: ["*"]
 
   - package-ecosystem: "npm"
     directory: "/e2e"
@@ -27,3 +36,6 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      npm:
+        patterns: ["*"]


### PR DESCRIPTION
## Summary

Add a catch-all group (`patterns: ["*"]`) to each ecosystem in `.github/dependabot.yml` so that cargo, docker, github-actions, and npm updates each open a **single combined PR** per week instead of one PR per dependency.

This mirrors the configuration used in `henry40408/lur`.

## Changes

- `cargo` → group `cargo`
- `docker` → group `docker`
- `github-actions` → group `actions`
- `npm` (`/e2e`) → group `npm`

The existing weekly schedule and 7-day cooldown (supply-chain policy) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)