### PR TITLE
Phase C: enable PostgreSQL backend at runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,48 @@ jobs:
       - name: cargo deny check
         run: cargo deny check
 
+  # PostgreSQL backend integration test. The default nextest run (lint/coverage)
+  # only exercises the SQLite backend; this job stands up a throwaway Postgres
+  # and runs the dual-backend dialect-fork test (`tests/postgres_test.rs`)
+  # against it. Gated by TEST_DATABASE_URL — without it the test skips.
+  postgres:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:17-alpine
+        env:
+          POSTGRES_USER: rdrs
+          POSTGRES_PASSWORD: rdrs
+          POSTGRES_DB: rdrs
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U rdrs -d rdrs"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@10c3493d811a9096cee4fdf287e41e852f6a51ba # 1.94.0
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
+      - uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2
+        with:
+          tool: nextest
+
+      - name: Run Postgres integration test
+        env:
+          RDRS_FAST_HASH: "1"
+          TEST_DATABASE_URL: postgres://rdrs:rdrs@localhost:5432/rdrs
+        run: cargo nextest run --test postgres_test
+
   e2e-tests:
     runs-on: ubuntu-latest
     strategy:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,12 +60,20 @@ the cross-cutting facts that span multiple files.
   into the single binary. This is why a rebuild is mandatory before E2E sees UI
   edits (see above) and why deployment is a single static binary.
 
-- **Dual-connection DB pool** (`db/pool.rs`). One write connection and one
-  read-only connection (`PRAGMA query_only=ON`) under WAL, with priority
-  scheduling so interactive user requests preempt background work. Models expose
-  CRUD as associated functions and take `*Params` structs instead of long
-  positional argument lists. Schema migrations are versioned via
-  `PRAGMA user_version` in `db/schema.rs`.
+- **Dual-backend `sqlx` data layer** (`db/pool.rs`). The backend is chosen once
+  at startup from `DATABASE_URL`: a bare path or `sqlite://` URL selects SQLite
+  (WAL, the zero-config single-binary default); a `postgres://` URL selects
+  PostgreSQL. `enum Db { Sqlite(SqlitePool), Postgres(PgPool) }` (and a
+  backend-tagged `enum Tx`) dispatch every query through the `query_*!` /
+  `db_execute!` macros so SQL + binds are written once. The few genuine dialect
+  differences are isolated behind `entry::filters::Dialect` and a `pg_rewrite`
+  shim (`datetime('now')`→`now()`, `to_char` cursor comparisons, `make_interval`,
+  quoted `"user"`, etc. — see the multi-db spec). PG connections pin
+  `TimeZone=UTC` so timestamp-string cursors stay byte-identical to SQLite.
+  Migrations are embedded per backend under `migrations/{sqlite,postgres}/` and
+  run via `sqlx::migrate!`. Models expose CRUD as free functions taking `&Db` /
+  `&mut Tx` and `*Params` structs. The env-gated `tests/postgres_test.rs`
+  validates the PG paths against a live server (CI Postgres service lane).
 
 - **Background feed sync** (`services/background.rs`, `feed_sync.rs`). Feeds are
   distributed across 60 one-minute buckets by URL hash (`feed.bucket` column);

--- a/docs/superpowers/specs/2026-07-07-multi-db-sqlx-migration.md
+++ b/docs/superpowers/specs/2026-07-07-multi-db-sqlx-migration.md
@@ -2,7 +2,10 @@
 
 **Date:** 2026-07-07
 **Branches:** `chore/sqlx-multi-db-spike` (feasibility spike, pushed), `refactor/db-repo-seam` (Phase A)
-**Status:** Feasibility proven by spike; phased migration approved, Phase A in progress
+**Status:** Phases A & B merged. **Phase C landed** (2026-07-07): PostgreSQL is
+runtime-enabled and validated against live PG 17 by `tests/postgres_test.rs`
+(env-gated on `TEST_DATABASE_URL`) plus a CI Postgres service lane. SQLite remains
+the zero-config default.
 
 ## Goal
 
@@ -151,15 +154,30 @@ This is where the model functions **and** the ~146 call-site closures flip from 
 
 **Gate:** SQLite suite green (== today); binary boots; E2E green. (PG not yet in CI.)
 
-### Phase C — Postgres enablement & hardening
-- **C1** CI PG lane (testcontainers-rs or a service container); local SQLite lane needs
-  no Docker (PG tests `#[ignore]` + env-gated, as in the spike).
-- **C2** *(optional)* run SSR E2E against both backends for near-free double coverage.
-- **C3** docs: `README.md`, `ARCHITECTURE.md`, `CLAUDE.md` (PG opt-in; SQLite stays the
-  zero-config single-binary default).
-- **C4** `deny.toml`: review sqlx's transitive licenses/advisories (sqlx 0.9.0, published
-  2026-05-21, already past the 7-day cooldown).
+### Phase C — Postgres enablement & hardening (landed 2026-07-07)
+- **C1** ✅ CI PG lane: a `postgres:17-alpine` service container runs the env-gated
+  `tests/postgres_test.rs` (skips locally without `TEST_DATABASE_URL`; no Docker needed
+  for the default SQLite lane).
+- **C2** *(deferred)* running the SSR E2E against both backends — left as future work.
+- **C3** docs: this spec + `CLAUDE.md` note that PG is opt-in via a `postgres://`
+  `DATABASE_URL`; SQLite stays the zero-config single-binary default.
+- **C4** ✅ `deny.toml`: `cargo deny check` clean with the sqlx stack.
 - **C5** ops: SQLite deploy unchanged; PG via `DATABASE_URL`; Docker image unchanged.
+
+**What Phase C actually forked** (all isolated behind `Dialect` / `match db`, SQLite
+path unchanged): connections pin `TimeZone=UTC`; `datetime('now')`→`now()` via a
+central `pg_rewrite` shim in the dispatch macros + dynamic-exec helpers; the composite
+cursor and snapshot/`read_at` comparisons wrap the column in `to_char(...,'YYYY-MM-DD
+HH24:MI:SS')` on PG (`Dialect::cursor_ts`) so the string-ordered cursor stays
+byte-identical; interval arithmetic forks to `make_interval` (`Dialect::days_ago`);
+date-range bounds bind as `NaiveDate` (PG implicitly casts `date`→`timestamptz`);
+timestamp columns read into `String` wrap in `to_char`; `DATE()`→`to_char`,
+`PRAGMA`→`pg_database_size()`, `EXTRACT(EPOCH …)`; the `"user"` reserved word is quoted
+uniformly; non-id `INTEGER` columns are `BIGINT` and the `has_icon` 0/1 flag is
+`CAST(... AS BIGINT)` to match the `i64` reads under sqlx-PG's strict int widths.
+
+**Deferred (TODO(phase-d)):** the PG cursor `to_char` predicate is not sargable — bind
+the cursor as `timestamptz` to restore index range scans.
 
 ## Risks to watch (Phase B)
 1. **`INDEXED BY` removal** — SQLite perf crutches; build equivalent (incl. partial)

--- a/migrations/postgres/0001_initial.sql
+++ b/migrations/postgres/0001_initial.sql
@@ -50,7 +50,7 @@ CREATE TABLE IF NOT EXISTS feed (
     custom_user_agent TEXT,
     http2_disabled BOOLEAN NOT NULL DEFAULT FALSE,
     custom_referrer TEXT,
-    bucket INTEGER,
+    bucket BIGINT,
     created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
     UNIQUE(category_id, url)
@@ -130,10 +130,10 @@ CREATE INDEX IF NOT EXISTS idx_image_entity ON image(entity_type, entity_id);
 CREATE TABLE IF NOT EXISTS user_settings (
     id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     user_id BIGINT NOT NULL UNIQUE REFERENCES "user"(id) ON DELETE CASCADE,
-    entries_per_page INTEGER NOT NULL DEFAULT 30,
+    entries_per_page BIGINT NOT NULL DEFAULT 30,
     save_services TEXT,
     theme TEXT,
-    retention_read_days INTEGER NOT NULL DEFAULT 0,
+    retention_read_days BIGINT NOT NULL DEFAULT 0,
     created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );

--- a/src/config.rs
+++ b/src/config.rs
@@ -166,19 +166,6 @@ impl Config {
 
     /// Validate cross-field invariants at startup. Returns the first problem.
     pub fn validate(&self) -> Result<(), String> {
-        // PostgreSQL is a recognized backend in the config contract but its
-        // driver isn't wired up yet (arrives in the sqlx cutover — Phase B of
-        // docs/superpowers/specs/2026-07-07-multi-db-sqlx-migration.md). Fail
-        // fast with a clear message instead of letting the SQLite driver try to
-        // open a `postgres://` URL as a file path.
-        if self.backend() == Backend::Postgres {
-            return Err(
-                "DATABASE_URL selects PostgreSQL, which is not supported yet. \
-                 Use a SQLite file path or a sqlite:// URL. PostgreSQL support \
-                 is in progress."
-                    .to_string(),
-            );
-        }
         if self.auth_proxy_enabled() && self.trusted_proxy_networks.is_empty() {
             return Err(
                 "AUTH_PROXY_HEADER is set but TRUSTED_PROXY_NETWORKS is empty. \
@@ -276,13 +263,13 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_rejects_postgres_for_now() {
+    fn test_validate_accepts_both_backends() {
+        // Both a PostgreSQL URL and a SQLite path pass validation now that the
+        // sqlx data layer supports both backends (Phase C).
         let mut config = test_config();
         config.database_url = "postgres://user@localhost/rdrs".to_string();
-        let err = config.validate().expect_err("postgres must be rejected");
-        assert!(err.contains("PostgreSQL"), "message was: {err}");
+        assert!(config.validate().is_ok());
 
-        // SQLite path still validates fine.
         config.database_url = "rdrs.sqlite3".to_string();
         assert!(config.validate().is_ok());
     }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,3 +1,3 @@
 pub mod pool;
 
-pub use pool::{Db, Tx, is_unique_violation};
+pub use pool::{Db, Tx, is_unique_violation, pg_rewrite};

--- a/src/db/pool.rs
+++ b/src/db/pool.rs
@@ -2,8 +2,9 @@ use std::str::FromStr;
 use std::time::Duration;
 
 use sqlx::migrate::Migrator;
+use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
 use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous};
-use sqlx::{PgPool, Postgres, Sqlite, SqlitePool};
+use sqlx::{Executor, PgPool, Postgres, Sqlite, SqlitePool};
 use tracing::info;
 
 use crate::config::Backend;
@@ -65,7 +66,24 @@ impl Db {
                 Db::Sqlite(pool)
             }
             Backend::Postgres => {
-                let pool = PgPool::connect(url).await?;
+                // Pin every pooled connection to UTC. Entry timestamps are
+                // written with `now()` / naive `%Y-%m-%d %H:%M:%S` string binds
+                // and the composite pagination cursor compares them as strings
+                // via `to_char(col, 'YYYY-MM-DD HH24:MI:SS')`. All three are
+                // interpreted in the session `TimeZone`, so pinning it to UTC
+                // makes the PG cursor strings byte-identical to SQLite's
+                // `datetime('now')` TEXT — a divergent server default would
+                // otherwise shift the cursor and corrupt pagination order.
+                let opts = PgConnectOptions::from_str(url)?;
+                let pool = PgPoolOptions::new()
+                    .after_connect(|conn, _meta| {
+                        Box::pin(async move {
+                            conn.execute("SET TIME ZONE 'UTC'").await?;
+                            Ok(())
+                        })
+                    })
+                    .connect_with(opts)
+                    .await?;
                 Db::Postgres(pool)
             }
         };
@@ -161,6 +179,24 @@ pub fn is_unique_violation(e: &sqlx::Error) -> bool {
     matches!(e, sqlx::Error::Database(db) if db.kind() == sqlx::error::ErrorKind::UniqueViolation)
 }
 
+/// Rewrite the SQLite-dialect fragments in a macro `$sql` literal to their
+/// PostgreSQL equivalents at dispatch time. Applied *only* in the Postgres arm
+/// of the `query_*!` / `db_execute!` macros so a model writes one SQL literal
+/// that runs correctly on both backends.
+///
+/// Currently rewrites the SQLite scalar `datetime('now')` — which yields the
+/// `%Y-%m-%d %H:%M:%S` TEXT that the composite pagination cursor and the
+/// timestamp-column DEFAULTs depend on — to PostgreSQL `now()` (a `timestamptz`
+/// that, under the connection's pinned `TimeZone=UTC`, encodes to the same
+/// instant). The exact literal token is matched, so the comma-modifier forms
+/// (`datetime('now', '-25 hours')`, `datetime('now', $2)`) are deliberately
+/// left untouched — those need interval arithmetic and are handled with
+/// explicit `Dialect` forks at their call sites.
+#[doc(hidden)]
+pub fn pg_rewrite(sql: &str) -> String {
+    sql.replace("datetime('now')", "now()")
+}
+
 // --- dispatch macros -------------------------------------------------------
 //
 // These collapse the two-arm `match db { Sqlite(..) => .., Postgres(..) => .. }`
@@ -169,6 +205,10 @@ pub fn is_unique_violation(e: &sqlx::Error) -> bool {
 // (a SQLite superset PostgreSQL requires) and `RETURNING` is used in place of
 // `last_insert_rowid()`. Bind arguments are evaluated in *both* arms, so pass
 // `Copy` values or references (`&str`, `i64`, `DateTime<Utc>`, `&[u8]`).
+//
+// The Postgres arm runs `$sql` through `pg_rewrite` (see above) so SQLite-only
+// scalars like `datetime('now')` become their PG equivalents; the SQLite arm
+// uses the literal verbatim to keep its prepared-statement cache keyed on it.
 //
 // `$ty` must derive `sqlx::FromRow` (its generated impl is row-generic, so one
 // derive serves both `SqliteRow` and `PgRow`). Each macro has a `_tx` sibling
@@ -187,7 +227,9 @@ macro_rules! query_one {
             }
             $crate::db::Db::Postgres(pool) => {
                 #[allow(unused_mut)]
-                let mut q = ::sqlx::query_as::<::sqlx::Postgres, $ty>($sql);
+                let mut q = ::sqlx::query_as::<::sqlx::Postgres, $ty>(
+                    ::sqlx::AssertSqlSafe($crate::db::pg_rewrite($sql)),
+                );
                 $( q = q.bind($bind); )*
                 q.fetch_one(pool).await
             }
@@ -208,7 +250,9 @@ macro_rules! query_opt {
             }
             $crate::db::Db::Postgres(pool) => {
                 #[allow(unused_mut)]
-                let mut q = ::sqlx::query_as::<::sqlx::Postgres, $ty>($sql);
+                let mut q = ::sqlx::query_as::<::sqlx::Postgres, $ty>(
+                    ::sqlx::AssertSqlSafe($crate::db::pg_rewrite($sql)),
+                );
                 $( q = q.bind($bind); )*
                 q.fetch_optional(pool).await
             }
@@ -229,7 +273,9 @@ macro_rules! query_all {
             }
             $crate::db::Db::Postgres(pool) => {
                 #[allow(unused_mut)]
-                let mut q = ::sqlx::query_as::<::sqlx::Postgres, $ty>($sql);
+                let mut q = ::sqlx::query_as::<::sqlx::Postgres, $ty>(
+                    ::sqlx::AssertSqlSafe($crate::db::pg_rewrite($sql)),
+                );
                 $( q = q.bind($bind); )*
                 q.fetch_all(pool).await
             }
@@ -250,7 +296,9 @@ macro_rules! query_scalar {
             }
             $crate::db::Db::Postgres(pool) => {
                 #[allow(unused_mut)]
-                let mut q = ::sqlx::query_scalar::<::sqlx::Postgres, $ty>($sql);
+                let mut q = ::sqlx::query_scalar::<::sqlx::Postgres, $ty>(
+                    ::sqlx::AssertSqlSafe($crate::db::pg_rewrite($sql)),
+                );
                 $( q = q.bind($bind); )*
                 q.fetch_one(pool).await
             }
@@ -271,7 +319,9 @@ macro_rules! db_execute {
             }
             $crate::db::Db::Postgres(pool) => {
                 #[allow(unused_mut)]
-                let mut q = ::sqlx::query::<::sqlx::Postgres>($sql);
+                let mut q = ::sqlx::query::<::sqlx::Postgres>(
+                    ::sqlx::AssertSqlSafe($crate::db::pg_rewrite($sql)),
+                );
                 $( q = q.bind($bind); )*
                 q.execute(pool).await.map(|r| r.rows_affected())
             }
@@ -292,7 +342,9 @@ macro_rules! query_one_tx {
             }
             $crate::db::Tx::Postgres(t) => {
                 #[allow(unused_mut)]
-                let mut q = ::sqlx::query_as::<::sqlx::Postgres, $ty>($sql);
+                let mut q = ::sqlx::query_as::<::sqlx::Postgres, $ty>(
+                    ::sqlx::AssertSqlSafe($crate::db::pg_rewrite($sql)),
+                );
                 $( q = q.bind($bind); )*
                 q.fetch_one(&mut **t).await
             }
@@ -313,7 +365,9 @@ macro_rules! query_opt_tx {
             }
             $crate::db::Tx::Postgres(t) => {
                 #[allow(unused_mut)]
-                let mut q = ::sqlx::query_as::<::sqlx::Postgres, $ty>($sql);
+                let mut q = ::sqlx::query_as::<::sqlx::Postgres, $ty>(
+                    ::sqlx::AssertSqlSafe($crate::db::pg_rewrite($sql)),
+                );
                 $( q = q.bind($bind); )*
                 q.fetch_optional(&mut **t).await
             }
@@ -334,7 +388,9 @@ macro_rules! query_all_tx {
             }
             $crate::db::Tx::Postgres(t) => {
                 #[allow(unused_mut)]
-                let mut q = ::sqlx::query_as::<::sqlx::Postgres, $ty>($sql);
+                let mut q = ::sqlx::query_as::<::sqlx::Postgres, $ty>(
+                    ::sqlx::AssertSqlSafe($crate::db::pg_rewrite($sql)),
+                );
                 $( q = q.bind($bind); )*
                 q.fetch_all(&mut **t).await
             }
@@ -355,7 +411,9 @@ macro_rules! query_scalar_tx {
             }
             $crate::db::Tx::Postgres(t) => {
                 #[allow(unused_mut)]
-                let mut q = ::sqlx::query_scalar::<::sqlx::Postgres, $ty>($sql);
+                let mut q = ::sqlx::query_scalar::<::sqlx::Postgres, $ty>(
+                    ::sqlx::AssertSqlSafe($crate::db::pg_rewrite($sql)),
+                );
                 $( q = q.bind($bind); )*
                 q.fetch_one(&mut **t).await
             }
@@ -376,7 +434,9 @@ macro_rules! db_execute_tx {
             }
             $crate::db::Tx::Postgres(t) => {
                 #[allow(unused_mut)]
-                let mut q = ::sqlx::query::<::sqlx::Postgres>($sql);
+                let mut q = ::sqlx::query::<::sqlx::Postgres>(
+                    ::sqlx::AssertSqlSafe($crate::db::pg_rewrite($sql)),
+                );
                 $( q = q.bind($bind); )*
                 q.execute(&mut **t).await.map(|r| r.rows_affected())
             }

--- a/src/models/entry/filters.rs
+++ b/src/models/entry/filters.rs
@@ -48,10 +48,40 @@ impl Dialect {
     /// Unix-epoch-seconds expression for a timestamp column/expression:
     /// `CAST(strftime('%s', expr) AS INTEGER)` on `SQLite`,
     /// `EXTRACT(EPOCH FROM expr)::bigint` on `PostgreSQL`.
-    fn epoch(self, expr: &str) -> String {
+    pub(super) fn epoch(self, expr: &str) -> String {
         match self {
             Dialect::Sqlite => format!("CAST(strftime('%s', {expr}) AS INTEGER)"),
             Dialect::Postgres => format!("EXTRACT(EPOCH FROM {expr})::bigint"),
+        }
+    }
+
+    /// Render a timestamp column/expression as the `%Y-%m-%d %H:%M:%S` TEXT the
+    /// composite pagination cursor compares against. On `SQLite` the columns
+    /// already store exactly that TEXT, so the expression passes through. On
+    /// `PostgreSQL` the columns are `TIMESTAMPTZ`, so wrap in
+    /// `to_char(expr, 'YYYY-MM-DD HH24:MI:SS')`; under the connection's pinned
+    /// `TimeZone=UTC` this reproduces the same string `SQLite` stores, keeping the
+    /// string-ordered cursor byte-identical across backends. (The `ORDER BY`
+    /// still sorts on the raw expression, so the native index is unaffected;
+    /// only the cursor's WHERE predicate uses this form. TODO(phase-d): bind the
+    /// cursor as `timestamptz` on PG to make that predicate sargable too.)
+    pub(super) fn cursor_ts(self, expr: &str) -> String {
+        match self {
+            Dialect::Sqlite => expr.to_string(),
+            Dialect::Postgres => format!("to_char({expr}, 'YYYY-MM-DD HH24:MI:SS')"),
+        }
+    }
+
+    /// A timestamp `N` days in the past, where `N` is given by the SQL
+    /// expression `days_expr` (an integer literal like `30`, or an integer
+    /// column like `us.retention_read_days`). Used by the read-retention and
+    /// snapshot-window predicates, which compare a stored timestamp against this
+    /// cutoff. `SQLite` builds it with `datetime('now', '-N days')` (concatenating
+    /// the count in); `PostgreSQL` uses `now() - make_interval(days => N)`.
+    pub(super) fn days_ago(self, days_expr: &str) -> String {
+        match self {
+            Dialect::Sqlite => format!("datetime('now', '-' || ({days_expr}) || ' days')"),
+            Dialect::Postgres => format!("now() - make_interval(days => ({days_expr})::int)"),
         }
     }
 
@@ -125,9 +155,12 @@ pub(super) fn apply_filter_conditions(
             // Snapshot semantics: entries read during the current page view
             // (read_at at-or-after the page's render instant) stay in the
             // unread navigation set. `>=` (not `>`) so a same-second
-            // open-after-load still counts as in-snapshot.
+            // open-after-load still counts as in-snapshot. `read_after` is the
+            // `%Y-%m-%d %H:%M:%S` snapshot string, so compare it against the
+            // same TEXT form of `read_at` on both backends (to_char on PG).
             let idx = binds.len() + 1;
-            conditions.push(format!("(e.read_at IS NULL OR e.read_at >= ${idx})"));
+            let read_at = dialect.cursor_ts("e.read_at");
+            conditions.push(format!("(e.read_at IS NULL OR {read_at} >= ${idx})"));
             binds.push(Bind::Text(read_after.clone()));
         } else {
             conditions.push("e.read_at IS NULL".to_string());
@@ -199,6 +232,7 @@ pub(super) fn apply_continuation_condition(
     continuation: Option<&ContinuationCursor>,
     sort_order: EntrySortOrder,
     oldest_first: bool,
+    dialect: Dialect,
 ) {
     let Some(cursor) = continuation else {
         return;
@@ -211,6 +245,11 @@ pub(super) fn apply_continuation_condition(
                 EntrySortOrder::StarredAt => "e.starred_at",
                 EntrySortOrder::PublishedAt => "COALESCE(e.published_at, e.created_at)",
             };
+            // Compare the cursor string against the same TEXT form on both
+            // backends (a no-op on SQLite; `to_char(...)` on PG). The bound
+            // cursor value is the `%Y-%m-%d %H:%M:%S` string emitted by
+            // `fetch_sort_ts`.
+            let expr = dialect.cursor_ts(sort_ts_expr);
             let (cmp_outer, cmp_inner) = if oldest_first {
                 (">=", ">")
             } else {
@@ -221,7 +260,6 @@ pub(super) fn apply_continuation_condition(
             let id_idx = binds.len() + 3;
             conditions.push(format!(
                 "{expr} {cmp_outer} ${ts1} AND ({expr} {cmp_inner} ${ts2} OR e.id {cmp_inner} ${id_idx})",
-                expr = sort_ts_expr,
             ));
             binds.push(Bind::Text(sort_ts.clone()));
             binds.push(Bind::Text(sort_ts.clone()));

--- a/src/models/entry/mod.rs
+++ b/src/models/entry/mod.rs
@@ -1,12 +1,10 @@
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, SubsecRound, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::db::{Db, Tx};
 use crate::error::{AppError, AppResult};
 use crate::utils::text::strip_to_search_text;
-use crate::{
-    db_execute, db_execute_tx, query_all, query_all_tx, query_opt, query_opt_tx, query_scalar,
-};
+use crate::{db_execute, db_execute_tx, query_all, query_opt, query_opt_tx, query_scalar};
 
 mod filters;
 use filters::{
@@ -193,7 +191,7 @@ const ENTRY_WITH_FEED_COLUMNS_COUNT: &str = "e.id AS id, e.feed_id AS feed_id, e
 
 /// Same columns as [`ENTRY_WITH_FEED_COLUMNS_COUNT`] but computes `has_icon`
 /// from a `LEFT JOIN image i` already present in the query.
-const ENTRY_WITH_FEED_COLUMNS_JOIN: &str = "e.id AS id, e.feed_id AS feed_id, e.guid AS guid, e.title AS title, e.link AS link, e.content AS content, e.summary AS summary, e.author AS author, e.published_at AS published_at, e.read_at AS read_at, e.starred_at AS starred_at, e.created_at AS created_at, e.updated_at AS updated_at, f.title AS feed_title, f.url AS feed_url, f.site_url AS site_url, c.id AS category_id, c.name AS category_name, CASE WHEN i.id IS NOT NULL THEN 1 ELSE 0 END AS has_icon, f.custom_referrer AS custom_referrer";
+const ENTRY_WITH_FEED_COLUMNS_JOIN: &str = "e.id AS id, e.feed_id AS feed_id, e.guid AS guid, e.title AS title, e.link AS link, e.content AS content, e.summary AS summary, e.author AS author, e.published_at AS published_at, e.read_at AS read_at, e.starred_at AS starred_at, e.created_at AS created_at, e.updated_at AS updated_at, f.title AS feed_title, f.url AS feed_url, f.site_url AS site_url, c.id AS category_id, c.name AS category_name, CAST(CASE WHEN i.id IS NOT NULL THEN 1 ELSE 0 END AS BIGINT) AS has_icon, f.custom_referrer AS custom_referrer";
 
 // --- dynamic-query execution helpers ---------------------------------------
 //
@@ -303,7 +301,8 @@ async fn exec_dynamic(db: &Db, sql: String, binds: Vec<Bind>) -> Result<u64, sql
             q.execute(pool).await.map(|r| r.rows_affected())
         }
         Db::Postgres(pool) => {
-            let mut q = sqlx::query::<sqlx::Postgres>(sqlx::AssertSqlSafe(sql));
+            let mut q =
+                sqlx::query::<sqlx::Postgres>(sqlx::AssertSqlSafe(crate::db::pg_rewrite(&sql)));
             for b in &binds {
                 q = match b {
                     Bind::Int(i) => q.bind(*i),
@@ -333,7 +332,8 @@ async fn exec_dynamic_tx(
             q.execute(&mut **t).await.map(|r| r.rows_affected())
         }
         Tx::Postgres(t) => {
-            let mut q = sqlx::query::<sqlx::Postgres>(sqlx::AssertSqlSafe(sql));
+            let mut q =
+                sqlx::query::<sqlx::Postgres>(sqlx::AssertSqlSafe(crate::db::pg_rewrite(&sql)));
             for b in &binds {
                 q = match b {
                     Bind::Int(i) => q.bind(*i),
@@ -405,9 +405,12 @@ pub async fn fetch_sort_ts(
         EntrySortOrder::StarredAt => "starred_at",
         EntrySortOrder::PublishedAt => "COALESCE(published_at, created_at)",
     };
-    // TODO(phase-c): reads the raw stored timestamp TEXT; on PG these columns are
-    // TIMESTAMPTZ and would need `to_char`/cast to reproduce the cursor string.
-    let sql = format!("SELECT {column_expr} FROM entry WHERE id = $1");
+    // Emit the cursor string in the exact form the WHERE predicate compares
+    // against: the raw TEXT column on SQLite, `to_char(..., 'YYYY-MM-DD
+    // HH24:MI:SS')` on PG (columns are TIMESTAMPTZ there). See
+    // `Dialect::cursor_ts`.
+    let ts_expr = Dialect::from_db(db).cursor_ts(column_expr);
+    let sql = format!("SELECT {ts_expr} FROM entry WHERE id = $1");
     let r = match db {
         Db::Sqlite(pool) => {
             sqlx::query_scalar::<sqlx::Sqlite, Option<String>>(sqlx::AssertSqlSafe(sql))
@@ -622,7 +625,12 @@ pub async fn upsert_entry_id(
     author: Option<&str>,
     published_at: Option<DateTime<Utc>>,
 ) -> AppResult<UpsertOutcome> {
-    let published_at_str = published_at.map(|dt| dt.format("%Y-%m-%d %H:%M:%S").to_string());
+    // Bind published_at as a seconds-truncated NaiveDateTime: sqlx encodes it as
+    // the `%Y-%m-%d %H:%M:%S` TEXT the SQLite composite cursor compares against,
+    // and as a `timestamp` that assignment-casts into the column's `timestamptz`
+    // (UTC session) on PG. A raw `%Y-%m-%d %H:%M:%S` *string* bind is rejected by
+    // PG here — text does not coerce into a timestamptz column.
+    let published_at_ts = published_at.map(|dt| dt.naive_utc().trunc_subsecs(0));
     let content_text = content.map(strip_to_search_text);
 
     let existing =
@@ -655,7 +663,7 @@ pub async fn upsert_entry_id(
         content,
         summary,
         author,
-        published_at_str.as_deref(),
+        published_at_ts,
         content_text.as_deref()
     )
     .map_err(AppError::Database)?;
@@ -680,7 +688,12 @@ pub async fn upsert_entry_id_tx(
     author: Option<&str>,
     published_at: Option<DateTime<Utc>>,
 ) -> AppResult<UpsertOutcome> {
-    let published_at_str = published_at.map(|dt| dt.format("%Y-%m-%d %H:%M:%S").to_string());
+    // Bind published_at as a seconds-truncated NaiveDateTime: sqlx encodes it as
+    // the `%Y-%m-%d %H:%M:%S` TEXT the SQLite composite cursor compares against,
+    // and as a `timestamp` that assignment-casts into the column's `timestamptz`
+    // (UTC session) on PG. A raw `%Y-%m-%d %H:%M:%S` *string* bind is rejected by
+    // PG here — text does not coerce into a timestamptz column.
+    let published_at_ts = published_at.map(|dt| dt.naive_utc().trunc_subsecs(0));
     let content_text = content.map(strip_to_search_text);
 
     let existing =
@@ -713,7 +726,7 @@ pub async fn upsert_entry_id_tx(
         content,
         summary,
         author,
-        published_at_str.as_deref(),
+        published_at_ts,
         content_text.as_deref()
     )
     .map_err(AppError::Database)?;
@@ -735,19 +748,25 @@ pub async fn insert_tombstone(db: &Db, feed_id: i64, guid: &str) -> AppResult<()
     Ok(())
 }
 
-/// Victim-selection query for retention pruning. TODO(phase-c): the per-row
-/// `datetime('now', '-' || us.retention_read_days || ' days')` interval is
-/// SQLite-only; PG needs `now() - make_interval(days => us.retention_read_days)`.
-const RETENTION_VICTIMS_SQL: &str = "SELECT e.id, e.feed_id, e.guid \
-     FROM entry e \
-     JOIN feed f           ON f.id = e.feed_id \
-     JOIN category c       ON c.id = f.category_id \
-     JOIN user_settings us ON us.user_id = c.user_id \
-     WHERE us.retention_read_days > 0 \
-       AND e.read_at    IS NOT NULL \
-       AND e.starred_at IS NULL \
-       AND e.read_at < datetime('now', '-' || us.retention_read_days || ' days') \
-     LIMIT $1";
+/// Build the victim-selection query for retention pruning. The per-user age
+/// cutoff `read_at < now - retention_read_days` dialect-forks its interval
+/// expression (see [`Dialect::days_ago`]), so the SQL is assembled at call time
+/// rather than being a `const` literal.
+fn retention_victims_sql(dialect: Dialect) -> String {
+    let cutoff = dialect.days_ago("us.retention_read_days");
+    format!(
+        "SELECT e.id, e.feed_id, e.guid \
+         FROM entry e \
+         JOIN feed f           ON f.id = e.feed_id \
+         JOIN category c       ON c.id = f.category_id \
+         JOIN user_settings us ON us.user_id = c.user_id \
+         WHERE us.retention_read_days > 0 \
+           AND e.read_at    IS NOT NULL \
+           AND e.starred_at IS NULL \
+           AND e.read_at < {cutoff} \
+         LIMIT $1"
+    )
+}
 
 /// Delete up to `batch_size` read, aged, non-starred entries belonging to users
 /// who have opted into retention (`user_settings.retention_read_days > 0`),
@@ -758,14 +777,26 @@ const RETENTION_VICTIMS_SQL: &str = "SELECT e.id, e.feed_id, e.guid \
 /// side) so the delete targets exact ids rather than re-running a `LIMIT`
 /// without `ORDER BY`. Each user's own threshold is applied via the join.
 pub async fn prune_read_retention_batch(db: &Db, batch_size: usize) -> AppResult<u64> {
+    let sql = retention_victims_sql(Dialect::from_db(db));
     let mut tx = db.begin().await?;
 
-    let victims: Vec<(i64, i64, String)> = query_all_tx!(
-        &mut tx,
-        (i64, i64, String),
-        RETENTION_VICTIMS_SQL,
-        batch_size as i64
-    )
+    // Dynamic SQL (dialect-forked interval) can't go through the static-SQL
+    // `query_all_tx!` macro, so dispatch the fetch on the transaction's backend
+    // directly.
+    let victims: Vec<(i64, i64, String)> = match &mut tx {
+        Tx::Sqlite(t) => {
+            sqlx::query_as::<sqlx::Sqlite, (i64, i64, String)>(sqlx::AssertSqlSafe(sql))
+                .bind(batch_size as i64)
+                .fetch_all(&mut **t)
+                .await
+        }
+        Tx::Postgres(t) => {
+            sqlx::query_as::<sqlx::Postgres, (i64, i64, String)>(sqlx::AssertSqlSafe(sql))
+                .bind(batch_size as i64)
+                .fetch_all(&mut **t)
+                .await
+        }
+    }
     .map_err(AppError::Database)?;
 
     if victims.is_empty() {
@@ -1062,6 +1093,7 @@ pub async fn list_ids_by_user(
         pagination.continuation.as_ref(),
         pagination.sort_order,
         pagination.oldest_first,
+        dialect,
     );
 
     let where_clause = conditions.join(" AND ");
@@ -1075,10 +1107,11 @@ pub async fn list_ids_by_user(
     };
 
     let limit_idx = binds.len() + 1;
-    // TODO(phase-c): `strftime('%s', ...)` epoch extraction is SQLite-only; PG
-    // needs `EXTRACT(EPOCH FROM ...)::bigint`.
+    // Epoch-microseconds sentinel for the "no more pages" boundary; the epoch
+    // extraction dialect-forks (SQLite `strftime` vs PG `EXTRACT(EPOCH …)`).
+    let epoch_us = dialect.epoch("COALESCE(e.published_at, e.created_at)");
     let sql = format!(
-        "SELECT e.id, CAST(strftime('%s', COALESCE(e.published_at, e.created_at)) AS INTEGER) * 1000000 \
+        "SELECT e.id, {epoch_us} * 1000000 \
          FROM entry e \
          INNER JOIN feed f ON e.feed_id = f.id \
          INNER JOIN category c ON f.category_id = c.id \
@@ -1118,6 +1151,7 @@ pub async fn list_by_user_with_continuation(
         pagination.continuation.as_ref(),
         pagination.sort_order,
         pagination.oldest_first,
+        dialect,
     );
 
     let where_clause = conditions.join(" AND ");
@@ -1177,7 +1211,8 @@ pub async fn mark_all_read_by_feed(
     // TEXT format. TODO(phase-c): PG needs `now() - make_interval(days => ...)`.
     let age_condition = older_than_days
         .map(|days| {
-            format!(" AND COALESCE(published_at, created_at) < datetime('now', '-{days} days')")
+            let cutoff = Dialect::from_db(db).days_ago(&days.to_string());
+            format!(" AND COALESCE(published_at, created_at) < {cutoff}")
         })
         .unwrap_or_default();
 
@@ -1199,7 +1234,8 @@ pub async fn mark_all_read_by_user(
 ) -> AppResult<i64> {
     let age_condition = older_than_days
         .map(|days| {
-            format!(" AND COALESCE(published_at, created_at) < datetime('now', '-{days} days')")
+            let cutoff = Dialect::from_db(db).days_ago(&days.to_string());
+            format!(" AND COALESCE(published_at, created_at) < {cutoff}")
         })
         .unwrap_or_default();
 
@@ -1267,28 +1303,42 @@ pub async fn find_neighbors(
 ) -> AppResult<EntryNeighbors> {
     let dialect = Dialect::from_db(db);
 
-    // Get the current entry's sort timestamp (raw stored TEXT).
-    let sort_time = query_opt!(
-        db,
-        (String,),
-        "SELECT COALESCE(e.published_at, e.created_at) \
+    // Get the current entry's sort timestamp as the `%Y-%m-%d %H:%M:%S` cursor
+    // TEXT (to_char on PG — see `Dialect::cursor_ts`), so it compares against the
+    // neighbour predicates below in the same form on both backends.
+    let sort_ts_select = dialect.cursor_ts("COALESCE(e.published_at, e.created_at)");
+    let sort_time_sql = format!(
+        "SELECT {sort_ts_select} \
          FROM entry e \
          INNER JOIN feed f ON e.feed_id = f.id \
          INNER JOIN category c ON f.category_id = c.id \
-         WHERE e.id = $1 AND c.user_id = $2",
-        entry_id,
-        user_id
-    )
+         WHERE e.id = $1 AND c.user_id = $2"
+    );
+    let sort_time: Option<String> = match db {
+        Db::Sqlite(pool) => {
+            sqlx::query_scalar::<sqlx::Sqlite, Option<String>>(sqlx::AssertSqlSafe(sort_time_sql))
+                .bind(entry_id)
+                .bind(user_id)
+                .fetch_optional(pool)
+                .await
+                .map(Option::flatten)
+        }
+        Db::Postgres(pool) => {
+            sqlx::query_scalar::<sqlx::Postgres, Option<String>>(sqlx::AssertSqlSafe(sort_time_sql))
+                .bind(entry_id)
+                .bind(user_id)
+                .fetch_optional(pool)
+                .await
+                .map(Option::flatten)
+        }
+    }
     .map_err(AppError::Database)?;
 
-    let sort_time = match sort_time {
-        Some((t,)) => t,
-        None => {
-            return Ok(EntryNeighbors {
-                prev_id: None,
-                next_id: None,
-            });
-        }
+    let Some(sort_time) = sort_time else {
+        return Ok(EntryNeighbors {
+            prev_id: None,
+            next_id: None,
+        });
     };
 
     // Build filter conditions using apply_filter_conditions.
@@ -1342,6 +1392,11 @@ pub async fn find_neighbors(
     };
     let entry_hint = dialect.index_hint(raw_hint);
 
+    // Compare the bound `sort_time` cursor TEXT against the same form of the
+    // sort expression (raw on SQLite; to_char on PG). ORDER BY stays on the raw
+    // expression so the native sort index is unaffected.
+    let cmp_ts = dialect.cursor_ts("COALESCE(e.published_at, e.created_at)");
+
     // Find previous entry (newer, comes before in DESC order)
     let prev_sql = format!(
         "SELECT e.id \
@@ -1349,7 +1404,7 @@ pub async fn find_neighbors(
          {join_kw} feed f ON e.feed_id = f.id \
          {join_kw} category c ON f.category_id = c.id \
          WHERE c.user_id = $1 \
-           AND COALESCE(e.published_at, e.created_at) > $2{prev_extra} \
+           AND {cmp_ts} > $2{prev_extra} \
          ORDER BY COALESCE(e.published_at, e.created_at) ASC \
          LIMIT 1"
     );
@@ -1361,8 +1416,8 @@ pub async fn find_neighbors(
          {join_kw} feed f ON e.feed_id = f.id \
          {join_kw} category c ON f.category_id = c.id \
          WHERE c.user_id = $1 \
-           AND (COALESCE(e.published_at, e.created_at) < $2 \
-                OR (COALESCE(e.published_at, e.created_at) = $2 AND e.id < $3)){next_extra} \
+           AND ({cmp_ts} < $2 \
+                OR ({cmp_ts} = $2 AND e.id < $3)){next_extra} \
          ORDER BY COALESCE(e.published_at, e.created_at) DESC, e.id DESC \
          LIMIT 1"
     );
@@ -1409,7 +1464,8 @@ pub async fn mark_all_read_by_category(
 ) -> AppResult<i64> {
     let age_condition = older_than_days
         .map(|days| {
-            format!(" AND COALESCE(published_at, created_at) < datetime('now', '-{days} days')")
+            let cutoff = Dialect::from_db(db).days_ago(&days.to_string());
+            format!(" AND COALESCE(published_at, created_at) < {cutoff}")
         })
         .unwrap_or_default();
 

--- a/src/models/statistics.rs
+++ b/src/models/statistics.rs
@@ -4,6 +4,29 @@ use crate::db::Db;
 use crate::error::{AppError, AppResult};
 use crate::{query_all, query_scalar};
 
+/// Render a timestamp column/expression as the `%Y-%m-%d %H:%M:%S` TEXT this
+/// module reads into `String`. `SQLite` stores exactly that TEXT (pass-through);
+/// PG columns are `TIMESTAMPTZ`, so wrap in `to_char(..., 'YYYY-MM-DD
+/// HH24:MI:SS')` (UTC session) — a bare read would fail to decode a timestamptz
+/// into `String`. Mirrors `entry::filters::Dialect::cursor_ts`.
+fn ts_text(db: &Db, expr: &str) -> String {
+    match db {
+        Db::Sqlite(_) => expr.to_string(),
+        Db::Postgres(_) => format!("to_char({expr}, 'YYYY-MM-DD HH24:MI:SS')"),
+    }
+}
+
+/// Parse a `YYYY-MM-DD` date-range bound for binding. As a `NaiveDate` it
+/// compares correctly against the timestamp columns on both backends: `SQLite`
+/// compares the `YYYY-MM-DD` TEXT lexicographically against the stored
+/// `%Y-%m-%d %H:%M:%S`, and `PostgreSQL` implicitly casts `date` to
+/// `timestamptz` — a raw `%Y-%m-%d` *string* bind would not coerce against a
+/// timestamptz column. Falls back to today on an unparseable input (matching the
+/// range-fill fallback used when charting).
+fn parse_ymd(s: &str) -> NaiveDate {
+    NaiveDate::parse_from_str(s, "%Y-%m-%d").unwrap_or_else(|_| chrono::Utc::now().date_naive())
+}
+
 /// Overview metrics for a user within a date range.
 #[derive(Default)]
 pub struct PersonalOverview {
@@ -134,6 +157,9 @@ pub async fn get_personal_overview(
     from: &str,
     to: &str,
 ) -> AppResult<PersonalOverview> {
+    // Bind the range bounds as dates (see `parse_ymd`) so the `>= $2 / < $3`
+    // comparisons against the timestamp columns work on both backends.
+    let (from, to) = (parse_ymd(from), parse_ymd(to));
     let total_entries: i64 = query_scalar!(
         db,
         i64,
@@ -230,26 +256,44 @@ pub async fn get_daily_read_counts(
     to: &str,
 ) -> AppResult<Vec<DailyReadCount>> {
     // Ad-hoc `(date_string, count)` rows → fetch as a tuple and post-process in
-    // Rust (fill zero-count days below).
-    // TODO(phase-c): PG dialect — `DATE(e.read_at)` should be `(e.read_at)::date`.
-    let rows = query_all!(
-        db,
-        (String, i64),
-        r#"
-        SELECT DATE(e.read_at) AS read_date, COUNT(e.id) AS cnt
-        FROM entry e
-        INNER JOIN feed f ON e.feed_id = f.id
-        INNER JOIN category c ON f.category_id = c.id
-        WHERE c.user_id = $1
-          AND e.read_at >= $2
-          AND e.read_at < $3
-        GROUP BY read_date
-        ORDER BY read_date
-        "#,
-        user_id,
-        from,
-        to,
-    )
+    // Rust (fill zero-count days below). Only the day bucket dialect-forks:
+    // SQLite's `DATE()` vs PG's `to_char(...)`. The range bounds are bound as
+    // dates (see `parse_ymd`) so the raw `read_at >= $2 / < $3` comparison works
+    // on both backends without wrapping the column.
+    let day_bucket = match db {
+        Db::Sqlite(_) => "DATE(e.read_at)".to_string(),
+        Db::Postgres(_) => "to_char(e.read_at, 'YYYY-MM-DD')".to_string(),
+    };
+    let (from_d, to_d) = (parse_ymd(from), parse_ymd(to));
+    let sql = format!(
+        "SELECT {day_bucket} AS read_date, COUNT(e.id) AS cnt \
+         FROM entry e \
+         INNER JOIN feed f ON e.feed_id = f.id \
+         INNER JOIN category c ON f.category_id = c.id \
+         WHERE c.user_id = $1 \
+           AND e.read_at >= $2 \
+           AND e.read_at < $3 \
+         GROUP BY read_date \
+         ORDER BY read_date"
+    );
+    let rows: Vec<(String, i64)> = match db {
+        Db::Sqlite(pool) => {
+            sqlx::query_as::<sqlx::Sqlite, (String, i64)>(sqlx::AssertSqlSafe(sql))
+                .bind(user_id)
+                .bind(from_d)
+                .bind(to_d)
+                .fetch_all(pool)
+                .await
+        }
+        Db::Postgres(pool) => {
+            sqlx::query_as::<sqlx::Postgres, (String, i64)>(sqlx::AssertSqlSafe(sql))
+                .bind(user_id)
+                .bind(from_d)
+                .bind(to_d)
+                .fetch_all(pool)
+                .await
+        }
+    }
     .map_err(AppError::Database)?;
 
     let mut counts_map = std::collections::HashMap::new();
@@ -289,6 +333,7 @@ pub async fn get_entries_by_category(
 ) -> AppResult<Vec<CategoryCount>> {
     // `AS count` so `FromRow` (column-name match) populates `CategoryCount.count`;
     // HAVING/ORDER BY reference the aggregate directly (portable, alias-free).
+    let (from, to) = (parse_ymd(from), parse_ymd(to));
     query_all!(
         db,
         CategoryCount,
@@ -324,6 +369,7 @@ pub async fn get_top_feeds(
 ) -> AppResult<Vec<FeedCount>> {
     // `AS count` so `FromRow` (column-name match) populates `FeedCount.count`;
     // HAVING/ORDER BY reference the aggregate directly (portable, alias-free).
+    let (from, to) = (parse_ymd(from), parse_ymd(to));
     query_all!(
         db,
         FeedCount,
@@ -351,7 +397,7 @@ pub async fn get_top_feeds(
 /// Get site-wide admin counts (period-independent).
 pub async fn get_admin_counts(db: &Db) -> AppResult<AdminCounts> {
     let total_users: i64 =
-        query_scalar!(db, i64, "SELECT COUNT(*) FROM user").map_err(AppError::Database)?;
+        query_scalar!(db, i64, "SELECT COUNT(*) FROM \"user\"").map_err(AppError::Database)?;
 
     let total_feeds: i64 =
         query_scalar!(db, i64, "SELECT COUNT(*) FROM feed").map_err(AppError::Database)?;
@@ -364,6 +410,7 @@ pub async fn get_admin_counts(db: &Db) -> AppResult<AdminCounts> {
 
 /// Get site-wide admin entry stats within a date range.
 pub async fn get_admin_entry_stats(db: &Db, from: &str, to: &str) -> AppResult<AdminEntryStats> {
+    let (from, to) = (parse_ymd(from), parse_ymd(to));
     let total_entries: i64 = query_scalar!(
         db,
         i64,
@@ -403,9 +450,12 @@ pub async fn get_admin_entry_stats(db: &Db, from: &str, to: &str) -> AppResult<A
 
 /// Get site-wide database storage + record stats (period-independent).
 pub async fn get_admin_database_stats(db: &Db) -> AppResult<AdminDatabaseStats> {
-    // Page-level storage stats come from SQLite PRAGMAs, which have no direct
-    // sqlx/portable equivalent, so dispatch per-backend explicitly.
-    let (page_count, page_size, freelist): (i64, i64, i64) = match db {
+    // Storage stats dialect-fork. SQLite exposes page-level accounting via
+    // PRAGMAs (total size = page_count * page_size; reclaimable = freelist *
+    // page_size). PostgreSQL reports the on-disk database size via
+    // `pg_database_size()`; it has no directly comparable freelist/reclaimable
+    // figure (bloat is a VACUUM concern), so reclaimable is reported as 0.
+    let (db_size_bytes, reclaimable_bytes) = match db {
         Db::Sqlite(pool) => {
             let page_count = sqlx::query_scalar::<_, i64>("PRAGMA page_count")
                 .fetch_one(pool)
@@ -419,15 +469,17 @@ pub async fn get_admin_database_stats(db: &Db) -> AppResult<AdminDatabaseStats> 
                 .fetch_one(pool)
                 .await
                 .map_err(AppError::Database)?;
-            (page_count, page_size, freelist)
+            (page_count * page_size, freelist * page_size)
         }
-        // TODO(phase-c): PG size via pg_database_size() (and there is no
-        // freelist concept — VACUUM/bloat stats differ). Zeroes for now.
-        Db::Postgres(_pool) => (0, 0, 0),
+        Db::Postgres(pool) => {
+            let size = sqlx::query_scalar::<_, i64>("SELECT pg_database_size(current_database())")
+                .fetch_one(pool)
+                .await
+                .map_err(AppError::Database)?;
+            (size, 0)
+        }
     };
 
-    let db_size_bytes = page_count * page_size;
-    let reclaimable_bytes = freelist * page_size;
     let fragmentation_ratio = if db_size_bytes > 0 {
         reclaimable_bytes as f64 / db_size_bytes as f64
     } else {
@@ -436,13 +488,37 @@ pub async fn get_admin_database_stats(db: &Db) -> AppResult<AdminDatabaseStats> 
 
     let total_entries: i64 =
         query_scalar!(db, i64, "SELECT COUNT(*) FROM entry").map_err(AppError::Database)?;
-    // Bare MIN/MAX so SQLite uses the idx_entry_created_at endpoint optimization.
-    let min_created: Option<String> =
-        query_scalar!(db, Option<String>, "SELECT MIN(created_at) FROM entry")
-            .map_err(AppError::Database)?;
-    let max_created: Option<String> =
-        query_scalar!(db, Option<String>, "SELECT MAX(created_at) FROM entry")
-            .map_err(AppError::Database)?;
+    // Bare MIN/MAX so SQLite uses the idx_entry_created_at endpoint
+    // optimization; the timestamp is read back as the `%Y-%m-%d %H:%M:%S` TEXT
+    // `try_parse_datetime` expects (to_char on PG — see `ts_text`).
+    let min_sql = format!("SELECT {} FROM entry", ts_text(db, "MIN(created_at)"));
+    let max_sql = format!("SELECT {} FROM entry", ts_text(db, "MAX(created_at)"));
+    let min_created: Option<String> = match db {
+        Db::Sqlite(pool) => {
+            sqlx::query_scalar::<_, Option<String>>(sqlx::AssertSqlSafe(min_sql))
+                .fetch_one(pool)
+                .await
+        }
+        Db::Postgres(pool) => {
+            sqlx::query_scalar::<_, Option<String>>(sqlx::AssertSqlSafe(min_sql))
+                .fetch_one(pool)
+                .await
+        }
+    }
+    .map_err(AppError::Database)?;
+    let max_created: Option<String> = match db {
+        Db::Sqlite(pool) => {
+            sqlx::query_scalar::<_, Option<String>>(sqlx::AssertSqlSafe(max_sql))
+                .fetch_one(pool)
+                .await
+        }
+        Db::Postgres(pool) => {
+            sqlx::query_scalar::<_, Option<String>>(sqlx::AssertSqlSafe(max_sql))
+                .fetch_one(pool)
+                .await
+        }
+    }
+    .map_err(AppError::Database)?;
     let tombstone_count: i64 = query_scalar!(db, i64, "SELECT COUNT(*) FROM entry_tombstone")
         .map_err(AppError::Database)?;
 

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -105,7 +105,7 @@ pub async fn create_user(
     query_one!(
         db,
         User,
-        "INSERT INTO user (username, password_hash, role) VALUES ($1, $2, $3) \
+        "INSERT INTO \"user\" (username, password_hash, role) VALUES ($1, $2, $3) \
          RETURNING id, username, password_hash, role, disabled_at, created_at",
         username,
         password_hash,
@@ -125,7 +125,7 @@ pub async fn find_by_username(db: &Db, username: &str) -> AppResult<Option<User>
         db,
         User,
         "SELECT id, username, password_hash, role, disabled_at, created_at \
-         FROM user WHERE username = $1",
+         FROM \"user\" WHERE username = $1",
         username
     )
     .map_err(AppError::Database)
@@ -136,7 +136,7 @@ pub async fn find_by_id(db: &Db, id: i64) -> AppResult<Option<User>> {
         db,
         User,
         "SELECT id, username, password_hash, role, disabled_at, created_at \
-         FROM user WHERE id = $1",
+         FROM \"user\" WHERE id = $1",
         id
     )
     .map_err(AppError::Database)
@@ -147,7 +147,7 @@ pub async fn list_all(db: &Db) -> AppResult<Vec<User>> {
         db,
         User,
         "SELECT id, username, password_hash, role, disabled_at, created_at \
-         FROM user ORDER BY id"
+         FROM \"user\" ORDER BY id"
     )
     .map_err(AppError::Database)
 }
@@ -155,7 +155,7 @@ pub async fn list_all(db: &Db) -> AppResult<Vec<User>> {
 pub async fn update_password(db: &Db, user_id: i64, new_password_hash: &str) -> AppResult<()> {
     let rows = db_execute!(
         db,
-        "UPDATE user SET password_hash = $1 WHERE id = $2",
+        "UPDATE \"user\" SET password_hash = $1 WHERE id = $2",
         new_password_hash,
         user_id
     )
@@ -170,7 +170,7 @@ pub async fn update_password(db: &Db, user_id: i64, new_password_hash: &str) -> 
 pub async fn update_role(db: &Db, user_id: i64, role: Role) -> AppResult<()> {
     let rows = db_execute!(
         db,
-        "UPDATE user SET role = $1 WHERE id = $2",
+        "UPDATE \"user\" SET role = $1 WHERE id = $2",
         role.as_str(),
         user_id
     )
@@ -185,7 +185,7 @@ pub async fn update_role(db: &Db, user_id: i64, role: Role) -> AppResult<()> {
 pub async fn disable_user(db: &Db, user_id: i64) -> AppResult<()> {
     let rows = db_execute!(
         db,
-        "UPDATE user SET disabled_at = $1 WHERE id = $2",
+        "UPDATE \"user\" SET disabled_at = $1 WHERE id = $2",
         Utc::now(),
         user_id
     )
@@ -200,7 +200,7 @@ pub async fn disable_user(db: &Db, user_id: i64) -> AppResult<()> {
 pub async fn enable_user(db: &Db, user_id: i64) -> AppResult<()> {
     let rows = db_execute!(
         db,
-        "UPDATE user SET disabled_at = NULL WHERE id = $1",
+        "UPDATE \"user\" SET disabled_at = NULL WHERE id = $1",
         user_id
     )
     .map_err(AppError::Database)?;
@@ -222,7 +222,7 @@ pub async fn delete_user(db: &Db, user_id: i64) -> AppResult<()> {
 }
 
 pub async fn count(db: &Db) -> AppResult<i64> {
-    query_scalar!(db, i64, "SELECT COUNT(*) FROM user").map_err(AppError::Database)
+    query_scalar!(db, i64, "SELECT COUNT(*) FROM \"user\"").map_err(AppError::Database)
 }
 
 #[cfg(test)]

--- a/src/services/content_text_backfill.rs
+++ b/src/services/content_text_backfill.rs
@@ -124,7 +124,7 @@ mod tests {
     async fn setup_db() -> Db {
         let db = Db::connect_in_memory().await.unwrap();
         for stmt in [
-            "INSERT INTO user (id, username, password_hash) VALUES (1, 'u', 'x')",
+            "INSERT INTO \"user\" (id, username, password_hash) VALUES (1, 'u', 'x')",
             "INSERT INTO category (id, user_id, name) VALUES (1, 1, 'c')",
             "INSERT INTO feed (id, category_id, url) VALUES (1, 1, 'http://x')",
         ] {

--- a/tests/postgres_test.rs
+++ b/tests/postgres_test.rs
@@ -1,0 +1,289 @@
+//! Live-PostgreSQL integration test for the dual-backend data layer (Phase C).
+//!
+//! Gated on `TEST_DATABASE_URL` (a `postgres://` URL): when unset the test is a
+//! no-op so the default `cargo nextest` run — which only has `SQLite` — stays
+//! green. CI sets it to a throwaway Postgres service. Locally:
+//!
+//! ```sh
+//! docker run -d --name pg -e POSTGRES_PASSWORD=rdrs -e POSTGRES_USER=rdrs \
+//!     -e POSTGRES_DB=rdrs -p 55432:5432 postgres:17-alpine
+//! TEST_DATABASE_URL=postgres://rdrs:rdrs@localhost:55432/rdrs \
+//!     cargo nextest run --test postgres_test
+//! ```
+//!
+//! Everything runs in ONE test function so it stays isolated on a shared server
+//! (parallel tests would race on the same tables). It drives the SQL paths that
+//! dialect-fork between `SQLite` and PG — the composite-cursor `to_char`
+//! comparison, `datetime('now')`→`now()`, interval arithmetic (`make_interval`),
+//! `pg_database_size`, the `DATE()`/`to_char` stats bucket, the `"user"`
+//! reserved-word quoting, and the `is_unique_violation` mapping — against a real
+//! server.
+
+use rdrs::config::Backend;
+use rdrs::db::Db;
+use rdrs::error::AppError;
+use rdrs::models::user::Role;
+use rdrs::models::{
+    category, entry,
+    entry::{ContinuationCursor, ContinuationParams, EntryFilter, EntrySortOrder},
+    feed, statistics, user, user_settings,
+};
+
+/// Connect to the test Postgres and wipe every table so the run is isolated and
+/// repeatable against a persistent container. Returns `None` (skip) when
+/// `TEST_DATABASE_URL` is unset.
+async fn setup() -> Option<Db> {
+    let url = std::env::var("TEST_DATABASE_URL").ok()?;
+    let db = Db::connect(&url, Backend::Postgres)
+        .await
+        .expect("connect to TEST_DATABASE_URL Postgres");
+    rdrs::db_execute!(
+        &db,
+        "TRUNCATE \"user\", category, feed, entry, entry_summary, entry_tombstone, \
+         image, passkey, session, user_settings, webauthn_challenge RESTART IDENTITY CASCADE"
+    )
+    .expect("truncate");
+    Some(db)
+}
+
+async fn seed_feed(db: &Db) -> (i64, i64, i64) {
+    let user_id = user::create_user(db, "pguser", "hash", Role::User)
+        .await
+        .unwrap()
+        .id;
+    let category_id = category::create_category(db, user_id, "Tech")
+        .await
+        .unwrap()
+        .id;
+    let feed_id = feed::create_feed(
+        db,
+        &feed::CreateFeedParams {
+            category_id,
+            url: "https://example.com/feed.xml",
+            title: Some("Feed"),
+            description: None,
+            site_url: None,
+            custom_user_agent: None,
+            http2_disabled: None,
+            custom_referrer: None,
+        },
+    )
+    .await
+    .unwrap()
+    .id;
+    (user_id, category_id, feed_id)
+}
+
+fn utc(s: &str) -> chrono::DateTime<chrono::Utc> {
+    chrono::DateTime::parse_from_rfc3339(s)
+        .unwrap()
+        .with_timezone(&chrono::Utc)
+}
+
+#[tokio::test]
+async fn pg_dialect_smoke() {
+    let Some(db) = setup().await else {
+        eprintln!("TEST_DATABASE_URL unset; skipping Postgres integration test");
+        return;
+    };
+    let (user_id, _cat, feed_id) = seed_feed(&db).await;
+
+    // --- composite-cursor pagination (to_char cursor + %Y-%m-%d %H:%M:%S) -----
+    let mut ids = Vec::new();
+    for (guid, pub_at) in [
+        ("g1", "2026-07-07T12:00:00Z"),
+        ("g2", "2026-07-07T12:00:00Z"), // shares a second → id tie-break
+        ("g3", "2026-07-06T09:30:00Z"),
+    ] {
+        let (e, _) = entry::upsert_entry(
+            &db,
+            feed_id,
+            guid,
+            Some("t"),
+            Some("l"),
+            None,
+            None,
+            None,
+            Some(utc(pub_at)),
+        )
+        .await
+        .unwrap();
+        ids.push(e.id);
+    }
+
+    let filter = EntryFilter::default();
+    let page1 = entry::list_by_user_with_continuation(
+        &db,
+        user_id,
+        &filter,
+        &ContinuationParams {
+            oldest_first: false,
+            limit: 1,
+            sort_order: EntrySortOrder::PublishedAt,
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(page1.len(), 1);
+    let last = &page1[0];
+    let sort_ts = entry::fetch_sort_ts(&db, last.entry.id, EntrySortOrder::PublishedAt)
+        .await
+        .unwrap()
+        .expect("sort_ts");
+    // The cursor string must be the SQLite-compatible space-format, not RFC3339.
+    assert_eq!(
+        sort_ts, "2026-07-07 12:00:00",
+        "cursor ts must be %Y-%m-%d %H:%M:%S"
+    );
+
+    let page2 = entry::list_by_user_with_continuation(
+        &db,
+        user_id,
+        &filter,
+        &ContinuationParams {
+            oldest_first: false,
+            limit: 10,
+            sort_order: EntrySortOrder::PublishedAt,
+            continuation: Some(ContinuationCursor::Composite {
+                sort_ts,
+                id: last.entry.id,
+            }),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        page2.len(),
+        2,
+        "cursor must return the two remaining entries"
+    );
+    assert!(
+        page2[0].entry.id < last.entry.id || page2[0].entry.published_at < last.entry.published_at,
+        "continuation must not repeat or precede the cursor row"
+    );
+
+    // --- personal overview + category/feed stats (date-range vs timestamp) ----
+    let overview = statistics::get_personal_overview(&db, user_id, "2026-07-01", "2026-07-31")
+        .await
+        .unwrap();
+    assert_eq!(overview.total_entries, 3, "all 3 entries fall in range");
+    let by_cat = statistics::get_entries_by_category(&db, user_id, "2026-07-01", "2026-07-31")
+        .await
+        .unwrap();
+    assert_eq!(by_cat.len(), 1);
+    assert_eq!(by_cat[0].count, 3);
+    let top_feeds = statistics::get_top_feeds(&db, user_id, "2026-07-01", "2026-07-31", 10)
+        .await
+        .unwrap();
+    assert_eq!(top_feeds.len(), 1);
+    assert_eq!(top_feeds[0].count, 3);
+    let admin_entries = statistics::get_admin_entry_stats(&db, "2026-07-01", "2026-07-31")
+        .await
+        .unwrap();
+    assert_eq!(admin_entries.total_entries, 3);
+
+    // --- find_neighbors (cursor to_char comparison + sort_ts read) ------------
+    // ids[2] is g3 (oldest by published_at): it has a newer neighbour (prev) and
+    // no older one (next).
+    let oldest = ids[2];
+    let neigh = entry::find_neighbors(&db, user_id, oldest, &EntryFilter::default())
+        .await
+        .unwrap();
+    assert!(
+        neigh.prev_id.is_some(),
+        "oldest entry has a newer neighbour"
+    );
+    assert!(
+        neigh.next_id.is_none(),
+        "oldest entry has no older neighbour"
+    );
+
+    // --- datetime('now')->now() shim + snapshot read_after (to_char) ----------
+    let target = last.entry.id;
+    let (_, changed) = entry::set_read_for_user(&db, user_id, target, true)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(changed);
+    let refreshed = entry::find_by_id(&db, target).await.unwrap().unwrap();
+    assert!(refreshed.read_at.is_some(), "read_at set via now()");
+
+    // Unread filter with a snapshot boundary just before the read instant keeps
+    // the just-read entry in-snapshot: exercises the to_char read_at comparison.
+    let snapshot = EntryFilter {
+        unread_only: true,
+        read_after: Some("2000-01-01 00:00:00".to_string()),
+        ..Default::default()
+    };
+    let in_snapshot = entry::list_by_user_with_continuation(
+        &db,
+        user_id,
+        &snapshot,
+        &ContinuationParams {
+            oldest_first: false,
+            limit: 10,
+            sort_order: EntrySortOrder::PublishedAt,
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    assert!(
+        in_snapshot.iter().any(|e| e.entry.id == target),
+        "read-after snapshot must keep the just-read entry visible"
+    );
+
+    // --- mark_all_read_by_feed age cutoff (make_interval fork) ----------------
+    let affected = entry::mark_all_read_by_feed(&db, feed_id, Some(3650))
+        .await
+        .unwrap();
+    assert_eq!(affected, 0, "no entry is older than 3650 days");
+
+    // --- retention prune (column-driven make_interval fork) -------------------
+    // Backdate the read entry 40 days (PG-only test SQL) and set 30-day
+    // retention so it becomes a prune victim.
+    rdrs::db_execute!(
+        &db,
+        "UPDATE entry SET read_at = now() - make_interval(days => 40) WHERE id = $1",
+        target
+    )
+    .unwrap();
+    user_settings::update_retention_read_days(&db, user_id, 30)
+        .await
+        .unwrap();
+    let deleted = entry::prune_read_retention_batch(&db, 100).await.unwrap();
+    assert_eq!(deleted, 1, "the 40-day-old read entry must be pruned");
+    assert!(entry::find_by_id(&db, target).await.unwrap().is_none());
+
+    // --- statistics: DATE()/to_char bucket + read_at range --------------------
+    // Read one of the remaining entries "today" for a non-empty daily bucket.
+    let read_today = page2[0].entry.id;
+    entry::set_read_for_user(&db, user_id, read_today, true)
+        .await
+        .unwrap();
+    let today = chrono::Utc::now().format("%Y-%m-%d").to_string();
+    let tomorrow = (chrono::Utc::now() + chrono::Duration::days(1))
+        .format("%Y-%m-%d")
+        .to_string();
+    let counts = statistics::get_daily_read_counts(&db, user_id, &today, &tomorrow)
+        .await
+        .unwrap();
+    let total: i64 = counts.iter().map(|c| c.count).sum();
+    assert_eq!(total, 1, "exactly one entry read today");
+
+    // --- admin stats: pg_database_size + MIN/MAX(created_at) to_char ----------
+    let admin = statistics::get_admin_database_stats(&db).await.unwrap();
+    assert!(admin.db_size_bytes > 0, "pg_database_size must be positive");
+    assert_eq!(admin.total_entries, 2, "two entries remain after prune");
+
+    // --- unique-violation mapping (is_unique_violation on PG) ------------------
+    let err = category::create_category(&db, user_id, "Tech")
+        .await
+        .expect_err("duplicate category must fail");
+    assert!(
+        matches!(err, AppError::CategoryExists),
+        "expected CategoryExists, got {err:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Completes the multi-database effort: **PostgreSQL is now a runtime-selectable backend** alongside SQLite, chosen once at startup from `DATABASE_URL` (bare path / `sqlite://` → SQLite; `postgres://` → PostgreSQL). SQLite stays the zero-config single-binary default and **every SQLite path is unchanged**.

All dialect differences are isolated behind `entry::filters::Dialect` and a central `pg_rewrite` shim, so model SQL is still written once and dispatched through the `query_*!` / `db_execute!` macros.

## What forks on PostgreSQL

- Connections pin `TimeZone=UTC` so timestamp-string cursors stay byte-identical to SQLite's `datetime('now')` TEXT.
- `pg_rewrite` shim rewrites `datetime('now')` → `now()` in the dispatch macros and dynamic-exec helpers.
- Composite cursor, snapshot `read_after`, and neighbor comparisons wrap the column in `to_char(...,'YYYY-MM-DD HH24:MI:SS')` (`Dialect::cursor_ts`) so the string-ordered cursor is preserved; `fetch_sort_ts` and neighbor `sort_ts` reads use the same.
- Interval arithmetic forks to `make_interval` (`Dialect::days_ago`); date-range bounds bind as `NaiveDate` (PG implicitly casts `date` → `timestamptz`).
- Timestamp columns read into `String` wrap in `to_char`; `DATE()` → `to_char`, `PRAGMA` → `pg_database_size()`, epoch via `EXTRACT(EPOCH …)`.
- The reserved `"user"` table is quoted uniformly (valid on both backends).
- PG migration: non-id `INTEGER` → `BIGINT` and the `has_icon` 0/1 flag `CAST(... AS BIGINT)` to match the `i64` reads under sqlx-PG's strict integer widths.
- The config `validate()` PostgreSQL rejection is removed.

## Testing

- New env-gated `tests/postgres_test.rs` drives every dialect-forked path (cursor pagination, `datetime('now')`, snapshot `read_after`, interval/retention, statistics date-range + daily bucket, `pg_database_size`, `"user"` quoting, unique-violation mapping, neighbors) against a **live PostgreSQL 17**. It skips cleanly without `TEST_DATABASE_URL`.
- A `postgres:17-alpine` CI service lane runs it.
- Full SQLite suite (**975 tests**) and the PG integration test both pass locally; `fmt` / `clippy -D warnings` / `deny` clean.

## Deferred

`TODO(phase-d)`: the PG cursor `to_char` predicate is not sargable — binding the cursor as `timestamptz` would restore index range scans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)