### PR TITLE
Multi-DB Phase A: DATABASE_URL backend contract + sqlx migration design

### DIFF
--- a/docs/superpowers/specs/2026-07-07-multi-db-sqlx-migration.md
+++ b/docs/superpowers/specs/2026-07-07-multi-db-sqlx-migration.md
@@ -84,54 +84,58 @@ a single contained change rather than a long-lived broken branch.
   actor closure API (`db/pool.rs`) is the seam; it disappears entirely under async sqlx.
 - Domain errors do **not** leak rusqlite to callers (handlers see `AppError::CategoryExists`,
   not the driver error); the ~26 constraint matches are contained inside model bodies.
+- **The `db.user(|conn| …)` closure IS the unit-of-work / transaction boundary.** Many
+  closures compose *several* model functions on one `conn` (e.g. OPML import loops
+  find-or-create category → create feed in a single closure), and several use explicit
+  `conn.unchecked_transaction()` (`entry/mod.rs`, `greader/tag.rs`,
+  `content_text_backfill.rs`, `feed_sync.rs`). A single model fn like `create_category`
+  is called from ~24 sites, mostly *inside* such composed closures — it is a building
+  block, not a standalone call.
 - Timestamps are stored as **TEXT via `datetime('now')` DEFAULT** and parsed back to
   `DateTime<Utc>` in Rust (`parse_datetime`). Migrations are versioned by
   `PRAGMA user_version` in `db/schema.rs`; partial/sort indexes added in v4/v5.
 - 17 test files build fixtures with `Connection::open_in_memory()`.
 
-## The permanent seam: an async `Db` facade
+## Seam decision: why NOT a per-model-function facade
 
-Phase A introduces the API that survives into the sqlx world, so Phase B only swaps its
-internals. Callers move off `db.user(|conn| model::fn(conn, …))` onto async facade
-methods:
+A first design idea was a per-model-function async facade
+(`db.create_category(…).await`) whose body delegates to the rusqlite actor in Phase A
+and swaps to sqlx in Phase B. **Rejected** after the audit above: turning each model fn
+into its own `db.user(|conn| …)` round-trip **breaks the composed closures' atomicity** —
+the OPML importer's find-or-create-category-then-create-feed would split into separate
+connections/turns, so a category could commit while its feed insert fails. The
+unit-of-work is the *closure*, not the function.
 
-```rust
-// call site after Phase A (unchanged through Phase B):
-let cat = state.db.create_category(user_id, &name).await?;
-```
+The only atomicity-preserving facade would be **coarse, use-case-grained** (one method
+per closure, ~146 of them). But those method bodies get rewritten *again* in Phase B —
+close to double the work, bought only "incremental releasability." Not worth it.
 
-Phase A implements each facade method by delegating to the *existing* rusqlite actor:
-
-```rust
-// Phase A body (rusqlite): keeps main releasable
-pub async fn create_category(&self, user_id: i64, name: &str) -> AppResult<Category> {
-    self.pool.user(move |conn| category::create_category(conn, user_id, name)).await?
-}
-// Phase B body (sqlx): same signature, new guts — callers untouched
-```
-
-Facade shape: methods on the `Db` type (thin, one per model fn), grouped by model in
-submodules/impl blocks. Not a `dyn Repo` trait — the boot-time enum makes static
-dispatch sufficient and avoids trait-object churn.
+**Decision:** the model layer and the closures that compose it are one tightly-coupled
+unit (shared `&Connection`, sync→async boundary, transaction boundaries) and **flip
+together in Phase B**. Phase A does not attempt to pre-decouple call sites; it invests in
+the safe, non-throwaway prep that genuinely shrinks Phase B risk.
 
 ## Phased plan
 
-### Phase A — decouple (stays on rusqlite; every PR releasable to main)
-1. **A4 (first, self-contained):** classify `DATABASE_URL` into a `Backend` (SQLite vs
-   Postgres) in `config.rs`; SQLite behaves exactly as today, `postgres://` returns a
-   clear "not yet supported" error. Establishes the user-facing URL contract, zero
-   behavior change. *(Started on `refactor/db-repo-seam`.)*
-2. **A1:** introduce the async `Db` facade; migrate the ~146 call sites off the
-   `db.<accessor>(|conn| …)` closures onto facade methods, one model per PR
-   (start with `category`, the smallest vertical slice).
-3. **A2:** switch timestamp writes from `datetime('now')` DEFAULT to app-bound
+### Phase A — safe prep (stays on rusqlite; every PR releasable to main)
+Scope deliberately narrow — no call-site decoupling (see the seam decision above).
+1. **A4 (done):** classify `DATABASE_URL` into a `Backend` (SQLite vs Postgres) in
+   `config.rs`; SQLite behaves exactly as today, `postgres://` returns a clear "not yet
+   supported" error. Zero behavior change. *(Committed on `refactor/db-repo-seam`.)*
+2. **A2:** switch timestamp writes from `datetime('now')` DEFAULT to app-bound
    `Utc::now()` (doable under rusqlite; removes the biggest Phase-B datetime divergence).
-4. **A3:** confirm no rusqlite type escapes the model layer after A1 (audit gate).
+3. **A5 (inventory):** classify the ~146 `db.<accessor>(|conn| …)` closures — single-model
+   vs multi-model, and which hold an explicit `unchecked_transaction()`. The multi-model
+   / transactional ones become sqlx `transaction()` blocks in Phase B; this inventory is
+   the Phase B work-list, not code.
 
 **Gate:** `cargo nextest run` green, `cargo clippy -D warnings`, E2E green, no behavior
 change.
 
 ### Phase B — cutover (one PR: rusqlite → sqlx)
+This is where the model functions **and** the ~146 call-site closures flip from sync
+`&Connection` to async sqlx together (guided by the A5 inventory); multi-model /
+`unchecked_transaction()` closures become sqlx `transaction()` blocks.
 - **B1** `Cargo.toml`: drop rusqlite, add sqlx; re-run `cargo deny`.
 - **B2** `db/pool.rs`: `enum Db` over `SqlitePool`/`PgPool`; WAL/tuning via
   `SqliteConnectOptions`; SQLite biased gate; PG dual pool sizing (user 8 / bg 2).
@@ -169,5 +173,6 @@ change.
 5. **Search semantics** — `COLLATE NOCASE` (ASCII) vs `ILIKE` (locale-aware) on non-ASCII.
 
 ## Effort
-Phase A ≈ 2–4 days · Phase B ≈ 1.5–2.5 weeks · Phase C ≈ 3–5 days. ≈ 3–4 weeks total.
+Phase A ≈ 1–2 days (A4 done; A2 + inventory remain) · Phase B ≈ 2–3 weeks (absorbs the
+model + closure flip) · Phase C ≈ 3–5 days. ≈ 3–4 weeks total.
 Endpoint: one code path, two backends, SQLite deploy experience unchanged.

--- a/docs/superpowers/specs/2026-07-07-multi-db-sqlx-migration.md
+++ b/docs/superpowers/specs/2026-07-07-multi-db-sqlx-migration.md
@@ -173,6 +173,49 @@ This is where the model functions **and** the ~146 call-site closures flip from 
 5. **Search semantics** — `COLLATE NOCASE` (ASCII) vs `ILIKE` (locale-aware) on non-ASCII.
 
 ## Effort
-Phase A ≈ 1–2 days (A4 done; A2 + inventory remain) · Phase B ≈ 2–3 weeks (absorbs the
+Phase A ≈ 1–2 days (A4 + A5 done; A2 folds into B) · Phase B ≈ 2–3 weeks (absorbs the
 model + closure flip) · Phase C ≈ 3–5 days. ≈ 3–4 weeks total.
 Endpoint: one code path, two backends, SQLite deploy experience unchanged.
+
+## Appendix — A5 closure inventory (Phase B work-list)
+
+Per-file count of `db.<accessor>(|conn| …)` call sites (the units that flip to async
+sqlx in Phase B). `pool.rs` is excluded (that's the actor definition/tests). `TX` marks
+files with an explicit `unchecked_transaction()` — those closures become sqlx
+`transaction()` blocks; the rest are mechanical single-round-trip conversions.
+
+| File | user | read_user | bg | read_bg | detach | TX |
+|---|---|---|---|---|---|---|
+| handlers/pages/mod.rs | 2 | 16 | | | | |
+| handlers/entries.rs | 2 | 12 | | | 3 | |
+| services/feed_sync.rs | 7 | | 10 | | | 2 |
+| services/summary_worker.rs | 5 | 1 | 6 | 1 | | |
+| handlers/passkey.rs | 9 | 3 | | | | |
+| handlers/user.rs | 6 | 5 | | | | |
+| handlers/feeds.rs | 5 | 3 | | | | |
+| handlers/greader/subscription.rs | 5 | 3 | | | | |
+| handlers/admin.rs | 5 | | | | | |
+| handlers/greader/tag.rs | 4 | 1 | | | | 1 |
+| handlers/entry.rs | 2 | 4 | | | | |
+| handlers/greader/item.rs | | 4 | | | | |
+| services/summary_cleanup.rs | 3 | | 2 | | | |
+| handlers/categories.rs | 3 | | | | | |
+| handlers/auth.rs | 3 | | | | | |
+| services/content_text_backfill.rs | 2 | | 2 | | | 1 |
+| middleware/auth.rs | 2 | 3 | | | | |
+| handlers/greader/auth.rs | 2 | 1 | | | | |
+| services/entry_retention.rs | 1 | | 3 | | | |
+| middleware/forward_auth.rs | 1 | 1 | | | | |
+| handlers/feed.rs | | 1 | | | | |
+| handlers/greader/user.rs | | 1 | | | | |
+| services/background.rs | | | | 1 | | |
+
+**Transaction / multi-model closures (need sqlx `transaction()`):**
+`feed_sync.rs` (×2), `content_text_backfill.rs`, `greader/tag.rs` (tag rename), plus the
+in-model `entry/mod.rs` `unchecked_transaction()`. Also atomicity-sensitive even without
+an explicit BEGIN: the OPML importers in `feeds.rs` and `greader/subscription.rs`
+(find-or-create category → create feeds in one closure).
+
+**Hotspots (largest single-file surface):** `pages/mod.rs` (18), `entries.rs` (17),
+`feed_sync.rs` (17), `summary_worker.rs` (13). Sequence Phase B model-by-model but expect
+these four files to carry most of the closure-conversion churn.

--- a/docs/superpowers/specs/2026-07-07-multi-db-sqlx-migration.md
+++ b/docs/superpowers/specs/2026-07-07-multi-db-sqlx-migration.md
@@ -1,0 +1,173 @@
+# Multi-Database Support (SQLite + PostgreSQL) via sqlx — Migration Design
+
+**Date:** 2026-07-07
+**Branches:** `chore/sqlx-multi-db-spike` (feasibility spike, pushed), `refactor/db-repo-seam` (Phase A)
+**Status:** Feasibility proven by spike; phased migration approved, Phase A in progress
+
+## Goal
+
+Let a self-hoster run rdrs against **their own PostgreSQL server** as an alternative
+to the built-in SQLite. Many self-hosters already operate a Postgres instance and want
+to reuse it for backups, HA, and central ops.
+
+The backend is chosen **once at startup** from `DATABASE_URL` — SQLite *or* Postgres.
+There is **no mid-flight switching, no cross-backend data migration, no dual-write.**
+This premise removes the need for `sqlx::Any` and lets the whole design collapse to a
+single `enum Db` built once at boot.
+
+Route chosen: **unify both backends on `sqlx`** (async), replacing rusqlite entirely —
+not a rusqlite + parallel-Postgres trait layer. sqlx gives one async API, one pooling
+story, one `FromRow`/type-mapping system, one `sqlx::Error`, and each driver is
+independently battle-tested.
+
+## Non-Goals (YAGNI / possible follow-ups)
+
+- No runtime backend switching or data migration tool between SQLite and Postgres.
+- No `sqlx::Any` driver (its type support is narrower; the boot-time choice makes it
+  unnecessary).
+- No compile-time query macros (`query!`) — they validate against a single live
+  `DATABASE_URL` and cannot cover two backends. We use runtime `query_as`/`QueryBuilder`,
+  accepting the loss of compile-time SQL checking.
+- No MySQL / other backends.
+- No change to the SSR/Askama/Axum layers, the GReader API, or the SSE stream.
+
+## What the spike proved (feasibility)
+
+Standalone crate `spike/sqlx-slice/` (isolated — see the hard constraint below),
+7 tests green against SQLite in-memory **and** a live PostgreSQL 17:
+
+- **Dispatch:** one `enum Db { Sqlite(SqlitePool), Postgres(PgPool) }`, built once.
+- **Row mapping:** one `#[derive(FromRow)]` decodes both `SqliteRow` and `PgRow`.
+- **Type mapping:** `DateTime<Utc>` maps to SQLite TEXT and PG `timestamptz` — *iff the
+  app binds `Utc::now()`* instead of a `datetime('now')` column DEFAULT (so
+  encode/decode formats agree). **Decision: bind timestamps, never DEFAULT.**
+- **`RETURNING`** works on both (SQLite ≥ 3.35, bundled) → removes the SQLite-only
+  `last_insert_rowid()` pattern; the insert becomes identical across backends.
+- **Unified constraint errors:** one `sqlx::error::ErrorKind::UniqueViolation` check
+  replaces the ~26 per-driver `rusqlite::Error::SqliteFailure { ConstraintViolation }`
+  matches.
+- **Placeholders:** a single `$N`-style string runs on both (SQLite's parameter syntax
+  is a superset), so per-arm SQL is *not* duplicated for placeholder reasons.
+- **Dynamic query builder** (`entry/filters.rs`): one generic `sqlx::QueryBuilder<DB>`
+  with the three genuine dialect forks isolated in a `Dialect` type (below).
+- **Priority scheduler:** Postgres uses two independently-capped pools; SQLite keeps a
+  thin biased two-channel gate in front of the single write pool.
+
+### The three genuine dialect forks (everything else is portable)
+
+| Concern | SQLite | Postgres |
+|---|---|---|
+| Case-insensitive search | `LIKE … COLLATE NOCASE` | `ILIKE` |
+| Epoch from a timestamp | `CAST(strftime('%s', …) AS INTEGER)` | `EXTRACT(EPOCH FROM …)` |
+| Query-level index hint | ` INDEXED BY idx_…` | *(none — Postgres has no hint; trust planner)* |
+
+Note the search semantics differ subtly: `COLLATE NOCASE` folds ASCII only; `ILIKE` is
+locale-aware. Documented, accepted.
+
+## Hard constraint (drives the whole strategy)
+
+**rusqlite 0.40 and sqlx-sqlite 0.9 cannot coexist in one binary.** Both declare
+`links = "sqlite3"` with incompatible `libsqlite3-sys` majors (`^0.38` vs `<0.38`), so
+Cargo refuses to build both. Consequence: the SQLite driver swap is a **one-shot
+cutover** — there is no "run both drivers, migrate model-by-model" period. This is why
+the spike lives in an isolated crate, and why the migration is phased so the cutover is
+a single contained change rather than a long-lived broken branch.
+
+## Current-state audit (Phase A findings)
+
+- Models are **synchronous free functions** taking `conn: &rusqlite::Connection` and
+  returning domain structs (`AppResult<Category>` etc.), across 13 model files, ~290
+  raw-SQL sites. `entry/mod.rs` alone has ~69; `statistics.rs` ~29.
+- Handlers/services reach the DB via **~146 closure call sites** of the shape
+  `state.db.user(move |conn| category::create_category(conn, …)).await`
+  (`user` / `read_user` / `background` / `read_background` / `user_detached`). The sync
+  actor closure API (`db/pool.rs`) is the seam; it disappears entirely under async sqlx.
+- Domain errors do **not** leak rusqlite to callers (handlers see `AppError::CategoryExists`,
+  not the driver error); the ~26 constraint matches are contained inside model bodies.
+- Timestamps are stored as **TEXT via `datetime('now')` DEFAULT** and parsed back to
+  `DateTime<Utc>` in Rust (`parse_datetime`). Migrations are versioned by
+  `PRAGMA user_version` in `db/schema.rs`; partial/sort indexes added in v4/v5.
+- 17 test files build fixtures with `Connection::open_in_memory()`.
+
+## The permanent seam: an async `Db` facade
+
+Phase A introduces the API that survives into the sqlx world, so Phase B only swaps its
+internals. Callers move off `db.user(|conn| model::fn(conn, …))` onto async facade
+methods:
+
+```rust
+// call site after Phase A (unchanged through Phase B):
+let cat = state.db.create_category(user_id, &name).await?;
+```
+
+Phase A implements each facade method by delegating to the *existing* rusqlite actor:
+
+```rust
+// Phase A body (rusqlite): keeps main releasable
+pub async fn create_category(&self, user_id: i64, name: &str) -> AppResult<Category> {
+    self.pool.user(move |conn| category::create_category(conn, user_id, name)).await?
+}
+// Phase B body (sqlx): same signature, new guts — callers untouched
+```
+
+Facade shape: methods on the `Db` type (thin, one per model fn), grouped by model in
+submodules/impl blocks. Not a `dyn Repo` trait — the boot-time enum makes static
+dispatch sufficient and avoids trait-object churn.
+
+## Phased plan
+
+### Phase A — decouple (stays on rusqlite; every PR releasable to main)
+1. **A4 (first, self-contained):** classify `DATABASE_URL` into a `Backend` (SQLite vs
+   Postgres) in `config.rs`; SQLite behaves exactly as today, `postgres://` returns a
+   clear "not yet supported" error. Establishes the user-facing URL contract, zero
+   behavior change. *(Started on `refactor/db-repo-seam`.)*
+2. **A1:** introduce the async `Db` facade; migrate the ~146 call sites off the
+   `db.<accessor>(|conn| …)` closures onto facade methods, one model per PR
+   (start with `category`, the smallest vertical slice).
+3. **A2:** switch timestamp writes from `datetime('now')` DEFAULT to app-bound
+   `Utc::now()` (doable under rusqlite; removes the biggest Phase-B datetime divergence).
+4. **A3:** confirm no rusqlite type escapes the model layer after A1 (audit gate).
+
+**Gate:** `cargo nextest run` green, `cargo clippy -D warnings`, E2E green, no behavior
+change.
+
+### Phase B — cutover (one PR: rusqlite → sqlx)
+- **B1** `Cargo.toml`: drop rusqlite, add sqlx; re-run `cargo deny`.
+- **B2** `db/pool.rs`: `enum Db` over `SqlitePool`/`PgPool`; WAL/tuning via
+  `SqliteConnectOptions`; SQLite biased gate; PG dual pool sizing (user 8 / bg 2).
+- **B3** models: async bodies, `#[derive(FromRow)]`, `RETURNING`, unified `ErrorKind`
+  (signatures unchanged from Phase A).
+- **B4** `entry/filters.rs` + `entry/mod.rs`: `QueryBuilder<DB>` + `Dialect` (spike is the
+  template).
+- **B5** `error.rs`: `Database(rusqlite::Error)` → `Database(sqlx::Error)`.
+- **B6** `db/schema.rs` → `migrations/{sqlite,postgres}/` numbered `.sql`, two
+  `sqlx::migrate!` migrators selected by backend (PG partial indexes for the v4/v5 sort
+  indexes).
+- **B7** test fixtures: in-memory sqlx pool + migrator.
+
+**Gate:** SQLite suite green (== today); binary boots; E2E green. (PG not yet in CI.)
+
+### Phase C — Postgres enablement & hardening
+- **C1** CI PG lane (testcontainers-rs or a service container); local SQLite lane needs
+  no Docker (PG tests `#[ignore]` + env-gated, as in the spike).
+- **C2** *(optional)* run SSR E2E against both backends for near-free double coverage.
+- **C3** docs: `README.md`, `ARCHITECTURE.md`, `CLAUDE.md` (PG opt-in; SQLite stays the
+  zero-config single-binary default).
+- **C4** `deny.toml`: review sqlx's transitive licenses/advisories (sqlx 0.9.0, published
+  2026-05-21, already past the 7-day cooldown).
+- **C5** ops: SQLite deploy unchanged; PG via `DATABASE_URL`; Docker image unchanged.
+
+## Risks to watch (Phase B)
+1. **`INDEXED BY` removal** — SQLite perf crutches; build equivalent (incl. partial)
+   Postgres indexes and confirm adoption with `EXPLAIN`.
+2. **`statistics.rs` date grouping** — `strftime` aggregates need PG equivalents
+   (`date_trunc` / `to_char`).
+3. **Transactions** — multi-statement writes (e.g. feed + initial entries) → sqlx
+   transactions.
+4. **Type affinity** — SQLite `0/1 INTEGER` vs PG `BOOLEAN`; DDL must use correct types
+   (Rust `bool` maps via sqlx).
+5. **Search semantics** — `COLLATE NOCASE` (ASCII) vs `ILIKE` (locale-aware) on non-ASCII.
+
+## Effort
+Phase A ≈ 2–4 days · Phase B ≈ 1.5–2.5 weeks · Phase C ≈ 3–5 days. ≈ 3–4 weeks total.
+Endpoint: one code path, two backends, SQLite deploy experience unchanged.

--- a/src/config.rs
+++ b/src/config.rs
@@ -61,6 +61,27 @@ pub fn parse_trusted_networks(raw: &str) -> Result<Vec<IpNet>, String> {
     Ok(nets)
 }
 
+/// Which database engine `database_url` selects. Determined once at startup —
+/// rdrs runs against exactly one backend for the life of the process (no
+/// mid-flight switching). See the migration spec.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Backend {
+    Sqlite,
+    Postgres,
+}
+
+/// Classify a `database_url` into a [`Backend`] by scheme. A `postgres://` or
+/// `postgresql://` URL selects `Postgres`; anything else — a `sqlite://` URL or
+/// a bare file path like `rdrs.sqlite3` — selects `SQLite`.
+pub fn classify_backend(database_url: &str) -> Backend {
+    let lower = database_url.trim_start().to_ascii_lowercase();
+    if lower.starts_with("postgres://") || lower.starts_with("postgresql://") {
+        Backend::Postgres
+    } else {
+        Backend::Sqlite
+    }
+}
+
 impl Config {
     pub fn from_env() -> Result<Self, String> {
         let (image_proxy_secret, image_proxy_secret_generated) = Self::load_image_proxy_secret();
@@ -138,8 +159,26 @@ impl Config {
             .any(|net| net.contains(&ip))
     }
 
+    /// The database engine selected by `database_url`.
+    pub fn backend(&self) -> Backend {
+        classify_backend(&self.database_url)
+    }
+
     /// Validate cross-field invariants at startup. Returns the first problem.
     pub fn validate(&self) -> Result<(), String> {
+        // PostgreSQL is a recognized backend in the config contract but its
+        // driver isn't wired up yet (arrives in the sqlx cutover — Phase B of
+        // docs/superpowers/specs/2026-07-07-multi-db-sqlx-migration.md). Fail
+        // fast with a clear message instead of letting the SQLite driver try to
+        // open a `postgres://` URL as a file path.
+        if self.backend() == Backend::Postgres {
+            return Err(
+                "DATABASE_URL selects PostgreSQL, which is not supported yet. \
+                 Use a SQLite file path or a sqlite:// URL. PostgreSQL support \
+                 is in progress."
+                    .to_string(),
+            );
+        }
         if self.auth_proxy_enabled() && self.trusted_proxy_networks.is_empty() {
             return Err(
                 "AUTH_PROXY_HEADER is set but TRUSTED_PROXY_NETWORKS is empty. \
@@ -217,6 +256,35 @@ mod tests {
             auth_proxy_admin_group: String::new(),
             auth_proxy_logout_url: None,
         }
+    }
+
+    #[test]
+    fn test_classify_backend() {
+        assert_eq!(classify_backend("rdrs.sqlite3"), Backend::Sqlite);
+        assert_eq!(classify_backend("/var/lib/rdrs/data.db"), Backend::Sqlite);
+        assert_eq!(classify_backend("sqlite://rdrs.sqlite3"), Backend::Sqlite);
+        assert_eq!(
+            classify_backend("postgres://user:pw@localhost/rdrs"),
+            Backend::Postgres
+        );
+        assert_eq!(
+            classify_backend("postgresql://user@db:5432/rdrs"),
+            Backend::Postgres
+        );
+        // scheme match is case-insensitive and tolerant of leading whitespace
+        assert_eq!(classify_backend("  POSTGRES://x"), Backend::Postgres);
+    }
+
+    #[test]
+    fn test_validate_rejects_postgres_for_now() {
+        let mut config = test_config();
+        config.database_url = "postgres://user@localhost/rdrs".to_string();
+        let err = config.validate().expect_err("postgres must be rejected");
+        assert!(err.contains("PostgreSQL"), "message was: {err}");
+
+        // SQLite path still validates fine.
+        config.database_url = "rdrs.sqlite3".to_string();
+        assert!(config.validate().is_ok());
     }
 
     #[test]


### PR DESCRIPTION
Phase A (safe prep) of adding **PostgreSQL as a second database backend** alongside SQLite, unifying both on `sqlx`. This PR is releasable on its own: it establishes the config contract and records the design, with **zero behavior change** for existing SQLite users. The actual rusqlite→sqlx cutover is Phase B (a separate branch).

## What's here

**A4 — `DATABASE_URL` backend contract** (`src/config.rs`)
- New `Backend` enum + `classify_backend()`: `postgres://` / `postgresql://` selects Postgres, anything else (a `sqlite://` URL or a bare file path) selects SQLite.
- `Config::validate()` now fails fast with a clear message on a `postgres://` URL, since the SQLite driver would otherwise try to open it as a file path. Postgres support arrives in Phase B.
- SQLite behaves exactly as today.

**Design spec** (`docs/superpowers/specs/2026-07-07-multi-db-sqlx-migration.md`)
- Feasibility findings from the spike (proven green on SQLite + live PostgreSQL 17): single boot-time `enum Db`, one `#[derive(FromRow)]`, `RETURNING` on both, unified `ErrorKind::UniqueViolation`, `$N` placeholders portable to both, and the three genuine dialect forks (`COLLATE NOCASE`/`ILIKE`, `strftime`/`EXTRACT`, `INDEXED BY`/none).
- The hard constraint that shapes the whole plan: rusqlite 0.40 and sqlx-sqlite 0.9 cannot coexist in one binary (incompatible `libsqlite3-sys` majors both linking `sqlite3`), so the SQLite driver swap is a one-shot cutover.
- Seam decision: a per-model-function facade was **rejected** — the `db.user(|conn| …)` closure is the unit-of-work/transaction boundary and many closures compose several model calls atomically, so per-fn round-trips would break atomicity. The model layer and its ~146 closures flip together in Phase B.
- A5 appendix: per-file inventory of those ~146 closures (the Phase B work-list), flagging transactional/multi-model closures and hotspot files.

## Testing
- `cargo nextest run config::` — 9/9 pass (incl. new `test_classify_backend`, `test_validate_rejects_postgres_for_now`).
- `cargo clippy --lib -- -D warnings` — clean.

## Not in this PR
- No sqlx dependency, no driver changes (the feasibility spike lives on `chore/sqlx-multi-db-spike`).
- Phase B (rusqlite→sqlx cutover) and Phase C (Postgres CI/docs) are separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)