### PR TITLE
fix: keep copy icon when summary Copy button shows "Copied!"

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1173,9 +1173,13 @@ function installSummaryActions() {
             const text = parts.join('\n\n');
             try {
                 await navigator.clipboard.writeText(text);
-                const original = copyBtn.textContent;
-                copyBtn.textContent = 'Copied!';
-                setTimeout(() => { copyBtn.textContent = original; }, 2000);
+                // Only swap the label span's text — writing to the button's
+                // textContent would clobber the icon span too, dropping the
+                // copy glyph until the container re-renders.
+                const label = copyBtn.querySelector('.action-label') || copyBtn;
+                const original = label.textContent;
+                label.textContent = 'Copied!';
+                setTimeout(() => { label.textContent = original; }, 2000);
             } catch {
                 window.flash?.error('Failed to copy to clipboard');
             }


### PR DESCRIPTION
## Problem

When the summary **Copy** button is pressed, it flips to "Copied!" — but on the **first** click the copy icon disappears and the button visibly reflows (it reads as a second button stacking underneath). A second click no longer reproduces it.

## Root cause

The button is composed of two children: a `<span class="action-icon">` (copy SVG) and a `<span class="action-label">Copy</span>`. The click handler did:

```js
const original = copyBtn.textContent;   // "Copy"
copyBtn.textContent = 'Copied!';
setTimeout(() => { copyBtn.textContent = original; }, 2000);
```

Assigning to `Element.textContent` removes **all** child nodes and replaces them with a single text node, so the first click clobbers the icon span. Restoring `original` (a plain string) brings back only the text, not the icon — leaving the button as bare text until the container re-renders. The second click no longer has an icon to destroy, hence no reflow.

## Fix

Mutate only the `.action-label` span's text, leaving the icon span intact.

## Notes

- JS is embedded via `include_str!`; rebuilt locally with `cargo build`.
- No E2E test covered the copy action; steady-state UI is unchanged (the icon was always meant to be present), so screenshots are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)