### PR TITLE
fix(ui): re-bind Mark-Above listener after scoped-search swap

### DIFF
--- a/e2e/features/keyboard_shortcuts.feature
+++ b/e2e/features/keyboard_shortcuts.feature
@@ -29,6 +29,14 @@ Feature: Keyboard shortcuts
     And I press the "A" key
     Then I see 0 entries in the entry list
 
+  Scenario: A still marks loaded entries as read after a scoped search
+    When I open the entries page for feed "Shortcut Feed"
+    And I type "Entry" into the scoped search box
+    And the URL has the "q" query parameter set to "Entry"
+    And I confirm the next dialog
+    And I press the "A" key
+    Then I see 0 entries in the entry list
+
   Scenario: Enter opens the selected entry into the reading pane
     When I open the inbox
     And I press the "j" key

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1381,7 +1381,13 @@ document.addEventListener('rdrs:swap-complete', installEntriesSearch);
 // `a=user/-/state/com.google/read`.
 function installMarkAboveButton() {
     const btn = document.getElementById('mark-above-read');
-    if (!btn) return;
+    if (!btn || btn.dataset.markAboveBound) return;
+    // The button lives *inside* the swapped `[data-entries-list]` container,
+    // so a scoped-search swap discards the listener-bearing element and drops
+    // in a fresh one — re-run on `rdrs:swap-complete` to re-bind. The
+    // per-element guard keeps unrelated swaps (which leave this same button in
+    // place) from stacking a second listener and double-POSTing.
+    btn.dataset.markAboveBound = '1';
     btn.addEventListener('click', async () => {
         const rows = Array.from(document.querySelectorAll('[data-entry-row]'));
         const ids = rows.map(r => r.dataset.entryId).filter(Boolean);
@@ -1418,6 +1424,7 @@ function installMarkAboveButton() {
     });
 }
 installMarkAboveButton();
+document.addEventListener('rdrs:swap-complete', installMarkAboveButton);
 
 // Entry-row click delegation. Clicking anywhere on a row (not just the
 // title link) opens the entry. Delegates to the title's


### PR DESCRIPTION
## Problem

After using scoped search, keyboard shortcuts appeared to stop working — e.g. `Shift+A` no longer marked loaded entries as read.

## Root cause

The **Mark Above as Read** button (`#mark-above-read`) is rendered *inside* the `[data-entries-list]` container. A scoped-search auto-submit swaps that whole container (`_entries_refresh_fragment.html`), discarding the listener-bearing button and dropping in a fresh one.

`installMarkAboveButton()` only ran once at module load and was **not** re-registered on `rdrs:swap-complete` (unlike `installEntriesSearch`). So after a scoped search the new button had no click listener — both `Shift+A` (which calls `btn.click()`) and a **direct mouse click** became no-ops.

Scope note: an audit of every keyboard shortcut and `install*` function found this is the **only** affected control. All other shortcuts survive swaps via document-level event delegation, native form submission, or by living on header elements outside the swapped list container.

## Fix

- Re-run `installMarkAboveButton()` on `rdrs:swap-complete`, matching the existing `installEntriesSearch` pattern.
- Add a per-element `dataset.markAboveBound` guard so unrelated swaps (which leave the same button in place) don't stack a second listener and double-POST.

## Testing

- New E2E regression scenario in `keyboard_shortcuts.feature`. It gates on the `?q=` address-bar sync so the swap is guaranteed to have replaced the button before `A` is pressed (a naive "list shows X" barrier was a false green, since the entry is present pre-search too).
- Verified **red → green**: fails against the pre-fix binary (3 entries remain), passes after the fix (0 remain).
- `keyboard_shortcuts`, `search`, and `triage` (scoped-search / mark-matching) suites all pass.

No rendered pixels change, so screenshots are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)