### PR TITLE
fix(ui): unify Mark-matching button style, add confirm, drop btn-sm

### DIFF
--- a/e2e/features/triage.feature
+++ b/e2e/features/triage.feature
@@ -76,5 +76,5 @@ Feature: Triage entries (star, mark-read, summarize)
     And I type "Superheroine" into the scoped search box
     Then the entry list shows "Superheroine Rises"
     And the entry list does not show "Other News"
-    When I click "Mark 1 matching as Read"
+    When I mark matching entries as read
     Then "Superheroine Rises" is no longer in the unread list

--- a/e2e/steps/scoped_search.steps.js
+++ b/e2e/steps/scoped_search.steps.js
@@ -50,6 +50,15 @@ Then("the entry list does not show {string}", async ({ page }, title) => {
   await expect(page.getByTestId("entry-item").filter({ hasText: title })).toHaveCount(0);
 });
 
+When("I mark matching entries as read", async ({ page }) => {
+  // The "Mark N matching as Read" form submits through an onsubmit
+  // window.confirm. Arm the one-shot dialog handler and trigger the click in
+  // the same step so the accept is in place before the prompt fires (a
+  // separate pre-arming step races the native form submit here).
+  page.once("dialog", (dialog) => dialog.accept());
+  await page.getByTestId("mark-matching-btn").click();
+});
+
 Then("{string} is no longer in the unread list", async ({ page }, title) => {
   // "Mark matching as Read" POSTs and redirects back to the same scoped
   // (q=…) unread-tab URL — the now-read entry drops out of the default

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -1175,9 +1175,7 @@ button:disabled {
     opacity: 1;
 }
 
-/* Compact size — shared by .btn-sm and any button/.btn inside an
-   .actions row. */
-.btn-sm,
+/* Compact size — any button/.btn inside an .actions row. */
 .actions button,
 .actions .btn {
     padding: var(--space-1) var(--space-2);
@@ -3096,13 +3094,6 @@ summary {
     margin-top: var(--space-4);
     margin-bottom: var(--space-4);
     padding: 0 var(--space-5);
-}
-
-/* "Mark Above as Read" reads cramped at btn-sm on desktop; give it a
-   comfortable size. Mobile still gets 44px from the touch baseline. */
-#mark-above-read {
-    font-size: var(--font-sm);
-    padding: var(--space-2) var(--space-4);
 }
 
 /* Mobile: align load-more / mark-above wrappers with .entry-item (which drops

--- a/templates/_entries_list_body.html
+++ b/templates/_entries_list_body.html
@@ -32,7 +32,7 @@
     {% endif %}
     {% if entries_layout.show_mark_above %}
     <div class="mark-above-form">
-        <button id="mark-above-read" type="button" class="btn-secondary btn-sm" data-testid="mark-above-btn">Mark Above as Read</button>
+        <button id="mark-above-read" type="button" class="btn btn-secondary" data-testid="mark-above-btn">Mark Above as Read</button>
     </div>
     {% endif %}
 {% endif %}

--- a/templates/_mark_matching_button.html
+++ b/templates/_mark_matching_button.html
@@ -1,7 +1,7 @@
 {% if let Some(n) = entries_layout.matching_count %}{% if *n > 0 %}{% if let Some(action) = entries_layout.search_action.as_ref() %}
-<form class="form-group form-group-inline" method="post" action="{{ action }}/mark-read" data-testid="mark-matching-form">
+<form class="form-group form-group-inline" method="post" action="{{ action }}/mark-read" data-testid="mark-matching-form" onsubmit="return confirm('Mark {{ n }} matching entries as read?')">
     {% if let Some(s) = entries_layout.status_filter.as_ref() %}<input type="hidden" name="status" value="{{ s }}">{% endif %}
     {% if let Some(qq) = entries_layout.search.as_ref() %}<input type="hidden" name="q" value="{{ qq }}">{% endif %}
-    <button type="submit" class="btn-secondary btn-sm" data-testid="mark-matching-btn">Mark {{ n }} matching as Read</button>
+    <button type="submit" class="btn btn-secondary" data-testid="mark-matching-btn">Mark {{ n }} matching as Read</button>
 </form>
 {% endif %}{% endif %}{% endif %}


### PR DESCRIPTION
## Summary

- The **"Mark N matching as Read"** button (scoped-search bulk action) used `btn-sm`, rendering smaller than the adjacent selects and search input in the filter bar. Switch it to the standard `btn btn-secondary` size so it matches the other toolbar controls.
- Guard that bulk mark-read behind a `window.confirm` (`Mark N matching entries as read?`), consistent with other destructive/bulk actions.
- With the last real `btn-sm` user gone, clean up the leftover: **"Mark Above as Read"** already carried a `#mark-above-read` override that restored it to the standard size, so switch it to `btn btn-secondary`, remove the now-redundant override, and drop the dead `.btn-sm` selector from the compact-size rule (kept for `.actions` rows).

## Testing

- `cargo build` — templates/CSS are embedded via `include_str!`, rebuilt so E2E sees the change.
- Updated the scoped-search E2E scenario to accept the new confirm dialog via a dedicated compound step (arms the one-shot dialog handler in the same step as the click, mirroring the mark-all pattern).
- E2E green, including the responsive "Mark Above as Read button is comfortably sized on desktop" scenario — the button renders identically after the cleanup.
- README screenshots unaffected: the mark-matching button only appears with an active scoped search (not captured), and "Mark Above" is pixel-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)