### PR TITLE
fix(ui): use OS-default font smoothing in light mode

### DIFF
--- a/e2e/features/preferences.feature
+++ b/e2e/features/preferences.feature
@@ -8,10 +8,12 @@ Feature: Preferences
   Scenario: Switching to dark theme sets data-theme to dark
     When I switch the theme to "dark"
     Then the html element has data-theme "dark"
+    And the body uses "antialiased" font smoothing
 
   Scenario: Switching to light theme sets data-theme to light
     When I switch the theme to "light"
     Then the html element has data-theme "light"
+    And the body uses "auto" font smoothing
 
   Scenario: Switching to system theme removes the data-theme attribute
     When I switch the theme to "dark"

--- a/e2e/steps/preferences.steps.js
+++ b/e2e/steps/preferences.steps.js
@@ -22,6 +22,21 @@ Then("the html element has no data-theme attribute", async ({ page }) => {
   await expect(page.locator("html")).not.toHaveAttribute("data-theme");
 });
 
+Then("the body uses {string} font smoothing", async ({ page }, value) => {
+  // Light mode drops the global `-webkit-font-smoothing: antialiased` (which
+  // renders dark ink on light paper thin on macOS) back to the heavier `auto`;
+  // dark mode keeps `antialiased`. The computed value is deterministic across
+  // platforms even though the visual effect is macOS-only, so this guards the
+  // per-theme rule without depending on screenshot rendering.
+  await expect
+    .poll(() =>
+      page.evaluate(() =>
+        getComputedStyle(document.body).getPropertyValue("-webkit-font-smoothing")
+      )
+    )
+    .toBe(value);
+});
+
 When("I change my password to {string}", async ({ page, currentUser, serverUrl }, newPassword) => {
   await page.locator('form[action="/user-settings/password"] [data-testid="current-password"]').fill(currentUser.password);
   await page.locator('form[action="/user-settings/password"] [data-testid="new-password"]').fill(newPassword);

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -173,6 +173,24 @@ body {
     overflow-x: hidden;
 }
 
+/* Light mode: use the OS default (heavier) smoothing instead of `antialiased`.
+   On macOS `antialiased` renders dark ink on light paper spindly — most visible
+   in the serif reading text, whose CJK falls back to the system serif (Songti).
+   Dark mode keeps `antialiased` (light-on-dark blooms, so it stays crisp). This
+   inherits from `body` to all text. Covers both an explicit light pick and the
+   no-`data-theme` default when the OS is light; `[data-theme="dark"]` is
+   excluded so it keeps antialiased. */
+[data-theme="light"] body {
+    -webkit-font-smoothing: auto;
+    -moz-osx-font-smoothing: auto;
+}
+@media (prefers-color-scheme: light) {
+    html:not([data-theme]) body {
+        -webkit-font-smoothing: auto;
+        -moz-osx-font-smoothing: auto;
+    }
+}
+
 ::selection { background: var(--color-accent-wash-2); }
 
 /* Global focus ring — 2px accent, matches the prototype. */


### PR DESCRIPTION
## Problem
The serif reading text renders too thin in **light mode** (dark mode looks fine).

## Root cause
`<body>` sets `-webkit-font-smoothing: antialiased` globally. On macOS this renders dark ink on light paper spindly, while light text on a dark ground blooms and stays crisp — so only light mode looks anemic. It's most visible in the reading text: Newsreader is latin-only, so **CJK falls back to the system serif** (Songti on macOS), which the aggressive smoothing thins out further. This is a rendering/perception issue, not the typeface itself — hence dark mode is unaffected.

## Fix
Scope light mode back to the heavier OS default `auto` (keep `antialiased` for dark):
- `[data-theme="light"] body` — explicit light pick
- `@media (prefers-color-scheme: light) html:not([data-theme]) body` — the no-`data-theme` default when the OS is light

`font-smoothing` inherits from `body`, so this lifts all light-mode text. `[data-theme="dark"]` is excluded and keeps `antialiased`.

## Testing
- Verified computed style: light → `auto`, dark → `antialiased` (unchanged).
- Added a deterministic computed-style assertion to `preferences.feature` (cross-platform, unlike the macOS-only visual effect); verified fail-before / pass-after.
- **Screenshots intentionally not regenerated**: the headless Chromium pipeline doesn't reproduce the `-webkit-font-smoothing` hint, so a regen would be byte noise (even the dark shots, which this change doesn't touch, differ run-to-run) rather than a faithful reflection of the change.

Note: the visual effect is only observable in a real browser on macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)