### PR TITLE
chore(deps): clear ammonia & anyhow advisories (RUSTSEC-2026-0193, -0190)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,14 +58,13 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "ammonia"
-version = "4.1.2"
+version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17e913097e1a2124b46746c980134e8c954bc17a6a59bb3fde96f088d126dde6"
+checksum = "68b9d3370580a12f4b7a10fdcc18b28942c083ba570e3d954fe59d10951b85a2"
 dependencies = [
- "cssparser 0.35.0",
- "html5ever 0.35.0",
+ "cssparser 0.37.0",
+ "html5ever 0.39.0",
  "maplit",
- "tendril 0.4.3",
  "url",
 ]
 
@@ -130,9 +129,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"
@@ -883,19 +882,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
  "hybrid-array",
-]
-
-[[package]]
-name = "cssparser"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e901edd733a1472f944a45116df3f846f54d37e67e68640ac8bb69689aca2aa"
-dependencies = [
- "cssparser-macros 0.6.1",
- "dtoa-short",
- "itoa",
- "phf 0.11.3",
- "smallvec",
 ]
 
 [[package]]
@@ -1662,17 +1648,6 @@ dependencies = [
 
 [[package]]
 name = "html5ever"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55d958c2f74b664487a2035fe1dadb032c48718a03b63f3ab0b8537db8549ed4"
-dependencies = [
- "log",
- "markup5ever 0.35.0",
- "match_token",
-]
-
-[[package]]
-name = "html5ever"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
@@ -2225,24 +2200,13 @@ dependencies = [
 
 [[package]]
 name = "markup5ever"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "311fe69c934650f8f19652b3946075f0fc41ad8757dbb68f1ca14e7900ecc1c3"
-dependencies = [
- "log",
- "tendril 0.4.3",
- "web_atoms 0.1.3",
-]
-
-[[package]]
-name = "markup5ever"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
 dependencies = [
  "log",
  "tendril 0.5.0",
- "web_atoms 0.2.3",
+ "web_atoms",
 ]
 
 [[package]]
@@ -2255,17 +2219,6 @@ dependencies = [
  "markup5ever 0.11.0",
  "tendril 0.4.3",
  "xml5ever",
-]
-
-[[package]]
-name = "match_token"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac84fd3f360fcc43dc5f5d186f02a94192761a080e8bc58621ad4d12296a58cf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -2695,21 +2648,11 @@ dependencies = [
 
 [[package]]
 name = "phf"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
-dependencies = [
- "phf_macros 0.11.3",
- "phf_shared 0.11.3",
-]
-
-[[package]]
-name = "phf"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
- "phf_macros 0.13.1",
+ "phf_macros",
  "phf_shared 0.13.1",
  "serde",
 ]
@@ -2722,16 +2665,6 @@ checksum = "4fb1c3a8bc4dd4e5cfce29b44ffc14bedd2ee294559a294e2a4d4c9e9a6a13cd"
 dependencies = [
  "phf_generator 0.10.0",
  "phf_shared 0.10.0",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
-dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
 ]
 
 [[package]]
@@ -2772,19 +2705,6 @@ checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
  "fastrand",
  "phf_shared 0.13.1",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
-dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -4713,18 +4633,6 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "web_atoms"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57ffde1dc01240bdf9992e3205668b235e59421fd085e8a317ed98da0178d414"
-dependencies = [
- "phf 0.11.3",
- "phf_codegen 0.11.3",
- "string_cache 0.8.9",
- "string_cache_codegen 0.5.4",
 ]
 
 [[package]]

--- a/deny.toml
+++ b/deny.toml
@@ -32,18 +32,10 @@ ignore = [
     # upstream releases against 0.41. Drop these once both paths are clean.
     "RUSTSEC-2026-0194",
     "RUSTSEC-2026-0195",
-    # The three entries below are tracked in issue #346 and MUST be removed as
-    # part of resolving it (once the 7-day cooldown on the fixes has elapsed,
-    # from 2026-07-07). They were accepted temporarily to unblock unrelated work.
-    #
-    # ammonia mXSS via MathML `annotation-xml` (our HTML sanitizer). Fixed in
-    # 4.1.3, published 2026-06-30 — younger than the 7-day cooldown.
-    "RUSTSEC-2026-0193",
-    # anyhow `Error::downcast_mut()` unsoundness (transitive via rav1e). Clear
-    # with `cargo update -p anyhow` to a patched release after the cooldown.
-    "RUSTSEC-2026-0190",
     # ttf-parser unmaintained (transitive via resvg/usvg/fontdb, favicon render).
-    # No maintained fix; revisit when the resvg chain drops or replaces it.
+    # No maintained fix — 0.25.1 is the latest release — so this can't be cleared
+    # by a version bump; revisit when the resvg chain drops or replaces it.
+    # Tracked in issue #346 (the ammonia/anyhow entries there are now resolved).
     "RUSTSEC-2026-0192",
     # crossbeam-epoch invalid pointer deref in the `fmt::Display`/`fmt::Pointer`
     # impls for `Atomic`/`Shared` on a null pointer (transitive via image and


### PR DESCRIPTION
Resolves two of the three advisories tracked in #346, now that their fixes have aged past the 7-day dependency cooldown (today is 2026-07-07).

## Changes

| Advisory | Crate | Before → After | Fix published |
|----------|-------|----------------|---------------|
| RUSTSEC-2026-0193 (mXSS via MathML `annotation-xml`) | ammonia (direct — HTML sanitizer) | 4.1.2 → **4.1.3** | 2026-06-30 |
| RUSTSEC-2026-0190 (`Error::downcast_mut()` unsoundness) | anyhow (transitive via rav1e) | 1.0.102 → **1.0.103** | 2026-06-25 |

Both `deny.toml` ignore entries are removed. Lockfile-only: `anyhow` is transitive; `ammonia`'s `"4"` requirement already admits 4.1.3, so `Cargo.toml` is untouched.

## Still open in #346

- **RUSTSEC-2026-0192** (ttf-parser unmaintained) stays ignored — 0.25.1 is the latest release, so it can't be cleared by a version bump. #346 remains open to track replacing/dropping it via the resvg chain.

## Verification

- `cargo deny check` → `advisories ok, bans ok, licenses ok, sources ok`
- `cargo build` passes
- Sanitize test suite (ammonia is our HTML sanitizer): 52 passed

Refs #346.

🤖 Generated with [Claude Code](https://claude.com/claude-code)