### PR TITLE
fix(ui): style the scoped-search input

### DIFF
--- a/static/css/app.css
+++ b/static/css/app.css
@@ -1058,6 +1058,7 @@ input[type="text"],
 input[type="password"],
 input[type="url"],
 input[type="number"],
+input[type="search"],
 select {
     width: 100%;
     padding: var(--space-2) var(--space-3);
@@ -1068,6 +1069,20 @@ select {
     background: var(--color-bg);
     color: var(--color-text);
     transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+/* Strip WebKit's native searchfield chrome (inset rounding, magnifier, and
+   the inner clear button) so type="search" boxes — the scoped-search input —
+   render identically to the other text inputs above. */
+input[type="search"] {
+    -webkit-appearance: none;
+    appearance: none;
+}
+
+input[type="search"]::-webkit-search-decoration,
+input[type="search"]::-webkit-search-cancel-button {
+    -webkit-appearance: none;
+    appearance: none;
 }
 
 select {


### PR DESCRIPTION
## Summary

The scoped-search box on category/feed views is an `input[type="search"]`, but the shared **desktop** input styling in `static/css/app.css` only covered `text` / `password` / `url` / `number`. The field fell through to the browser's native searchfield chrome (wrong size, inset rounding, magnifier/clear decorations) with none of the app's border, radius, padding, or font. The mobile breakpoint already listed `input[type="search"]`, confirming the desktop omission.

## What changed

- Add `input[type="search"]` to the shared input selector block.
- Strip WebKit's native searchfield appearance and inner decorations (`::-webkit-search-decoration`, `::-webkit-search-cancel-button`) so the box renders identically to the other inputs.

Only the scoped-search box uses `type="search"` in the whole app, so the change is scoped to it.

## Testing

- Verified end-to-end via Playwright in **light and dark**: computed style now reports `appearance: none`, `1px solid` border (theme-aware), `6px` radius, `8px 12px` padding, and the UI font — matching the adjacent filter selects. Screenshots confirm the box renders as a normal full-width field in both themes.
- The four README screenshots (unread list, keyboard-help) render views where `search_action` is `None`, so they do not show this field and are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)