### PR TITLE
ci: re-enable build provenance and tidy docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,21 +15,17 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0  # Fetch full history for git describe
-
       - name: Get version from git
         id: version
         run: echo "GIT_VERSION=$(git describe --tags --always --dirty)" >> $GITHUB_OUTPUT
-
       # No qemu: the Dockerfile builder is pinned to the native platform and zig
       # cross-compiles both musl targets, so the arm64 image needs no emulation.
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
-
       - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
       - uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
         id: meta
         with:
@@ -38,7 +34,6 @@ jobs:
             type=ref,event=branch
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-
       - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .
@@ -50,5 +45,3 @@ jobs:
             GIT_VERSION=${{ steps.version.outputs.GIT_VERSION }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          # Provenance false avoids unknown/unknown platform in manifest
-          provenance: false


### PR DESCRIPTION
## What

- Remove `provenance: false` so buildx attaches its default SLSA provenance
  attestation.
- Drop the blank lines between steps in the Docker workflow (keeping top-level
  block separators).

## Why

Provenance gives a verifiable record of how the image was built (source repo,
commit, build parameters), which complements the existing supply-chain gates
(`cargo deny`, dependency cooldown). The attestation lives in a separate
`unknown/unknown` manifest that `docker pull`/`run` never fetch, so **the
runtime image size is unchanged** — only a few KB of registry metadata is added.

This also realigns rdrs with the sibling services, none of which set
`provenance: false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)