### PR TITLE
build: ship a static musl Docker image via cargo-zigbuild

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,8 +20,8 @@ jobs:
         id: version
         run: echo "GIT_VERSION=$(git describe --tags --always --dirty)" >> $GITHUB_OUTPUT
 
-      - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
-
+      # No qemu: the Dockerfile builder is pinned to the native platform and zig
+      # cross-compiles both musl targets, so the arm64 image needs no emulation.
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,71 +1,63 @@
-# Stage 1: Chef - prepare recipe (runs on build platform)
-FROM --platform=$BUILDPLATFORM rust:1.96-bookworm AS chef
-RUN cargo install cargo-chef
+# syntax=docker/dockerfile:1
+
+# ---- build: cross-compile a static musl binary with cargo-zigbuild ----------
+# The builder is pinned to the native build platform; zig cross-compiles to the
+# target arch's musl triple, so no qemu emulation is needed — an arm64 image
+# builds at the host's native speed. The C dependencies — vendored OpenSSL
+# (pulled in by webauthn-rs), bundled SQLite, and mimalloc — are all compiled by
+# zig cc. OpenSSL's build driver (perl + make) and the favicon renderer (resvg,
+# pure Rust) need no extra system packages: perl and make already ship in the
+# rust:bookworm (buildpack-deps) base, so only zig has to be fetched.
+FROM --platform=$BUILDPLATFORM rust:1.96-bookworm AS build
+
+# curl + xz fetch zig; that is the only build-time system dependency.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl xz-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+# Zig 0.14.1 avoids the libc++-19 bindgen requirement that 0.15+ introduces.
+ARG ZIG_VERSION=0.14.1
+ARG ZIGBUILD_VERSION=0.22.3
+RUN cargo install cargo-zigbuild --version "${ZIGBUILD_VERSION}" --locked
+RUN set -eux; \
+    case "$(uname -m)" in \
+      x86_64) zarch=x86_64 ;; \
+      aarch64) zarch=aarch64 ;; \
+      *) echo "unsupported build arch $(uname -m)" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL "https://ziglang.org/download/${ZIG_VERSION}/zig-${zarch}-linux-${ZIG_VERSION}.tar.xz" \
+      | tar -xJ -C /opt; \
+    ln -s "/opt/zig-${zarch}-linux-${ZIG_VERSION}/zig" /usr/local/bin/zig
+
 WORKDIR /app
-
-# Stage 2: Planner - create recipe.json
-FROM chef AS planner
 COPY . .
-RUN cargo chef prepare --recipe-path recipe.json
 
-# Stage 3: Builder - cross-compile for target platform
-FROM chef AS builder
-
-# Target platform args (set by docker buildx)
-ARG TARGETPLATFORM
+# Map Docker's TARGETARCH onto the Rust musl triple and build. `rustup target
+# add` runs after the source (and rust-toolchain.toml) is in place, so it
+# resolves against the pinned toolchain rather than the base image's default.
+# .git is excluded by .dockerignore, so build.rs reads the version from the
+# GIT_VERSION build arg the CI workflow passes.
+ARG TARGETARCH
 ARG GIT_VERSION=dev
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/app/target,sharing=locked \
+    set -eux; \
+    case "$TARGETARCH" in \
+      amd64) target=x86_64-unknown-linux-musl ;; \
+      arm64) target=aarch64-unknown-linux-musl ;; \
+      *) echo "unsupported target arch $TARGETARCH" >&2; exit 1 ;; \
+    esac; \
+    rustup target add "$target"; \
+    GIT_VERSION="${GIT_VERSION}" cargo zigbuild --release --target "$target"; \
+    install -Dm755 "target/${target}/release/rdrs" /out/rdrs
 
-# Copy the toolchain pin BEFORE any rustup invocation so that rustup resolves
-# against the pinned toolchain (rust-toolchain.toml) rather than whatever patch
-# version the base image happens to ship. Without this the base image's default
-# toolchain gets the cross-compile target installed, and then `cargo build`
-# downloads the pinned toolchain fresh (without the target) and fails.
-COPY rust-toolchain.toml .
+# ---- runtime: minimal static image (CA certs + tzdata, no shell) ------------
+# distroless/static (not :nonroot) keeps the root runtime user the previous
+# distroless/cc image defaulted to, so the bind-mounted /data SQLite file stays
+# writable without a permissions change.
+FROM gcr.io/distroless/static-debian12
 
-# Install cross-compilation toolchain based on target
-RUN case "$TARGETPLATFORM" in \
-        "linux/arm64") \
-            apt-get update && apt-get install -y gcc-aarch64-linux-gnu && \
-            rustup target add aarch64-unknown-linux-gnu \
-            ;; \
-        "linux/amd64") \
-            # Native build, no extra toolchain needed \
-            ;; \
-    esac
-
-# Configure cargo for cross-compilation
-RUN mkdir -p .cargo && \
-    case "$TARGETPLATFORM" in \
-        "linux/arm64") \
-            echo '[target.aarch64-unknown-linux-gnu]' >> .cargo/config.toml && \
-            echo 'linker = "aarch64-linux-gnu-gcc"' >> .cargo/config.toml \
-            ;; \
-    esac
-
-# Set the Rust target based on platform
-RUN case "$TARGETPLATFORM" in \
-        "linux/arm64") echo "aarch64-unknown-linux-gnu" > /tmp/rust_target ;; \
-        "linux/amd64") echo "x86_64-unknown-linux-gnu" > /tmp/rust_target ;; \
-        *) echo "x86_64-unknown-linux-gnu" > /tmp/rust_target ;; \
-    esac
-
-COPY --from=planner /app/recipe.json recipe.json
-
-# Cook dependencies with target
-RUN RUST_TARGET=$(cat /tmp/rust_target) && \
-    cargo chef cook --release --recipe-path recipe.json --target $RUST_TARGET
-
-COPY . .
-
-# Build the application
-RUN RUST_TARGET=$(cat /tmp/rust_target) && \
-    GIT_VERSION=${GIT_VERSION} cargo build --release --target $RUST_TARGET && \
-    cp target/$RUST_TARGET/release/rdrs /app/rdrs
-
-# Stage 4: Runtime
-FROM gcr.io/distroless/cc-debian12
-
-COPY --from=builder /app/rdrs /rdrs
+COPY --from=build /out/rdrs /rdrs
 
 VOLUME /data
 


### PR DESCRIPTION
## What

Replace the `cargo-chef` + glibc + `distroless/cc-debian12` Docker build with a
`cargo-zigbuild` static-musl build on `distroless/static-debian12`, mirroring the
recipe already shipped in the sibling services (lur, comics, noadd, liftlog).

## Why

- **No qemu.** The builder is pinned to `$BUILDPLATFORM`; zig cross-compiles both
  musl targets, so the multi-arch image builds at native speed instead of under
  arm64 emulation.
- **Smaller, fully-static image.** A single statically-linked binary on
  `distroless/static-debian12` — no glibc, no `cc` runtime layer.

## Notes

- The only hard part was **vendored OpenSSL** (pulled in transitively by
  `webauthn-rs`); it compiles cleanly under `zig cc`. The bundled SQLite and
  mimalloc do too. OpenSSL's perl + make build driver already ships in the
  `rust:bookworm` (buildpack-deps) base, so no extra apt packages are needed.
- Runtime stays **root** (`static`, not `:nonroot`) so the bind-mounted `/data`
  SQLite file remains writable — no behavior change from the previous `cc` image.
- `mimalloc` was already wired as the global allocator; no source change required.

## Verification

Built locally for `linux/arm64` (release LTO) and smoke-tested:

- Binary: `ELF 64-bit ARM aarch64, statically linked, stripped` (~16.5 MB; image ~32 MB).
- Boot: migrations run, SQLite DB created under `/data` in WAL mode.
- HTTP: `GET /login` → 200, unauthenticated `GET /` → 303 redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)