### PR TITLE
fix(ui): reading-view layout and interaction polish

### DIFF
--- a/docs/superpowers/plans/2026-07-04-fluid-pane-widths.md
+++ b/docs/superpowers/plans/2026-07-04-fluid-pane-widths.md
@@ -1,0 +1,105 @@
+# Fluid Sidebar / List-Pane Widths Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the sidebar and entry-list widths scale fluidly on mid-width screens so the reading pane is no longer cramped on iPad Air 11" landscape (1180px), while leaving 1440px unchanged.
+
+**Architecture:** Change two CSS custom properties in `static/css/app.css` `:root` from fixed pixels to `clamp()` so they scale between a floor and their current cap. Both variables already flow through every consumer (`.sidebar`, `.main-content`, `.list-pane`) so no rule bodies change. Verify visually across viewports and regenerate the README screenshots.
+
+**Tech Stack:** Vanilla CSS (no build tooling); assets are `include_str!`-embedded into the Rust binary, so a `cargo build` is required before E2E/screenshots see the edit. Screenshots via Playwright (`e2e/`).
+
+## Global Constraints
+
+- Assets are compiled into the binary via `include_str!`/`include_bytes!`; **`cargo build` before any E2E/screenshot run** or it runs against stale CSS.
+- UI changes MUST regenerate the four `screenshots/` images (referenced by `README.md`) in the same change.
+- Commits MUST be GPG-signed; stage files explicitly by name (no `git add -A`/`.`).
+- No new media query, no change to the `max-width: 1024px` collapse breakpoint, the `min-width: 1600px` `--list-pane-width: 400px` override, or `--content-max-width: 720px`.
+- Floor values are fixed: sidebar `200px`, list-pane `320px` (approved, do not change).
+
+---
+
+### Task 1: Make sidebar and list-pane widths fluid
+
+**Files:**
+- Modify: `static/css/app.css:89-90` (the `--sidebar-width` and `--list-pane-width` declarations in `:root`)
+
+**Interfaces:**
+- Consumes: nothing (leaf change).
+- Produces: fluid `--sidebar-width` / `--list-pane-width`; consumers `.sidebar { width; min-width }`, `.main-content { margin-left }`, `.list-pane { width; min-width }` inherit the new behaviour unchanged.
+
+- [ ] **Step 1: Confirm the current declarations**
+
+Read `static/css/app.css` around lines 88–91. Expected:
+
+```css
+    /* Layout */
+    --sidebar-width: 232px;
+    --list-pane-width: 392px;
+```
+
+- [ ] **Step 2: Replace the two fixed values with clamp()**
+
+```css
+    /* Layout — fluid on mid-width screens (1024–1440) so the reading pane
+       isn't cramped on ~1180px tablets; both cap at their prior fixed value. */
+    --sidebar-width: clamp(200px, 16vw, 232px);
+    --list-pane-width: clamp(320px, 28vw, 392px);
+```
+
+Leave every other declaration in the block (`--content-max-width`, `--page-max-width`, etc.) untouched. Leave the `@media (min-width: 1600px) { --list-pane-width: 400px; }` and `@media (max-width: 1024px)` blocks untouched.
+
+- [ ] **Step 3: Rebuild so the embedded CSS is current**
+
+Run: `cargo build`
+Expected: builds successfully (CSS is embedded at compile time).
+
+- [ ] **Step 4: Visual verification across viewports**
+
+Use the `verify` skill / a Playwright-driven browser to load a logged-in entries page and check these widths (DevTools or computed style):
+
+| Viewport | Expected sidebar | Expected list-pane | Expected reading-pane | Check |
+| --- | --- | --- | --- | --- |
+| 1180 × 820 | 200px (floor) | ~330px | ~650px | reading pane visibly roomier; no clipped entry rows |
+| 1280 × 800 | ~205px | ~358px | wider still | smooth, no jump |
+| 1440 × 900 | 232px (cap) | 392px (cap) | ~816px | **identical to before this change** |
+| 1024 × 768 | drawer (hidden) | 100% | overlay | collapse layout unaffected |
+
+Expected: smooth scaling, no horizontal overflow, list floor (320px) never clips the entry row time/star columns.
+
+- [ ] **Step 5: Regenerate README screenshots**
+
+Run: `cd e2e && npm run screenshots`
+Expected: the four images under `screenshots/` are rewritten (light/dark unread list + keyboard-help). Confirm they render without layout breakage.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add static/css/app.css screenshots/
+git commit -S -m "$(cat <<'EOF'
+fix(ui): fluid sidebar/list-pane widths for mid-width screens
+
+The sidebar (232px) and entry list (392px) were fixed widths, so their
+combined 624px chrome ate 53% of an iPad Air 11" landscape (1180px)
+viewport, cramping the reading pane to 556px. Make both variables fluid
+via clamp() so they scale between a floor (200/320px) and their prior
+value; caps preserve the 1440px layout and the >=1600px override.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Expected: one commit containing `static/css/app.css` and the updated `screenshots/`.
+
+---
+
+## Notes / Out of scope
+
+- **No new E2E test.** A viewport-width assertion would be brittle (pixel maths against clamp/vw) and the change carries no logic branch to guard — YAGNI. Verification is the visual check (Step 4) plus the regenerated screenshots. If desired later, an optional follow-up could add a Playwright check asserting `.reading-pane` is wider than `.list-pane` at 1180px.
+- Floor values (`200px` / `320px`) are locked per the approved spec.
+
+## Self-Review
+
+- **Spec coverage:** The single spec change (two clamp values) → Task 1 Step 2. Behaviour table, 1600px override preservation, 1024px collapse non-interference, verification (rebuild → visual → screenshots) → Steps 3–5. Covered.
+- **Placeholder scan:** No TBD/TODO; exact code and commands in every step.
+- **Type consistency:** N/A (CSS); variable names `--sidebar-width` / `--list-pane-width` match the spec and existing consumers verbatim.

--- a/docs/superpowers/specs/2026-07-04-fluid-pane-widths-design.md
+++ b/docs/superpowers/specs/2026-07-04-fluid-pane-widths-design.md
@@ -1,0 +1,99 @@
+# Fluid sidebar / list-pane widths for mid-width screens
+
+**Date:** 2026-07-04
+**Branch:** `fix/tablet-pane-proportions`
+**Status:** Design — awaiting review
+
+## Problem
+
+On the iPad Air 11" (M3) in landscape (1180 × 820 CSS px) the three-pane reading
+layout feels cramped: the sidebar and entry list take up too large a share of the
+width, squeezing the reading pane. On a 1440 × 900 monitor the same layout feels
+well balanced.
+
+The three-pane layout applies at any viewport wider than the `max-width: 1024px`
+collapse breakpoint. Both the sidebar and the entry list are **fixed widths** that
+do not scale with the viewport:
+
+- `--sidebar-width: 232px`
+- `--list-pane-width: 392px` (bumped to `400px` at `min-width: 1600px`)
+
+So the fixed chrome is a constant **624px** regardless of screen width. As a share
+of the viewport that is:
+
+| Viewport | Fixed chrome | reading-pane | chrome share |
+| --- | --- | --- | --- |
+| 1440 × 900 (comfortable) | 624px | 816px (content capped 720) | 43% |
+| 1180 × 820 iPad Air landscape (cramped) | 624px | **556px** (below the 720 cap) | **53%** |
+
+The iPad sits just above the 1024px breakpoint, so it uses the desktop three-pane
+layout, and the un-scaling 624px chrome eats over half the width.
+
+## Chosen approach — B: fluid widths via `clamp()`
+
+Make the two layout variables scale proportionally between a floor and the current
+values, instead of adding a new media query. Selected over the alternatives (A: a
+targeted `1025–1400px` media query; C: raising the collapse breakpoint to ~1200px)
+because it is the smallest change (two variable values, no new breakpoint), fixes
+**every** width between 1024px and 1440px smoothly with no boundary jumps, and
+preserves the comfortable side-by-side three-pane layout the user likes at 1440px.
+
+### Change
+
+In `static/css/app.css` `:root`:
+
+```css
+--sidebar-width: clamp(200px, 16vw, 232px);
+--list-pane-width: clamp(320px, 28vw, 392px);
+```
+
+Everything else is unchanged. Both variables already flow through consistently:
+
+- `--sidebar-width` drives `.sidebar { width; min-width }` and
+  `.main-content { margin-left }` — they stay in sync because they read the same
+  variable.
+- `--list-pane-width` drives `.list-pane { width; min-width }`.
+- The `@media (min-width: 1600px)` override to `--list-pane-width: 400px` stays as
+  is; it takes over above 1600px and preserves the wide-screen bump. (Between 1400
+  and 1600 the clamp caps at 392, then steps to 400 at 1600 — an 8px step,
+  negligible.)
+- The `@media (max-width: 1024px)` block already overrides `.list-pane { width:
+  100%; min-width: 0 }` and hides/repositions the sidebar, so the clamp has no
+  effect below the collapse breakpoint.
+
+### Resulting behaviour
+
+| Viewport | sidebar | list-pane | reading-pane | chrome share |
+| --- | --- | --- | --- | --- |
+| 1180 (iPad Air landscape) | 200 (floor) | 330 | **650** | 45% |
+| 1440 (unchanged feel) | ~230 → 232 | 392 (cap) | ~816 | 43% |
+| ≥1600 | 232 | 400 (existing override) | — | — |
+
+- Sidebar reaches its 232px cap at ~1450px viewport; below ~1250px it rests at the
+  200px floor.
+- List-pane reaches its 392px cap at 1400px viewport; below ~1143px it rests at the
+  320px floor.
+- At 1180px the reading pane recovers from 556px to ~650px.
+
+## Out of scope
+
+- No change to the 1024px collapse breakpoint or the mobile/drawer layout.
+- No change to `--content-max-width` (720px) or reading-pane internals.
+- Floor values (`200px` / `320px`) are the proposed defaults; adjustable at review
+  (e.g. hold the list floor at 340px).
+
+## Verification
+
+1. `cargo build` (assets are `include_str!`-embedded, so a rebuild is required
+   before E2E / screenshots see CSS edits).
+2. Visual check at 1180 × 820, 1280, 1366, and 1440 × 900 — confirm smooth scaling,
+   no layout break, list floor never clips entry rows.
+3. Regenerate README screenshots: `cd e2e && npm run screenshots` (the four images
+   under `screenshots/` are part of any UI change).
+4. `cargo fmt --all -- --check` is irrelevant (CSS only); no Rust or test changes.
+
+## Risks
+
+- Very low. Pure CSS variable change. Main risk is a floor value that clips content
+  at the narrow end — mitigated by the 320px list floor (wider than the 1024px
+  collapse) and by the visual check above.

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -85,9 +85,10 @@
     --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
     --shadow-lg: 0 24px 64px rgba(27,28,30,0.18);
 
-    /* Layout */
-    --sidebar-width: 232px;
-    --list-pane-width: 392px;
+    /* Layout — fluid on mid-width screens (1024–1440) so the reading pane
+       isn't cramped on ~1180px tablets; both cap at their prior fixed value. */
+    --sidebar-width: clamp(200px, 16vw, 232px);
+    --list-pane-width: clamp(320px, 28vw, 392px);
     --content-max-width: 720px;
     --page-max-width: 1080px;
     /* Comfortable width for stacked form fields and 2-column info tables on

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -1429,6 +1429,10 @@ td input[type="text"] {
 .entry-item-meta a { color: var(--color-text-secondary); font-weight: 500; text-decoration: none; }
 .entry-item-meta a:hover { color: var(--color-accent); }
 .entry-item.entry-read .entry-item-meta a { color: var(--color-text-muted); font-weight: 400; }
+/* The read-state rule above (0,3,1) out-specifies the generic `a:hover` (0,2,1),
+   so read rows lost their meta-link hover feedback. Restore it with a matching
+   read-scoped hover (0,4,1). */
+.entry-item.entry-read .entry-item-meta a:hover { color: var(--color-accent); }
 .entry-item-meta .meta-sep { color: var(--color-text-muted); margin: 0 3px; }
 
 /* Favicon in the meta line — 15px, 3px radius, letter-tile fallback. Both the

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -279,8 +279,10 @@ code {
     left: 0;
     bottom: 0;
     z-index: 100;
-    overflow-y: auto;
-    overflow-x: hidden;
+    /* The sidebar itself no longer scrolls; the nav scrolls internally so the
+       header and footer stay pinned to the top and bottom (mirrors .list-pane's
+       header + scrolling body). */
+    overflow: hidden;
 }
 
 .sidebar-header {
@@ -288,6 +290,7 @@ code {
     display: flex;
     align-items: center;
     justify-content: space-between;
+    flex-shrink: 0;
 }
 
 .sidebar-logo {
@@ -316,6 +319,10 @@ code {
 
 .sidebar-nav {
     flex: 1;
+    /* min-height:0 lets this flex child shrink below its content height so
+       overflow-y can actually scroll instead of pushing the footer off-screen. */
+    min-height: 0;
+    overflow-y: auto;
     padding: 0 var(--space-3);
     display: flex;
     flex-direction: column;
@@ -412,6 +419,8 @@ code {
     justify-content: space-between;
     gap: var(--space-2);
     font-size: var(--font-sm);
+    /* Stays pinned to the bottom while .sidebar-nav scrolls. */
+    flex-shrink: 0;
 }
 
 .sidebar-user {


### PR DESCRIPTION
Three independent UI fixes surfaced while testing on an iPad Air 11" (M3) in landscape, bundled together.

## 1. Fluid sidebar / list-pane widths for mid-width screens
The sidebar (`232px`) and entry list (`392px`) were fixed widths, so their combined `624px` chrome ate **53%** of an iPad Air 11" landscape (`1180px`) viewport, cramping the reading pane to `556px` — while feeling well-balanced at `1440px` (43%). Made both variables fluid via `clamp()`:

```css
--sidebar-width: clamp(200px, 16vw, 232px);
--list-pane-width: clamp(320px, 28vw, 392px);
```

They scale smoothly between a floor and their prior value with no new breakpoint; the caps preserve the `1440px` layout and the `>=1600px` override. At `1180px` the reading pane recovers **556px → 650px**. Verified across 1024–1440px: no horizontal overflow, `1440px` unchanged.

Design spec and implementation plan are included under `docs/superpowers/`.

## 2. Restore meta-link hover feedback on read entry rows
`.entry-item.entry-read .entry-item-meta a` (specificity `0,3,1`) out-specified the generic `.entry-item-meta a:hover` (`0,2,1`), so hovering a **read** entry's feed/category link showed no color change. Added a read-scoped hover rule (`0,4,1`) restoring the accent hover. Unread rows are unaffected. Verified via a computed-style probe: read-row meta link now transitions muted → accent on hover.

## 3. Pin sidebar footer to the bottom
The whole sidebar was the scroll container, so with many feeds/categories the footer (user + Sign Out) scrolled out of view below the fold. Moved the scroll into `.sidebar-nav` (`flex:1; min-height:0; overflow-y:auto`) and marked the header/footer `flex-shrink:0`, mirroring `.list-pane`'s fixed header + scrolling body. Verified with 25 seeded categories at a 700px-tall viewport: the nav scrolls, the footer stays pinned to the bottom.

## Testing
- Full Rust suite green: `981 passed`.
- Each change verified end-to-end with a temporary Playwright computed-style/geometry probe (removed after verifying).
- No screenshot changes: the CSS caps to identical values at the `1920px` screenshot viewport, and the hover/scroll behaviours aren't captured in a static screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)