### PR TITLE
chore(infra): Rust 2024 edition, cargo-deny, Swatinem cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,15 +31,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Cache dependencies
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Check formatting
         run: cargo fmt --all -- --check
@@ -49,6 +41,17 @@ jobs:
 
       - name: Build
         run: cargo build --verbose
+
+  deny:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: dtolnay/rust-toolchain@10c3493d811a9096cee4fdf287e41e852f6a51ba # 1.94.0
+      - uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2
+        with:
+          tool: cargo-deny@0.18.9
+      - name: cargo deny check
+        run: cargo deny check
 
   e2e-tests:
     needs: build-and-test
@@ -68,15 +71,7 @@ jobs:
         uses: dtolnay/rust-toolchain@10c3493d811a9096cee4fdf287e41e852f6a51ba # 1.94.0
 
       - name: Cache Rust dependencies
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Build binary
         run: cargo build
@@ -138,16 +133,7 @@ jobs:
           components: llvm-tools-preview
 
       - name: Cache dependencies
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-coverage-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-coverage-
-            ${{ runner.os }}-cargo-
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - uses: taiki-e/install-action@ad25acb6b9413207b3174a4202c12aa9133691c6 # cargo-llvm-cov
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 - Format (CI gate): `cargo fmt --all -- --check` — run `cargo fmt` before committing.
 - Lint (CI gate): `cargo clippy -- -D warnings` — warnings fail the build.
+- Supply-chain (CI gate): `cargo deny check` — advisories, licenses, bans, sources.
 - Build: `cargo build` (debug) / `cargo build --release`.
 - Test: `cargo nextest run` (the project uses nextest, not `cargo test`).
 - Single test: `cargo nextest run <substring>` (e.g. `cargo nextest run test_create_category`).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2643,7 +2643,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
 dependencies = [
  "phf_shared 0.10.0",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -2653,7 +2653,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -2917,7 +2917,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2966,9 +2966,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -2977,9 +2977,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -3067,7 +3067,7 @@ dependencies = [
  "num-traits",
  "paste",
  "profiling",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "simd_helpers",
  "thiserror 2.0.18",
@@ -3424,9 +3424,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -4646,7 +4646,7 @@ dependencies = [
  "nom 7.1.3",
  "openssl",
  "openssl-sys",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "serde",
  "serde_cbor_2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rdrs"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 description = "RSS Reader in Rust"
 
 [lib]

--- a/build.rs
+++ b/build.rs
@@ -21,10 +21,11 @@ fn main() {
 fn get_git_version() -> String {
     // First, check if GIT_VERSION is set via environment variable
     // This is used for Docker builds where .git directory is not available
-    if let Ok(version) = std::env::var("GIT_VERSION") {
-        if !version.is_empty() && version != "dev" {
-            return version;
-        }
+    if let Ok(version) = std::env::var("GIT_VERSION")
+        && !version.is_empty()
+        && version != "dev"
+    {
+        return version;
     }
 
     // git describe --tags --always --dirty

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,69 @@
+# cargo-deny configuration — supply-chain checks for the dependency graph.
+# Run locally with `cargo deny check`; CI runs the same on every push and PR.
+
+[graph]
+# Check the dependency graph for all targets, not just the host's, so a
+# platform-specific dependency can't smuggle in a bad license or advisory.
+all-features = true
+
+[advisories]
+version = 2
+# Deny crates with a known security advisory (RUSTSEC) or that have been yanked.
+# `ignore` holds advisory IDs we've reviewed and consciously accept (none yet).
+yanked = "deny"
+ignore = [
+    # core2 is unmaintained and all versions are yanked; pulled in transitively
+    # with no maintained drop-in replacement available yet. The crate spec
+    # silences the separate `yanked = "deny"` check for the same crate.
+    "RUSTSEC-2026-0105",
+    "core2@0.4.0",
+    # paste (proc-macro helper) is no longer maintained; still pulled in
+    # transitively, no maintained replacement wired up.
+    "RUSTSEC-2024-0436",
+    # memmap2 unchecked pointer offset (unsound). Fixed in 0.9.11, but that
+    # release is younger than our 7-day dependency cooldown — re-bump and drop
+    # this entry once it has aged out.
+    "RUSTSEC-2026-0186",
+]
+
+[licenses]
+version = 2
+# Permissive / public-domain-equivalent licenses only. Verify the active set
+# with `cargo deny list`; add a license here only after reviewing the crate.
+allow = [
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "CC0-1.0",
+    "CDLA-Permissive-2.0",
+    "ISC",
+    "MIT",
+    "MIT-0",
+    # Weak (file-level) copyleft, pulled in by webauthn-rs (passkey auth) and
+    # the scraper/cssparser/selectors HTML stack — both real runtime deps.
+    "MPL-2.0",
+    "Unicode-3.0",
+    "Unlicense",
+    "Zlib",
+]
+confidence-threshold = 0.8
+
+# libfuzzer-sys is only reachable via `all-features`; allow its NCSA arm just
+# for that crate rather than widening the global allowlist for a fuzz-only dep.
+[[licenses.exceptions]]
+crate = "libfuzzer-sys"
+allow = ["NCSA"]
+
+[bans]
+# Duplicate transitive versions are common; surface them as a warning, not a
+# hard failure.
+multiple-versions = "warn"
+wildcards = "deny"
+
+[sources]
+# Only crates.io is trusted; an unknown registry or any git source is rejected.
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]

--- a/src/auth/password.rs
+++ b/src/auth/password.rs
@@ -1,8 +1,8 @@
 use std::sync::LazyLock;
 
 use argon2::{
-    password_hash::{rand_core::OsRng, PasswordHash, PasswordHasher, PasswordVerifier, SaltString},
     Algorithm, Argon2, Params, Version,
+    password_hash::{PasswordHash, PasswordHasher, PasswordVerifier, SaltString, rand_core::OsRng},
 };
 
 use crate::error::{AppError, AppResult};

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use base64::{engine::general_purpose::STANDARD, Engine};
+use base64::{Engine, engine::general_purpose::STANDARD};
 use ipnet::{IpNet, Ipv4Net, Ipv6Net};
 use rand::Rng;
 use std::env;
@@ -108,10 +108,10 @@ impl Config {
     fn load_image_proxy_secret() -> (Vec<u8>, bool) {
         if let Ok(secret_str) = env::var("IMAGE_PROXY_SECRET") {
             // Try to decode as base64 first
-            if let Ok(decoded) = STANDARD.decode(&secret_str) {
-                if decoded.len() >= 16 {
-                    return (decoded, false);
-                }
+            if let Ok(decoded) = STANDARD.decode(&secret_str)
+                && decoded.len() >= 16
+            {
+                return (decoded, false);
             }
             // Use raw bytes if at least 16 characters
             if secret_str.len() >= 16 {
@@ -183,14 +183,14 @@ impl Config {
                 self.webauthn_rp_origin
             ));
         }
-        if let Some(base) = &self.public_base_url {
-            if base.trim_end_matches('/') != self.webauthn_rp_origin.trim_end_matches('/') {
-                return Some(format!(
-                    "WEBAUTHN_RP_ORIGIN ('{}') does not match PUBLIC_BASE_URL ('{}'). Passkeys \
+        if let Some(base) = &self.public_base_url
+            && base.trim_end_matches('/') != self.webauthn_rp_origin.trim_end_matches('/')
+        {
+            return Some(format!(
+                "WEBAUTHN_RP_ORIGIN ('{}') does not match PUBLIC_BASE_URL ('{}'). Passkeys \
                      may be rejected — align WEBAUTHN_RP_ORIGIN with the URL users access.",
-                    self.webauthn_rp_origin, base
-                ));
-            }
+                self.webauthn_rp_origin, base
+            ));
         }
         None
     }

--- a/src/db/pool.rs
+++ b/src/db/pool.rs
@@ -71,17 +71,23 @@ impl DbPool {
     /// for the combined actor tasks.
     pub fn new(write_conn: Connection, read_conn: Connection) -> (Self, JoinHandle<()>) {
         // Enable WAL mode on write connection
-        if let Err(e) = write_conn.execute_batch("PRAGMA journal_mode=WAL;") {
-            error!("Failed to enable WAL mode: {}", e);
-        } else {
-            debug!("SQLite WAL mode enabled");
+        match write_conn.execute_batch("PRAGMA journal_mode=WAL;") {
+            Err(e) => {
+                error!("Failed to enable WAL mode: {}", e);
+            }
+            _ => {
+                debug!("SQLite WAL mode enabled");
+            }
         }
 
         // Set read connection to query-only mode for safety
-        if let Err(e) = read_conn.execute_batch("PRAGMA query_only=ON;") {
-            error!("Failed to enable query_only mode on read connection: {}", e);
-        } else {
-            debug!("Read connection query_only mode enabled");
+        match read_conn.execute_batch("PRAGMA query_only=ON;") {
+            Err(e) => {
+                error!("Failed to enable query_only mode on read connection: {}", e);
+            }
+            _ => {
+                debug!("Read connection query_only mode enabled");
+            }
         }
 
         // Tuning pragmas applied to both connections. synchronous=NORMAL is
@@ -340,13 +346,16 @@ const TUNING_PRAGMAS: &str = "\
 ";
 
 fn apply_tuning_pragmas(conn: &Connection, label: &str) {
-    if let Err(e) = conn.execute_batch(TUNING_PRAGMAS) {
-        error!(
-            "Failed to apply tuning pragmas on {} connection: {}",
-            label, e
-        );
-    } else {
-        debug!("SQLite tuning pragmas applied on {} connection", label);
+    match conn.execute_batch(TUNING_PRAGMAS) {
+        Err(e) => {
+            error!(
+                "Failed to apply tuning pragmas on {} connection: {}",
+                label, e
+            );
+        }
+        _ => {
+            debug!("SQLite tuning pragmas applied on {} connection", label);
+        }
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
 use axum::{
+    Json,
     http::StatusCode,
     response::{IntoResponse, Response},
-    Json,
 };
 use serde_json::json;
 use thiserror::Error;
@@ -132,40 +132,40 @@ impl IntoResponse for AppError {
             AppError::EntryNotFound => (StatusCode::NOT_FOUND, "Entry not found"),
             AppError::InvalidUrl => (StatusCode::BAD_REQUEST, "Invalid URL"),
             AppError::FetchError(msg) => {
-                return (StatusCode::BAD_GATEWAY, Json(json!({ "error": msg }))).into_response()
+                return (StatusCode::BAD_GATEWAY, Json(json!({ "error": msg }))).into_response();
             }
             AppError::NoFeedFound => (StatusCode::BAD_REQUEST, "No feed found at URL"),
             AppError::FeedParseError(msg) => {
-                return (StatusCode::BAD_REQUEST, Json(json!({ "error": msg }))).into_response()
+                return (StatusCode::BAD_REQUEST, Json(json!({ "error": msg }))).into_response();
             }
             AppError::Validation(msg) => {
-                return (StatusCode::BAD_REQUEST, Json(json!({ "error": msg }))).into_response()
+                return (StatusCode::BAD_REQUEST, Json(json!({ "error": msg }))).into_response();
             }
             AppError::OpmlParseError(msg) => {
-                return (StatusCode::BAD_REQUEST, Json(json!({ "error": msg }))).into_response()
+                return (StatusCode::BAD_REQUEST, Json(json!({ "error": msg }))).into_response();
             }
             AppError::InvalidImageUrl => (StatusCode::BAD_REQUEST, "Invalid image URL"),
             AppError::ImageFetchError(msg) => {
-                return (StatusCode::BAD_GATEWAY, Json(json!({ "error": msg }))).into_response()
+                return (StatusCode::BAD_GATEWAY, Json(json!({ "error": msg }))).into_response();
             }
             AppError::ImageTooLarge => (StatusCode::BAD_REQUEST, "Image too large"),
             AppError::UnsupportedImageType => (StatusCode::BAD_REQUEST, "Unsupported image type"),
             AppError::InvalidSignature => (StatusCode::BAD_REQUEST, "Invalid signature"),
             AppError::PasskeyNotFound => (StatusCode::NOT_FOUND, "Passkey not found"),
             AppError::PasskeyRegistrationFailed(msg) => {
-                return (StatusCode::BAD_REQUEST, Json(json!({ "error": msg }))).into_response()
+                return (StatusCode::BAD_REQUEST, Json(json!({ "error": msg }))).into_response();
             }
             AppError::PasskeyAuthenticationFailed(msg) => {
-                return (StatusCode::UNAUTHORIZED, Json(json!({ "error": msg }))).into_response()
+                return (StatusCode::UNAUTHORIZED, Json(json!({ "error": msg }))).into_response();
             }
             AppError::ChallengeNotFound => {
                 (StatusCode::BAD_REQUEST, "Challenge not found or expired")
             }
             AppError::NotFound(msg) => {
-                return (StatusCode::NOT_FOUND, Json(json!({ "error": msg }))).into_response()
+                return (StatusCode::NOT_FOUND, Json(json!({ "error": msg }))).into_response();
             }
             AppError::Internal(_) => (StatusCode::INTERNAL_SERVER_ERROR, "Internal server error"),
-            AppError::DbPool(ref e) => match e {
+            AppError::DbPool(e) => match e {
                 crate::db::DbError::Timeout => (
                     StatusCode::SERVICE_UNAVAILABLE,
                     "Database busy, please retry",

--- a/src/handlers/admin.rs
+++ b/src/handlers/admin.rs
@@ -1,17 +1,17 @@
 use axum::{
+    Form,
     extract::{Path, State},
     http::StatusCode,
     response::IntoResponse,
-    Form,
 };
 use serde::Deserialize;
 
+use crate::AppState;
 use crate::error::{AppError, AppResult};
-use crate::middleware::flash::FlashRedirect;
 use crate::middleware::AdminUser;
+use crate::middleware::flash::FlashRedirect;
 use crate::models::session;
 use crate::models::user::{self, Role};
-use crate::AppState;
 
 pub async fn stop_masquerade(
     State(state): State<AppState>,

--- a/src/handlers/auth.rs
+++ b/src/handlers/auth.rs
@@ -1,15 +1,15 @@
-use axum::{extract::State, http::StatusCode, Json};
+use axum::{Json, extract::State, http::StatusCode};
 use axum_extra::extract::cookie::{Cookie, CookieJar};
 use serde::{Deserialize, Serialize};
 use time::Duration;
 
+use crate::AppState;
 use crate::auth::{hash_password, verify_password};
 use crate::error::{AppError, AppResult};
 use crate::middleware::{AuthUser, SESSION_COOKIE_NAME};
 use crate::models::category;
 use crate::models::session;
 use crate::models::user::{self, Role};
-use crate::AppState;
 
 #[derive(Debug, Deserialize)]
 pub struct RegisterRequest {

--- a/src/handlers/categories.rs
+++ b/src/handlers/categories.rs
@@ -4,11 +4,11 @@ use axum::{
 };
 use serde::Deserialize;
 
+use crate::AppState;
 use crate::error::AppError;
 use crate::middleware::auth::AuthUser;
 use crate::middleware::flash::FlashRedirect;
 use crate::models::category;
-use crate::AppState;
 
 #[derive(Debug, Deserialize)]
 pub struct CategoryNameForm {

--- a/src/handlers/entries.rs
+++ b/src/handlers/entries.rs
@@ -6,16 +6,15 @@ use axum::{
 };
 
 use crate::{
+    AppState,
     error::{AppError, AppResult},
-    handlers::pages::{format_relative_time, row_view_from, EntryRowView, ReadingPaneView},
+    handlers::pages::{EntryRowView, ReadingPaneView, format_relative_time, row_view_from},
     middleware::auth::PageAuthUser,
     models::{entry, entry_summary, user_settings},
     services::{
-        fetch_and_extract, sanitize_html,
-        save::{linkding, BookmarkData},
-        SummaryJob, SummaryStatus,
+        SummaryJob, SummaryStatus, fetch_and_extract, sanitize_html,
+        save::{BookmarkData, linkding},
     },
-    AppState,
 };
 
 /// Fragment template for the reading pane — renders `_reading_pane.html`
@@ -567,11 +566,7 @@ async fn set_read_state(
 
     // Unread count: -1 when newly read, +1 when newly unread, else unchanged.
     let delta = if changed {
-        if desired_read {
-            -1
-        } else {
-            1
-        }
+        if desired_read { -1 } else { 1 }
     } else {
         0
     };
@@ -803,15 +798,15 @@ pub async fn save_entry_form(
 
     let mut succeeded: Vec<String> = Vec::new();
     let mut failed: Vec<String> = Vec::new();
-    if let Some(linkding_cfg) = save_config.linkding.as_ref() {
-        if linkding_cfg.is_configured() {
-            match linkding::save_to_linkding(linkding_cfg, &bookmark).await {
-                Ok(result) if result.success => {
-                    succeeded.push("Linkding".to_string());
-                }
-                Ok(result) => failed.push(format!("Linkding: {}", result.message)),
-                Err(e) => failed.push(format!("Linkding: {e}")),
+    if let Some(linkding_cfg) = save_config.linkding.as_ref()
+        && linkding_cfg.is_configured()
+    {
+        match linkding::save_to_linkding(linkding_cfg, &bookmark).await {
+            Ok(result) if result.success => {
+                succeeded.push("Linkding".to_string());
             }
+            Ok(result) => failed.push(format!("Linkding: {}", result.message)),
+            Err(e) => failed.push(format!("Linkding: {e}")),
         }
     }
 

--- a/src/handlers/entry.rs
+++ b/src/handlers/entry.rs
@@ -1,16 +1,16 @@
 use axum::{
-    extract::{Path, Query, State},
     Json,
+    extract::{Path, Query, State},
 };
 use serde::{Deserialize, Serialize};
 
+use crate::AppState;
 use crate::error::{AppError, AppResult};
 use crate::middleware::auth::AuthUser;
-use crate::models::{category, entry, entry_summary, user_settings, SummaryStatus};
+use crate::models::{SummaryStatus, category, entry, entry_summary, user_settings};
 use crate::services::http::JOB_QUEUE_TIMEOUT;
-use crate::services::save::{linkding, BookmarkData, SaveResult};
-use crate::services::{fetch_and_extract, sanitize_html, SummaryJob};
-use crate::AppState;
+use crate::services::save::{BookmarkData, SaveResult, linkding};
+use crate::services::{SummaryJob, fetch_and_extract, sanitize_html};
 
 #[derive(Debug, Serialize)]
 pub struct FetchFullContentResponse {
@@ -369,11 +369,11 @@ pub async fn save_to_services(
     let mut results = Vec::new();
 
     // Linkding
-    if let Some(linkding_config) = &save_config.linkding {
-        if linkding_config.is_configured() {
-            let result = linkding::save_to_linkding(linkding_config, &entry_data).await?;
-            results.push(result);
-        }
+    if let Some(linkding_config) = &save_config.linkding
+        && linkding_config.is_configured()
+    {
+        let result = linkding::save_to_linkding(linkding_config, &entry_data).await?;
+        results.push(result);
     }
 
     // Future services can be added here:

--- a/src/handlers/events.rs
+++ b/src/handlers/events.rs
@@ -5,13 +5,13 @@ use axum::{
     extract::State,
     response::sse::{Event, KeepAlive, Sse},
 };
-use tokio::sync::broadcast::{error::RecvError, Receiver};
+use tokio::sync::broadcast::{Receiver, error::RecvError};
 use tokio_stream::Stream;
 use tokio_util::sync::CancellationToken;
 
+use crate::AppState;
 use crate::middleware::auth::PageAuthUser;
 use crate::services::{EventKind, SummaryEventData, UserEvent};
-use crate::AppState;
 
 /// Build the `sidebar` SSE event (no data payload; the client just refetches).
 fn sidebar_event() -> Event {

--- a/src/handlers/favicon.rs
+++ b/src/handlers/favicon.rs
@@ -1,5 +1,5 @@
 use axum::{
-    http::{header, StatusCode},
+    http::{StatusCode, header},
     response::{IntoResponse, Response},
 };
 

--- a/src/handlers/feed.rs
+++ b/src/handlers/feed.rs
@@ -1,13 +1,13 @@
 use axum::{
     extract::{Path, State},
-    http::{header, StatusCode},
+    http::{StatusCode, header},
     response::{IntoResponse, Response},
 };
 
+use crate::AppState;
 use crate::error::{AppError, AppResult};
 use crate::middleware::AuthUser;
 use crate::models::{category, feed, image};
-use crate::AppState;
 
 pub async fn get_feed_icon(
     State(state): State<AppState>,

--- a/src/handlers/feeds.rs
+++ b/src/handlers/feeds.rs
@@ -1,16 +1,16 @@
 use axum::{
+    Form,
     extract::{Multipart, Path, State},
     response::IntoResponse,
-    Form,
 };
 use serde::Deserialize;
 
+use crate::AppState;
 use crate::error::AppError;
-use crate::middleware::flash::FlashRedirect;
 use crate::middleware::AuthUser;
+use crate::middleware::flash::FlashRedirect;
 use crate::models::{category, feed};
 use crate::services::{feed_discovery, feed_sync, opml};
-use crate::AppState;
 
 // Form-action POST endpoints for the SSR /feeds page. Each accepts
 // application/x-www-form-urlencoded (or multipart for import) bodies and
@@ -375,11 +375,11 @@ pub async fn import_opml_form(
         if bytes.is_empty() {
             continue;
         }
-        if let Ok(text) = std::str::from_utf8(&bytes) {
-            if !text.trim().is_empty() {
-                content = text.to_string();
-                break;
-            }
+        if let Ok(text) = std::str::from_utf8(&bytes)
+            && !text.trim().is_empty()
+        {
+            content = text.to_string();
+            break;
         }
     }
     if content.trim().is_empty() {

--- a/src/handlers/greader/auth.rs
+++ b/src/handlers/greader/auth.rs
@@ -1,19 +1,19 @@
 use axum::{
+    Form,
     extract::{FromRequestParts, State},
     http::request::Parts,
-    Form,
 };
 use axum_extra::extract::CookieJar;
 use chrono::Utc;
 use hmac::{Hmac, KeyInit, Mac};
 use sha2::Sha256;
 
+use crate::AppState;
 use crate::auth::verify_password;
 use crate::error::{AppError, AppResult};
 use crate::middleware::auth::SESSION_COOKIE_NAME;
 use crate::models::session::{self, Session};
 use crate::models::user::{self, User};
-use crate::AppState;
 
 type HmacSha256 = Hmac<Sha256>;
 
@@ -42,22 +42,19 @@ impl FromRequestParts<AppState> for GReaderUser {
         state: &AppState,
     ) -> Result<Self, Self::Rejection> {
         // 1. Try Authorization header: "GoogleLogin auth=<token>"
-        if let Some(auth_header) = parts.headers.get("authorization") {
-            if let Ok(auth_str) = auth_header.to_str() {
-                if let Some(token) = auth_str
-                    .strip_prefix("GoogleLogin auth=")
-                    .map(|s| s.trim().to_string())
-                {
-                    if !token.is_empty() {
-                        let (session, user) = validate_token(state, &token).await?;
-                        return Ok(GReaderUser {
-                            user,
-                            session,
-                            via_cookie: false,
-                        });
-                    }
-                }
-            }
+        if let Some(auth_header) = parts.headers.get("authorization")
+            && let Ok(auth_str) = auth_header.to_str()
+            && let Some(token) = auth_str
+                .strip_prefix("GoogleLogin auth=")
+                .map(|s| s.trim().to_string())
+            && !token.is_empty()
+        {
+            let (session, user) = validate_token(state, &token).await?;
+            return Ok(GReaderUser {
+                user,
+                session,
+                via_cookie: false,
+            });
         }
 
         // 2. Fallback: session cookie

--- a/src/handlers/greader/item.rs
+++ b/src/handlers/greader/item.rs
@@ -1,20 +1,21 @@
 use axum::{
-    extract::{Path, Query, State},
     Form, Json,
+    extract::{Path, Query, State},
 };
 use serde::Deserialize;
 
 use std::collections::HashMap;
 
+use crate::AppState;
 use crate::error::{AppError, AppResult};
 use crate::models::{category, entry, entry_summary, feed};
 use crate::services::sanitize_html;
-use crate::AppState;
 
 use super::auth::GReaderUser;
 use super::types::{
-    entry_id_to_item_id, item_id_to_entry_id, GReaderAlternateLink, GReaderContent, GReaderItem,
-    GReaderLink, GReaderOrigin, ItemRef, StreamContentsResponse, StreamId, StreamItemIdsResponse,
+    GReaderAlternateLink, GReaderContent, GReaderItem, GReaderLink, GReaderOrigin, ItemRef,
+    StreamContentsResponse, StreamId, StreamItemIdsResponse, entry_id_to_item_id,
+    item_id_to_entry_id,
 };
 
 // --- stream/contents ---
@@ -438,24 +439,24 @@ fn build_entry_filter_from_params(
     }
 
     // Apply exclude tag
-    if let Some(xt_str) = xt {
-        if let Ok(xt_stream) = StreamId::parse(xt_str) {
-            match xt_stream {
-                StreamId::Read => filter.unread_only = true,
-                StreamId::Starred => {} // exclude starred — no direct filter, ignore for now
-                _ => {}
-            }
+    if let Some(xt_str) = xt
+        && let Ok(xt_stream) = StreamId::parse(xt_str)
+    {
+        match xt_stream {
+            StreamId::Read => filter.unread_only = true,
+            StreamId::Starred => {} // exclude starred — no direct filter, ignore for now
+            _ => {}
         }
     }
 
     // Apply include tag
-    if let Some(it_str) = it {
-        if let Ok(it_stream) = StreamId::parse(it_str) {
-            match it_stream {
-                StreamId::Read => filter.read_only = true,
-                StreamId::Starred => filter.starred_only = true,
-                _ => {}
-            }
+    if let Some(it_str) = it
+        && let Ok(it_stream) = StreamId::parse(it_str)
+    {
+        match it_stream {
+            StreamId::Read => filter.read_only = true,
+            StreamId::Starred => filter.starred_only = true,
+            _ => {}
         }
     }
 

--- a/src/handlers/greader/mod.rs
+++ b/src/handlers/greader/mod.rs
@@ -6,8 +6,8 @@ pub mod types;
 pub mod user;
 
 use axum::{
-    routing::{get, post},
     Router,
+    routing::{get, post},
 };
 
 use crate::AppState;

--- a/src/handlers/greader/subscription.rs
+++ b/src/handlers/greader/subscription.rs
@@ -1,15 +1,15 @@
 use axum::{
-    extract::{Query, State},
-    http::{header, StatusCode},
-    response::IntoResponse,
     Form, Json,
+    extract::{Query, State},
+    http::{StatusCode, header},
+    response::IntoResponse,
 };
 use serde::Deserialize;
 
+use crate::AppState;
 use crate::error::{AppError, AppResult};
 use crate::models::{category, feed, image};
 use crate::services::{feed_discovery, opml};
-use crate::AppState;
 
 use super::auth::GReaderUser;
 use super::types::{Subscription, SubscriptionCategory, SubscriptionListResponse};

--- a/src/handlers/greader/tag.rs
+++ b/src/handlers/greader/tag.rs
@@ -1,12 +1,12 @@
-use axum::{extract::State, Form, Json};
+use axum::{Form, Json, extract::State};
 use serde::Deserialize;
 
+use crate::AppState;
 use crate::error::{AppError, AppResult};
 use crate::models::{category, entry, feed};
-use crate::AppState;
 
 use super::auth::GReaderUser;
-use super::types::{item_id_to_entry_id, StreamId, Tag, TagListResponse};
+use super::types::{StreamId, Tag, TagListResponse, item_id_to_entry_id};
 
 /// `GET /reader/api/0/tag/list`
 pub async fn tag_list(
@@ -323,7 +323,7 @@ pub async fn rename_tag(
         _ => {
             return Err(AppError::Validation(
                 "Destination must be a label tag".into(),
-            ))
+            ));
         }
     };
 

--- a/src/handlers/greader/user.rs
+++ b/src/handlers/greader/user.rs
@@ -1,9 +1,9 @@
-use axum::{extract::State, Json};
-use serde_json::{json, Value};
+use axum::{Json, extract::State};
+use serde_json::{Value, json};
 
+use crate::AppState;
 use crate::error::{AppError, AppResult};
 use crate::models::{category, entry, feed};
-use crate::AppState;
 
 use super::auth::GReaderUser;
 use super::types::{UnreadCount, UnreadCountResponse, UserInfoResponse};

--- a/src/handlers/pages/mod.rs
+++ b/src/handlers/pages/mod.rs
@@ -7,13 +7,13 @@ use axum::{
 
 use std::collections::HashMap;
 
+use crate::AppState;
 use crate::error::AppError;
 use crate::middleware::auth::{LoginRedirect, PageAdminUser, PageAuthUser};
 use crate::middleware::flash::{Flash, FlashMessage};
-use crate::models::user_settings;
 use crate::models::SummaryStatus;
+use crate::models::user_settings;
 use crate::models::{category, entry, entry_summary, feed};
-use crate::AppState;
 
 mod script_json;
 mod search_text;

--- a/src/handlers/passkey.rs
+++ b/src/handlers/passkey.rs
@@ -1,7 +1,7 @@
 use axum::{
+    Json,
     extract::{Path, State},
     http::StatusCode,
-    Json,
 };
 use axum_extra::extract::cookie::{Cookie, CookieJar};
 use serde::{Deserialize, Serialize};
@@ -9,10 +9,10 @@ use time::Duration;
 use uuid::Uuid;
 use webauthn_rs::prelude::*;
 
+use crate::AppState;
 use crate::error::{AppError, AppResult};
 use crate::middleware::{AuthUser, SESSION_COOKIE_NAME};
 use crate::models::{passkey, session, user, webauthn_challenge};
-use crate::AppState;
 
 // --- Registration ---
 

--- a/src/handlers/proxy.rs
+++ b/src/handlers/proxy.rs
@@ -1,18 +1,18 @@
 use axum::{
     extract::{Query, State},
-    http::{header, HeaderMap, StatusCode},
+    http::{HeaderMap, StatusCode, header},
     response::{IntoResponse, Response},
 };
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use serde::Deserialize;
 use url::Url;
 
 use crate::{
+    AppState,
     error::{AppError, AppResult},
-    services::http::{send_with_retry_on_error, RetryConfig, SHARED_CLIENT},
+    services::http::{RetryConfig, SHARED_CLIENT, send_with_retry_on_error},
     services::{verify_signature, verify_signature_with_referrer},
     utils::url_validation,
-    AppState,
 };
 
 const MAX_IMAGE_SIZE: u64 = 10 * 1024 * 1024; // 10MB
@@ -156,10 +156,10 @@ pub async fn proxy_image(
     .to_string();
 
     // Check Content-Length if available
-    if let Some(content_length) = response.content_length() {
-        if content_length > MAX_IMAGE_SIZE {
-            return Err(AppError::ImageTooLarge);
-        }
+    if let Some(content_length) = response.content_length()
+        && content_length > MAX_IMAGE_SIZE
+    {
+        return Err(AppError::ImageTooLarge);
     }
 
     // Read the body with size limit

--- a/src/handlers/static_assets.rs
+++ b/src/handlers/static_assets.rs
@@ -1,6 +1,6 @@
 use axum::{
     extract::Path,
-    http::{header, StatusCode},
+    http::{StatusCode, header},
     response::{IntoResponse, Response},
 };
 

--- a/src/handlers/user.rs
+++ b/src/handlers/user.rs
@@ -1,17 +1,17 @@
-use axum::{extract::State, http::StatusCode, response::IntoResponse, Form, Json};
+use axum::{Form, Json, extract::State, http::StatusCode, response::IntoResponse};
 use serde::{Deserialize, Serialize};
 use url::Url;
 
+use crate::AppState;
 use crate::auth::{hash_password, verify_password};
 use crate::error::{AppError, AppResult};
-use crate::middleware::flash::FlashRedirect;
 use crate::middleware::AuthUser;
+use crate::middleware::flash::FlashRedirect;
 use crate::models::session;
 use crate::models::user;
 use crate::models::user_settings;
 use crate::models::{category, entry};
 use crate::services::{KagiConfig, LinkdingConfig};
-use crate::AppState;
 
 #[derive(Debug, Serialize)]
 pub struct MeResponse {
@@ -348,12 +348,13 @@ pub async fn update_theme(
     let user_id = auth_user.user.id;
 
     // Validate theme value
-    if let Some(ref theme) = req.theme {
-        if theme != "dark" && theme != "light" {
-            return Err(AppError::Validation(
-                "Theme must be 'dark', 'light', or null".to_string(),
-            ));
-        }
+    if let Some(ref theme) = req.theme
+        && theme != "dark"
+        && theme != "light"
+    {
+        return Err(AppError::Validation(
+            "Theme must be 'dark', 'light', or null".to_string(),
+        ));
     }
 
     state

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
 use axum::{
-    routing::{delete, get, post, put},
     Router,
+    routing::{delete, get, post, put},
 };
 use tokio::sync::mpsc;
 use tower_http::{compression::CompressionLayer, timeout::TimeoutLayer};

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
-use rdrs::{auth, create_router, db, services, AppState, Config, DbPool};
+use rdrs::{AppState, Config, DbPool, auth, create_router, db, services};
 use rusqlite::Connection;
 use tokio_util::sync::CancellationToken;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};

--- a/src/middleware/auth.rs
+++ b/src/middleware/auth.rs
@@ -7,11 +7,11 @@ use axum::{
 };
 use axum_extra::extract::CookieJar;
 
+use crate::AppState;
 use crate::error::AppError;
 use crate::middleware::flash::FlashRedirect;
 use crate::models::session::{self, Session};
 use crate::models::user::{self, User};
-use crate::AppState;
 
 pub const SESSION_COOKIE_NAME: &str = "session_token";
 

--- a/src/middleware/etag.rs
+++ b/src/middleware/etag.rs
@@ -8,8 +8,8 @@
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use axum::body::{to_bytes, Body};
-use axum::http::{header, HeaderValue, Request, StatusCode};
+use axum::body::{Body, to_bytes};
+use axum::http::{HeaderValue, Request, StatusCode, header};
 use axum::response::Response;
 use sha2::{Digest, Sha256};
 use tower::{Layer, Service};
@@ -94,13 +94,13 @@ where
                 HeaderValue::from_str(&etag).expect("etag is ascii"),
             );
 
-            if let Some(client_value) = if_none_match {
-                if etag_matches(&client_value, &etag) {
-                    parts.status = StatusCode::NOT_MODIFIED;
-                    parts.headers.remove(header::CONTENT_LENGTH);
-                    parts.headers.remove(header::CONTENT_TYPE);
-                    return Ok(Response::from_parts(parts, Body::empty()));
-                }
+            if let Some(client_value) = if_none_match
+                && etag_matches(&client_value, &etag)
+            {
+                parts.status = StatusCode::NOT_MODIFIED;
+                parts.headers.remove(header::CONTENT_LENGTH);
+                parts.headers.remove(header::CONTENT_TYPE);
+                return Ok(Response::from_parts(parts, Body::empty()));
             }
 
             Ok(Response::from_parts(parts, Body::from(bytes)))

--- a/src/middleware/forward_auth.rs
+++ b/src/middleware/forward_auth.rs
@@ -9,12 +9,12 @@ use axum::{
 use axum_extra::extract::cookie::{Cookie, CookieJar, SameSite};
 use time::Duration;
 
+use crate::AppState;
 use crate::config::Config;
 use crate::error::AppError;
 use crate::middleware::{FlashRedirect, SESSION_COOKIE_NAME};
 use crate::models::user::{self, Role};
 use crate::models::{category, session};
-use crate::AppState;
 
 /// Path prefixes that must never trigger forward-auth auto-login: machine
 /// endpoints (GReader native clients, JSON/passkey APIs, SSE, static assets)
@@ -149,10 +149,10 @@ pub async fn forward_auth(
                     if u.is_disabled() {
                         return Ok::<Option<String>, AppError>(None);
                     }
-                    if let Some(role) = desired_role {
-                        if u.role != role {
-                            user::update_role(conn, u.id, role)?;
-                        }
+                    if let Some(role) = desired_role
+                        && u.role != role
+                    {
+                        user::update_role(conn, u.id, role)?;
                     }
                     u
                 }

--- a/src/middleware/mod.rs
+++ b/src/middleware/mod.rs
@@ -7,4 +7,4 @@ pub mod forward_auth;
 pub use auth::{AdminUser, AuthUser, PageAdminUser, PageAuthUser, SESSION_COOKIE_NAME};
 pub use date_header::DateHeaderLayer;
 pub use etag::ETagLayer;
-pub use flash::{Flash, FlashMessage, FlashRedirect, SetFlash, FLASH_COOKIE_NAME};
+pub use flash::{FLASH_COOKIE_NAME, Flash, FlashMessage, FlashRedirect, SetFlash};

--- a/src/models/category.rs
+++ b/src/models/category.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use rusqlite::{params, Connection, OptionalExtension};
+use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 
 use crate::error::{AppError, AppResult};
@@ -253,9 +253,11 @@ mod tests {
         let category = create_category(&conn, user1, "Books").unwrap();
 
         // user2 cannot access user1's category
-        assert!(find_by_id_and_user(&conn, category.id, user2)
-            .unwrap()
-            .is_none());
+        assert!(
+            find_by_id_and_user(&conn, category.id, user2)
+                .unwrap()
+                .is_none()
+        );
 
         // user2 cannot update user1's category
         let result = update_name(&conn, category.id, user2, "Novels");

--- a/src/models/entry/mod.rs
+++ b/src/models/entry/mod.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use rusqlite::{params, Connection, OptionalExtension};
+use rusqlite::{Connection, OptionalExtension, params};
 use serde::{Deserialize, Serialize};
 
 use crate::error::{AppError, AppResult};
@@ -596,12 +596,11 @@ pub fn prune_read_retention_batch(conn: &Connection, batch_size: usize) -> AppRe
             LIMIT ?1
             "#,
         )?;
-        let rows = stmt
-            .query_map(params![batch_size as i64], |row| {
-                Ok((row.get(0)?, row.get(1)?, row.get(2)?))
-            })?
-            .collect::<rusqlite::Result<Vec<_>>>()?;
-        rows
+
+        stmt.query_map(params![batch_size as i64], |row| {
+            Ok((row.get(0)?, row.get(1)?, row.get(2)?))
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?
     };
 
     if victims.is_empty() {
@@ -654,7 +653,7 @@ pub fn upsert_entry(
         UpsertOutcome::SkippedTombstoned => {
             return Err(AppError::Internal(
                 "upsert_entry called for a tombstoned guid".to_string(),
-            ))
+            ));
         }
     };
     let entry = find_by_id(conn, id)?.ok_or(AppError::EntryNotFound)?;
@@ -1104,7 +1103,7 @@ pub fn find_neighbors(
             return Ok(EntryNeighbors {
                 prev_id: None,
                 next_id: None,
-            })
+            });
         }
     };
 
@@ -1904,9 +1903,11 @@ mod tests {
         )
         .unwrap();
         assert!(matches!(outcome, UpsertOutcome::SkippedTombstoned));
-        assert!(find_by_guid_and_feed(&conn, "ghost", feed_id)
-            .unwrap()
-            .is_none());
+        assert!(
+            find_by_guid_and_feed(&conn, "ghost", feed_id)
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[test]
@@ -1998,30 +1999,36 @@ mod tests {
         // Star e1, e2 — only currently-unstarred rows count
         let starred = star_by_ids(&conn, user_id, &[e1.id, e2.id]).unwrap();
         assert_eq!(starred, 2);
-        assert!(find_by_id(&conn, e1.id)
-            .unwrap()
-            .unwrap()
-            .starred_at
-            .is_some());
+        assert!(
+            find_by_id(&conn, e1.id)
+                .unwrap()
+                .unwrap()
+                .starred_at
+                .is_some()
+        );
 
         // Starring again is a no-op (already starred)
         assert_eq!(star_by_ids(&conn, user_id, &[e1.id, e2.id]).unwrap(), 0);
 
         // Ownership scope: cannot star another user's entry
         assert_eq!(star_by_ids(&conn, user_id, &[other.id]).unwrap(), 0);
-        assert!(find_by_id(&conn, other.id)
-            .unwrap()
-            .unwrap()
-            .starred_at
-            .is_none());
+        assert!(
+            find_by_id(&conn, other.id)
+                .unwrap()
+                .unwrap()
+                .starred_at
+                .is_none()
+        );
 
         // Unstar e1
         assert_eq!(unstar_by_ids(&conn, user_id, &[e1.id]).unwrap(), 1);
-        assert!(find_by_id(&conn, e1.id)
-            .unwrap()
-            .unwrap()
-            .starred_at
-            .is_none());
+        assert!(
+            find_by_id(&conn, e1.id)
+                .unwrap()
+                .unwrap()
+                .starred_at
+                .is_none()
+        );
 
         // Mark read then mark unread by ids
         assert_eq!(
@@ -2920,18 +2927,26 @@ mod tests {
 
         // Only "old" is pruned; a tombstone is written for it.
         assert_eq!(prune_read_retention_batch(&conn, 500).unwrap(), 1);
-        assert!(find_by_guid_and_feed(&conn, "old", feed_id)
-            .unwrap()
-            .is_none());
-        assert!(find_by_guid_and_feed(&conn, "oldstar", feed_id)
-            .unwrap()
-            .is_some());
-        assert!(find_by_guid_and_feed(&conn, "fresh", feed_id)
-            .unwrap()
-            .is_some());
-        assert!(find_by_guid_and_feed(&conn, "unread", feed_id)
-            .unwrap()
-            .is_some());
+        assert!(
+            find_by_guid_and_feed(&conn, "old", feed_id)
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            find_by_guid_and_feed(&conn, "oldstar", feed_id)
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            find_by_guid_and_feed(&conn, "fresh", feed_id)
+                .unwrap()
+                .is_some()
+        );
+        assert!(
+            find_by_guid_and_feed(&conn, "unread", feed_id)
+                .unwrap()
+                .is_some()
+        );
 
         // Tombstone present -> a refresh serving "old" again is skipped.
         let outcome = upsert_entry_id(

--- a/src/models/entry_summary.rs
+++ b/src/models/entry_summary.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use rusqlite::{params, Connection, OptionalExtension};
+use rusqlite::{Connection, OptionalExtension, params};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 

--- a/src/models/feed.rs
+++ b/src/models/feed.rs
@@ -2,7 +2,7 @@ use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 
 use chrono::{DateTime, Utc};
-use rusqlite::{params, Connection, OptionalExtension};
+use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 
 use crate::error::{AppError, AppResult};

--- a/src/models/image.rs
+++ b/src/models/image.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use rusqlite::{params, Connection, OptionalExtension};
+use rusqlite::{Connection, OptionalExtension, params};
 
 use crate::error::{AppError, AppResult};
 

--- a/src/models/passkey.rs
+++ b/src/models/passkey.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use rusqlite::{params, Connection, OptionalExtension};
+use rusqlite::{Connection, OptionalExtension, params};
 use serde::Serialize;
 
 use crate::error::{AppError, AppResult};

--- a/src/models/session.rs
+++ b/src/models/session.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Duration, Utc};
 use rand::RngExt;
-use rusqlite::{params, Connection, OptionalExtension};
+use rusqlite::{Connection, OptionalExtension, params};
 
 use crate::error::{AppError, AppResult};
 

--- a/src/models/statistics.rs
+++ b/src/models/statistics.rs
@@ -1,5 +1,5 @@
 use chrono::NaiveDate;
-use rusqlite::{params, Connection};
+use rusqlite::{Connection, params};
 
 use crate::error::AppResult;
 

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use chrono::{DateTime, Utc};
-use rusqlite::{params, Connection, OptionalExtension};
+use rusqlite::{Connection, OptionalExtension, params};
 use serde::{Deserialize, Serialize};
 
 use crate::error::{AppError, AppResult};

--- a/src/models/user_settings.rs
+++ b/src/models/user_settings.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use rusqlite::{params, Connection, OptionalExtension};
+use rusqlite::{Connection, OptionalExtension, params};
 use serde::{Deserialize, Serialize};
 
 use crate::error::{AppError, AppResult};

--- a/src/models/webauthn_challenge.rs
+++ b/src/models/webauthn_challenge.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Duration, Utc};
-use rusqlite::{params, Connection, OptionalExtension};
+use rusqlite::{Connection, OptionalExtension, params};
 
 use crate::error::{AppError, AppResult};
 

--- a/src/services/background.rs
+++ b/src/services/background.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use chrono::Utc;
 use tokio::task::JoinHandle;
-use tokio::time::{interval, Duration};
+use tokio::time::{Duration, interval};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info};
 

--- a/src/services/feed_discovery.rs
+++ b/src/services/feed_discovery.rs
@@ -3,7 +3,7 @@ use scraper::{Html, Selector};
 use url::Url;
 
 use crate::error::{AppError, AppResult};
-use crate::services::http::{send_with_retry_on_error, RetryConfig, SHARED_CLIENT};
+use crate::services::http::{RetryConfig, SHARED_CLIENT, send_with_retry_on_error};
 
 #[derive(Debug, Clone)]
 pub struct DiscoveredFeed {

--- a/src/services/feed_sync.rs
+++ b/src/services/feed_sync.rs
@@ -7,7 +7,7 @@ use crate::db::DbPool;
 use crate::error::{AppError, AppResult};
 use crate::models::{entry, feed, image};
 use crate::services::http::{
-    send_with_retry_on_error, RetryConfig, FEED_SYNC_TIMEOUT, SHARED_CLIENT, SHARED_CLIENT_H1,
+    FEED_SYNC_TIMEOUT, RetryConfig, SHARED_CLIENT, SHARED_CLIENT_H1, send_with_retry_on_error,
 };
 use crate::services::icon_fetcher;
 use crate::utils::datetime::parse_timestamp;
@@ -69,16 +69,16 @@ pub async fn refresh_feed(
         headers.insert(USER_AGENT, value);
     }
 
-    if let Some(ref etag) = feed_data.etag {
-        if let Ok(value) = HeaderValue::from_str(etag) {
-            headers.insert(IF_NONE_MATCH, value);
-        }
+    if let Some(ref etag) = feed_data.etag
+        && let Ok(value) = HeaderValue::from_str(etag)
+    {
+        headers.insert(IF_NONE_MATCH, value);
     }
 
-    if let Some(ref last_modified) = feed_data.last_modified {
-        if let Ok(value) = HeaderValue::from_str(last_modified) {
-            headers.insert(IF_MODIFIED_SINCE, value);
-        }
+    if let Some(ref last_modified) = feed_data.last_modified
+        && let Ok(value) = HeaderValue::from_str(last_modified)
+    {
+        headers.insert(IF_MODIFIED_SINCE, value);
     }
 
     let retry_config = RetryConfig::default();
@@ -469,7 +469,7 @@ pub async fn refresh_bucket(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::db::{init_db, DbPool};
+    use crate::db::{DbPool, init_db};
     use crate::error::AppError;
     use crate::models::entry;
     use crate::models::user::Role;

--- a/src/services/http.rs
+++ b/src/services/http.rs
@@ -235,8 +235,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::atomic::{AtomicU32, Ordering};
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicU32, Ordering};
 
     #[test]
     fn test_is_transient_status() {

--- a/src/services/icon_fetcher.rs
+++ b/src/services/icon_fetcher.rs
@@ -3,7 +3,7 @@ use tracing::debug;
 use url::Url;
 
 use crate::error::AppResult;
-use crate::services::http::{send_with_retry_on_error, RetryConfig, ICON_TIMEOUT, SHARED_CLIENT};
+use crate::services::http::{ICON_TIMEOUT, RetryConfig, SHARED_CLIENT, send_with_retry_on_error};
 
 const MAX_ICON_SIZE: usize = 256 * 1024; // 256KB
 
@@ -20,26 +20,26 @@ pub async fn fetch_feed_icon(
     user_agent: &str,
 ) -> AppResult<Option<FetchedImage>> {
     // Try icon_url first
-    if let Some(url) = icon_url {
-        if let Ok(Some(img)) = fetch_image(url, user_agent).await {
-            debug!("Fetched icon from feed icon_url: {}", url);
-            return Ok(Some(img));
-        }
+    if let Some(url) = icon_url
+        && let Ok(Some(img)) = fetch_image(url, user_agent).await
+    {
+        debug!("Fetched icon from feed icon_url: {}", url);
+        return Ok(Some(img));
     }
 
     // Try logo_url
-    if let Some(url) = logo_url {
-        if let Ok(Some(img)) = fetch_image(url, user_agent).await {
-            debug!("Fetched icon from feed logo_url: {}", url);
-            return Ok(Some(img));
-        }
+    if let Some(url) = logo_url
+        && let Ok(Some(img)) = fetch_image(url, user_agent).await
+    {
+        debug!("Fetched icon from feed logo_url: {}", url);
+        return Ok(Some(img));
     }
 
     // Fallback to favicon
-    if let Some(url) = site_url {
-        if let Ok(Some(img)) = fetch_favicon(url, user_agent).await {
-            return Ok(Some(img));
-        }
+    if let Some(url) = site_url
+        && let Ok(Some(img)) = fetch_favicon(url, user_agent).await
+    {
+        return Ok(Some(img));
     }
 
     Ok(None)
@@ -142,11 +142,11 @@ async fn fetch_favicon(site_url: &str, user_agent: &str) -> AppResult<Option<Fet
         _ => return Ok(None),
     };
 
-    if let Some(icon_url) = extract_favicon_from_html(&html, &base_url) {
-        if let Ok(Some(img)) = fetch_image(&icon_url, user_agent).await {
-            debug!("Fetched favicon from HTML link: {}", icon_url);
-            return Ok(Some(img));
-        }
+    if let Some(icon_url) = extract_favicon_from_html(&html, &base_url)
+        && let Ok(Some(img)) = fetch_image(&icon_url, user_agent).await
+    {
+        debug!("Fetched favicon from HTML link: {}", icon_url);
+        return Ok(Some(img));
     }
 
     Ok(None)

--- a/src/services/image_proxy.rs
+++ b/src/services/image_proxy.rs
@@ -1,4 +1,4 @@
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use hmac::{Hmac, KeyInit, Mac};
 use sha2::Sha256;
 

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -21,22 +21,22 @@ pub mod summary_worker;
 pub use background::start_background_sync;
 pub use entry_retention::start_retention_worker;
 pub use events::{EventBus, EventKind, SummaryEventData, UserEvent};
-pub use feed_discovery::{discover_feed, DiscoveredFeed};
-pub use feed_sync::{refresh_feed, SyncResult};
+pub use feed_discovery::{DiscoveredFeed, discover_feed};
+pub use feed_sync::{SyncResult, refresh_feed};
 pub use html_entities::decode_html_entities;
 pub use image_proxy::{
     create_proxy_url, create_proxy_url_with_referrer, sign_url, sign_url_with_referrer,
     verify_signature, verify_signature_with_referrer,
 };
-pub use opml::{export_opml, parse_opml, OpmlFeed, OpmlOutline};
-pub use readability::{fetch_and_extract, ExtractedContent};
+pub use opml::{OpmlFeed, OpmlOutline, export_opml, parse_opml};
+pub use readability::{ExtractedContent, fetch_and_extract};
 pub use sanitize::sanitize_html;
 pub use save::{BookmarkData, LinkdingConfig, SaveResult, SaveServicesConfig};
 pub use sidebar_cache::{CachedChrome, SidebarCache};
 pub use summarize::KagiConfig;
-pub use summary_cache::{create_summary_cache, SummaryCache, SummaryCacheEntry, SummaryStatus};
+pub use summary_cache::{SummaryCache, SummaryCacheEntry, SummaryStatus, create_summary_cache};
 pub use summary_cleanup::start_cleanup_worker;
 pub use summary_worker::{
-    create_summary_channel, recover_incomplete_jobs, start_summary_worker, CancelRegistry,
-    SummaryJob,
+    CancelRegistry, SummaryJob, create_summary_channel, recover_incomplete_jobs,
+    start_summary_worker,
 };

--- a/src/services/opml.rs
+++ b/src/services/opml.rs
@@ -1,7 +1,7 @@
+use quick_xml::XmlVersion;
 use quick_xml::events::{BytesDecl, BytesEnd, BytesStart, BytesText, Event};
 use quick_xml::reader::Reader;
 use quick_xml::writer::Writer;
-use quick_xml::XmlVersion;
 use std::io::Cursor;
 
 use crate::error::{AppError, AppResult};
@@ -205,13 +205,13 @@ pub fn parse_opml(content: &str) -> AppResult<Vec<OpmlOutline>> {
                 } else {
                     // This is a category (Start outline without xmlUrl)
                     // Save previous category if exists
-                    if let Some(cat_name) = current_category.take() {
-                        if !current_feeds.is_empty() {
-                            outlines.push(OpmlOutline {
-                                category_name: cat_name,
-                                feeds: std::mem::take(&mut current_feeds),
-                            });
-                        }
+                    if let Some(cat_name) = current_category.take()
+                        && !current_feeds.is_empty()
+                    {
+                        outlines.push(OpmlOutline {
+                            category_name: cat_name,
+                            feeds: std::mem::take(&mut current_feeds),
+                        });
                     }
 
                     current_category = text.or(title);
@@ -273,13 +273,13 @@ pub fn parse_opml(content: &str) -> AppResult<Vec<OpmlOutline>> {
                     depth -= 1;
                     if depth == 0 {
                         // End of category
-                        if let Some(cat_name) = current_category.take() {
-                            if !current_feeds.is_empty() {
-                                outlines.push(OpmlOutline {
-                                    category_name: cat_name,
-                                    feeds: std::mem::take(&mut current_feeds),
-                                });
-                            }
+                        if let Some(cat_name) = current_category.take()
+                            && !current_feeds.is_empty()
+                        {
+                            outlines.push(OpmlOutline {
+                                category_name: cat_name,
+                                feeds: std::mem::take(&mut current_feeds),
+                            });
                         }
                     }
                 }
@@ -297,13 +297,13 @@ pub fn parse_opml(content: &str) -> AppResult<Vec<OpmlOutline>> {
     }
 
     // Handle any remaining category
-    if let Some(cat_name) = current_category {
-        if !current_feeds.is_empty() {
-            outlines.push(OpmlOutline {
-                category_name: cat_name,
-                feeds: current_feeds,
-            });
-        }
+    if let Some(cat_name) = current_category
+        && !current_feeds.is_empty()
+    {
+        outlines.push(OpmlOutline {
+            category_name: cat_name,
+            feeds: current_feeds,
+        });
     }
 
     if outlines.is_empty() {

--- a/src/services/readability.rs
+++ b/src/services/readability.rs
@@ -3,7 +3,7 @@ use reqwest::header::USER_AGENT;
 use url::Url;
 
 use crate::error::{AppError, AppResult};
-use crate::services::http::{send_with_retry_on_error, RetryConfig, SHARED_CLIENT};
+use crate::services::http::{RetryConfig, SHARED_CLIENT, send_with_retry_on_error};
 use crate::utils::url_validation;
 
 pub struct ExtractedContent {

--- a/src/services/sanitize.rs
+++ b/src/services/sanitize.rs
@@ -1,5 +1,5 @@
 use ammonia::Builder;
-use lol_html::{element, rewrite_str, RewriteStrSettings};
+use lol_html::{RewriteStrSettings, element, rewrite_str};
 use scraper::{Html, Selector};
 use std::collections::HashSet;
 use url::Url;
@@ -157,10 +157,10 @@ fn promote_lazy_images(html: &str) -> String {
 
         // Keep a real (non-placeholder) src as-is.
         let current_src = el.attr("src");
-        if let Some(src) = current_src {
-            if !src.starts_with("data:") {
-                continue;
-            }
+        if let Some(src) = current_src
+            && !src.starts_with("data:")
+        {
+            continue;
         }
 
         // Find the first usable lazy URL (non-empty, not another placeholder).

--- a/src/services/save/linkding.rs
+++ b/src/services/save/linkding.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use super::{BookmarkData, SaveResult};
 use crate::error::{AppError, AppResult};
-use crate::services::http::{send_with_retry_on_error, RetryConfig, EXTERNAL_API_TIMEOUT};
+use crate::services::http::{EXTERNAL_API_TIMEOUT, RetryConfig, send_with_retry_on_error};
 
 /// Linkding service configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/services/summarize/kagi.rs
+++ b/src/services/summarize/kagi.rs
@@ -2,7 +2,7 @@ use reqwest::Client;
 use serde::{Deserialize, Serialize};
 
 use crate::error::{AppError, AppResult};
-use crate::services::http::{send_with_retry_on_error, RetryConfig, EXTERNAL_API_TIMEOUT};
+use crate::services::http::{EXTERNAL_API_TIMEOUT, RetryConfig, send_with_retry_on_error};
 
 /// Kagi Universal Summarizer configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -79,10 +79,10 @@ async fn summarize_url_with_base(
         query.append_pair("summary_type", "summary");
         query.append_pair("url", url);
 
-        if let Some(lang) = &config.language {
-            if !lang.is_empty() {
-                query.append_pair("target_language", lang);
-            }
+        if let Some(lang) = &config.language
+            && !lang.is_empty()
+        {
+            query.append_pair("target_language", lang);
         }
     }
 
@@ -230,11 +230,13 @@ mod tests {
             .await
             .unwrap();
         assert!(!result.success);
-        assert!(result
-            .error
-            .as_deref()
-            .unwrap_or("")
-            .contains("not configured"));
+        assert!(
+            result
+                .error
+                .as_deref()
+                .unwrap_or("")
+                .contains("not configured")
+        );
     }
 
     #[tokio::test]
@@ -310,11 +312,13 @@ mod tests {
             .await
             .unwrap();
         assert!(!result.success);
-        assert!(result
-            .error
-            .as_deref()
-            .unwrap_or("")
-            .contains("Invalid session token"));
+        assert!(
+            result
+                .error
+                .as_deref()
+                .unwrap_or("")
+                .contains("Invalid session token")
+        );
     }
 
     #[tokio::test]
@@ -332,11 +336,13 @@ mod tests {
             .await
             .unwrap();
         assert!(!result.success);
-        assert!(result
-            .error
-            .as_deref()
-            .unwrap_or("")
-            .contains("Access forbidden"));
+        assert!(
+            result
+                .error
+                .as_deref()
+                .unwrap_or("")
+                .contains("Access forbidden")
+        );
     }
 
     #[tokio::test]
@@ -372,11 +378,13 @@ mod tests {
             .await
             .unwrap();
         assert!(!result.success);
-        assert!(result
-            .error
-            .as_deref()
-            .unwrap_or("")
-            .contains("Kagi error (500"));
+        assert!(
+            result
+                .error
+                .as_deref()
+                .unwrap_or("")
+                .contains("Kagi error (500")
+        );
     }
 
     #[tokio::test]

--- a/src/utils/datetime.rs
+++ b/src/utils/datetime.rs
@@ -69,12 +69,12 @@ fn parse_chinese_datetime(s: &str) -> Option<DateTime<Utc>> {
     let naive_dt = NaiveDateTime::new(date, time);
 
     // Parse timezone offset if present
-    if let Some(tz_str) = time_parts.get(1) {
-        if let Some(offset_secs) = parse_timezone_offset(tz_str) {
-            let offset = FixedOffset::east_opt(offset_secs)?;
-            let dt = naive_dt.and_local_timezone(offset).single()?;
-            return Some(dt.with_timezone(&Utc));
-        }
+    if let Some(tz_str) = time_parts.get(1)
+        && let Some(offset_secs) = parse_timezone_offset(tz_str)
+    {
+        let offset = FixedOffset::east_opt(offset_secs)?;
+        let dt = naive_dt.and_local_timezone(offset).single()?;
+        return Some(dt.with_timezone(&Utc));
     }
 
     Some(naive_dt.and_utc())
@@ -89,19 +89,18 @@ pub fn normalize_timezone_format(text: &str) -> String {
     // Check if ends with timezone like "+08:00" or "-05:30" (6 chars)
     if len >= 6 {
         let suffix = &text[len - 6..];
-        if let Some(sign) = suffix.chars().next() {
-            if (sign == '+' || sign == '-')
-                && suffix.chars().nth(3) == Some(':')
-                && suffix[1..3].chars().all(|c| c.is_ascii_digit())
-                && suffix[4..6].chars().all(|c| c.is_ascii_digit())
-            {
-                // Convert "+08:00" to "+0800"
-                let mut result = text[..len - 6].to_string();
-                result.push(sign);
-                result.push_str(&suffix[1..3]);
-                result.push_str(&suffix[4..6]);
-                return result;
-            }
+        if let Some(sign) = suffix.chars().next()
+            && (sign == '+' || sign == '-')
+            && suffix.chars().nth(3) == Some(':')
+            && suffix[1..3].chars().all(|c| c.is_ascii_digit())
+            && suffix[4..6].chars().all(|c| c.is_ascii_digit())
+        {
+            // Convert "+08:00" to "+0800"
+            let mut result = text[..len - 6].to_string();
+            result.push(sign);
+            result.push_str(&suffix[1..3]);
+            result.push_str(&suffix[4..6]);
+            return result;
         }
     }
 

--- a/src/utils/url_validation.rs
+++ b/src/utils/url_validation.rs
@@ -56,19 +56,19 @@ pub fn validate_url(url: &Url) -> Result<(), UrlValidationError> {
     }
 
     // Try to parse as IP address and check for private ranges
-    if let Ok(ip) = host.parse::<IpAddr>() {
-        if is_private_ip(&ip) {
-            return Err(UrlValidationError::PrivateIp);
-        }
+    if let Ok(ip) = host.parse::<IpAddr>()
+        && is_private_ip(&ip)
+    {
+        return Err(UrlValidationError::PrivateIp);
     }
 
     // Also check if it's an IPv6 address in brackets
-    if host.starts_with('[') && host.ends_with(']') {
-        if let Ok(ip) = host[1..host.len() - 1].parse::<IpAddr>() {
-            if is_private_ip(&ip) {
-                return Err(UrlValidationError::PrivateIp);
-            }
-        }
+    if host.starts_with('[')
+        && host.ends_with(']')
+        && let Ok(ip) = host[1..host.len() - 1].parse::<IpAddr>()
+        && is_private_ip(&ip)
+    {
+        return Err(UrlValidationError::PrivateIp);
     }
 
     Ok(())

--- a/tests/auth_test.rs
+++ b/tests/auth_test.rs
@@ -1,11 +1,11 @@
 mod common;
 use common::default_test_config;
 
-use axum::http::{header, StatusCode};
+use axum::http::{StatusCode, header};
 use axum_test::TestServer;
 use chrono::{DateTime, Duration, Utc};
-use rdrs::{auth, create_router, db, services, AppState, Config, DbPool};
-use rusqlite::{params, Connection};
+use rdrs::{AppState, Config, DbPool, auth, create_router, db, services};
+use rusqlite::{Connection, params};
 use serde_json::json;
 
 fn open_shared_memory(name: &str) -> Connection {

--- a/tests/compression_test.rs
+++ b/tests/compression_test.rs
@@ -6,9 +6,9 @@ use common::default_test_config;
 
 use std::sync::Arc;
 
-use axum::http::{header, HeaderValue};
+use axum::http::{HeaderValue, header};
 use axum_test::TestServer;
-use rdrs::{auth, create_router, db, services, AppState, Config, DbPool};
+use rdrs::{AppState, Config, DbPool, auth, create_router, db, services};
 use rusqlite::Connection;
 
 fn open_shared_memory(name: &str) -> Connection {

--- a/tests/entry_handlers_test.rs
+++ b/tests/entry_handlers_test.rs
@@ -20,7 +20,7 @@ use common::default_test_config;
 use std::sync::Arc;
 
 use axum_test::TestServer;
-use rdrs::{auth, create_router, db, services, AppState, Config, DbPool, Role};
+use rdrs::{AppState, Config, DbPool, Role, auth, create_router, db, services};
 use rusqlite::Connection;
 use serde_json::json;
 

--- a/tests/etag_test.rs
+++ b/tests/etag_test.rs
@@ -8,9 +8,9 @@ use common::default_test_config;
 
 use std::sync::Arc;
 
-use axum::http::{header, HeaderValue, StatusCode};
+use axum::http::{HeaderValue, StatusCode, header};
 use axum_test::TestServer;
-use rdrs::{auth, create_router, db, services, AppState, Config, DbPool};
+use rdrs::{AppState, Config, DbPool, auth, create_router, db, services};
 use rusqlite::Connection;
 
 fn open_shared_memory(name: &str) -> Connection {

--- a/tests/forward_auth_test.rs
+++ b/tests/forward_auth_test.rs
@@ -7,8 +7,8 @@ use std::sync::Arc;
 use axum::http::{HeaderMap, HeaderName};
 use axum_test::TestServer;
 use rdrs::{
-    auth, config::parse_trusted_networks, create_router, db,
-    middleware::forward_auth::forward_auth_identity, services, AppState, Config, DbPool,
+    AppState, Config, DbPool, auth, config::parse_trusted_networks, create_router, db,
+    middleware::forward_auth::forward_auth_identity, services,
 };
 use rusqlite::Connection;
 

--- a/tests/greader_test.rs
+++ b/tests/greader_test.rs
@@ -15,10 +15,10 @@ use common::default_test_config;
 
 use std::sync::Arc;
 
-use axum::http::{header, HeaderValue, StatusCode};
+use axum::http::{HeaderValue, StatusCode, header};
 use axum_test::TestServer;
 use rdrs::models::{category, entry, feed};
-use rdrs::{auth, create_router, db, services, AppState, Config, DbPool};
+use rdrs::{AppState, Config, DbPool, auth, create_router, db, services};
 use rusqlite::Connection;
 use serde_json::json;
 use wiremock::matchers::{method, path_regex};

--- a/tests/handlers_test.rs
+++ b/tests/handlers_test.rs
@@ -13,10 +13,10 @@ use common::default_test_config;
 
 use std::sync::Arc;
 
-use axum::http::{header, HeaderName, HeaderValue, StatusCode};
-use axum_test::multipart::{MultipartForm, Part};
+use axum::http::{HeaderName, HeaderValue, StatusCode, header};
 use axum_test::TestServer;
-use rdrs::{auth, create_router, db, services, AppState, Config, DbPool, Role};
+use axum_test::multipart::{MultipartForm, Part};
+use rdrs::{AppState, Config, DbPool, Role, auth, create_router, db, services};
 use rusqlite::Connection;
 use serde_json::json;
 
@@ -1706,10 +1706,12 @@ async fn test_passkey_auth_start_with_invalid_passkey_data() {
     response.assert_status_unauthorized();
 
     let body: serde_json::Value = response.json();
-    assert!(body["error"]
-        .as_str()
-        .unwrap()
-        .contains("No valid passkeys"));
+    assert!(
+        body["error"]
+            .as_str()
+            .unwrap()
+            .contains("No valid passkeys")
+    );
 }
 
 #[tokio::test]

--- a/tests/pages_test.rs
+++ b/tests/pages_test.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use axum::http::StatusCode;
 use axum_test::TestServer;
 use chrono::TimeZone;
-use rdrs::{auth, create_router, db, services, AppState, Config, DbPool, Role};
+use rdrs::{AppState, Config, DbPool, Role, auth, create_router, db, services};
 use rusqlite::Connection;
 use serde_json::json;
 
@@ -313,7 +313,7 @@ async fn test_unread_page_entry_query_invalid_id_falls_back_to_empty_pane() {
 async fn test_unread_page_entry_query_other_user_falls_back_to_empty_pane() {
     let app = create_test_app_named(default_test_config(), "test_unread_entry_query_other_user");
     setup_users(&app.db).await; // creates `admin` and `user`
-                                // Entry belongs to `user`; we log in as `admin`.
+    // Entry belongs to `user`; we log in as `admin`.
     let entry_id = seed_one_entry(&app.db, "user", "cross-user").await;
     login(&app.server, "admin").await;
 

--- a/tests/statistics_test.rs
+++ b/tests/statistics_test.rs
@@ -5,9 +5,9 @@ use std::sync::Arc;
 
 use axum::http::StatusCode;
 use axum_test::TestServer;
-use rdrs::{auth, create_router, db, services, AppState, Config, DbPool, Role};
+use rdrs::{AppState, Config, DbPool, Role, auth, create_router, db, services};
 use rusqlite::Connection;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 struct TestApp {
     server: TestServer,

--- a/tests/summary_cancel.rs
+++ b/tests/summary_cancel.rs
@@ -11,7 +11,7 @@ use common::default_test_config;
 use std::sync::Arc;
 
 use axum_test::TestServer;
-use rdrs::{auth, create_router, db, services, AppState, Config, DbPool, Role};
+use rdrs::{AppState, Config, DbPool, Role, auth, create_router, db, services};
 use rusqlite::Connection;
 use serde_json::json;
 use tokio_util::sync::CancellationToken;


### PR DESCRIPTION
## What

- **Migrate to Rust 2024 edition** (2021 → 2024). Code changes are the mechanical
  output of `cargo fix --edition` + `cargo clippy --fix` (let-chains, a
  let-and-return cleanup); no behavioral changes intended.
- Add `deny.toml` (advisories / licenses / bans / sources) and a `cargo-deny` CI
  job, matching the other Rust projects.
- Replace the hand-rolled `actions/cache` blocks with `Swatinem/rust-cache`
  (SHA-pinned `v2.9.1`); the Playwright browser cache is left as-is.

## License allowlist

- `MPL-2.0` allowed (webauthn-rs + the scraper/cssparser/selectors stack — real
  runtime deps).
- `libfuzzer-sys`'s NCSA arm scoped via a per-crate exception rather than
  widening the global allowlist.

## Security advisories surfaced by cargo-deny

Fixed via `Cargo.lock`: `rustls-webpki` → 0.103.13, `rand` → 0.9.4 / 0.8.6.

Documented in `deny.toml`'s ignore list:
- `RUSTSEC-2026-0105` (core2 unmaintained/yanked), `RUSTSEC-2024-0436` (paste
  unmaintained) — no maintained replacement.
- `RUSTSEC-2026-0186` — memmap2; fixed in 0.9.11, but that release is younger
  than the 7-day dependency cooldown. **Re-bump and drop the ignore once it ages
  out.**

## Verification

`cargo fmt`, `cargo clippy -- -D warnings`, `cargo deny check`, and
`cargo nextest run` (978 passed) all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)