### PR TITLE
Restore write-priority scheduling for SQLite

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,9 +63,10 @@ the cross-cutting facts that span multiple files.
 - **Dual-backend `sqlx` data layer** (`db/pool.rs`). The backend is chosen once
   at startup from `DATABASE_URL`: a bare path or `sqlite://` URL selects SQLite
   (WAL, the zero-config single-binary default); a `postgres://` URL selects
-  PostgreSQL. `enum Db { Sqlite(SqlitePool), Postgres(PgPool) }` (and a
-  backend-tagged `enum Tx`) dispatch every query through the `query_*!` /
-  `db_execute!` macros so SQL + binds are written once. The few genuine dialect
+  PostgreSQL. `struct Db` wraps `enum DbInner { Sqlite(SqlitePool),
+  Postgres(PgPool) }` plus a scheduling `Priority` and a shared SQLite scheduler;
+  it (and a backend-tagged `enum Tx`) dispatch every query through the `query_*!`
+  / `db_execute!` macros so SQL + binds are written once. The few genuine dialect
   differences are isolated behind `entry::filters::Dialect` and a `pg_rewrite`
   shim (`datetime('now')`→`now()`, `to_char` cursor comparisons, `make_interval`,
   quoted `"user"`, etc. — see the multi-db spec). PG connections pin
@@ -74,6 +75,11 @@ the cross-cutting facts that span multiple files.
   run via `sqlx::migrate!`. Models expose CRUD as free functions taking `&Db` /
   `&mut Tx` and `*Params` structs. The env-gated `tests/postgres_test.rs`
   validates the PG paths against a live server (CI Postgres service lane).
+  **Write priority (SQLite):** the default `Db` in `AppState` is `User`; the
+  background workers call `db.background()` so their DB ops yield to interactive
+  work while SQLite's single writer is contended (`admit()` gates a background op
+  until no `User` op is in flight). No-op on PostgreSQL (MVCC has real writer
+  concurrency).
 
 - **Background feed sync** (`services/background.rs`, `feed_sync.rs`). Feeds are
   distributed across 60 one-minute buckets by URL hash (`feed.bucket` column);

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,3 +1,3 @@
 pub mod pool;
 
-pub use pool::{Db, Tx, is_unique_violation, pg_rewrite};
+pub use pool::{Db, DbInner, Priority, Tx, is_unique_violation, pg_rewrite};

--- a/src/db/pool.rs
+++ b/src/db/pool.rs
@@ -1,10 +1,13 @@
 use std::str::FromStr;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use sqlx::migrate::Migrator;
 use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
 use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions, SqliteSynchronous};
 use sqlx::{Executor, PgPool, Postgres, Sqlite, SqlitePool};
+use tokio::sync::Notify;
 use tracing::info;
 
 use crate::config::Backend;
@@ -16,16 +19,94 @@ use crate::config::Backend;
 static SQLITE_MIGRATOR: Migrator = sqlx::migrate!("migrations/sqlite");
 static POSTGRES_MIGRATOR: Migrator = sqlx::migrate!("migrations/postgres");
 
-/// A boot-time-selected database handle wrapping a single backend's `sqlx`
-/// pool. The backend is chosen once from `DATABASE_URL` (see [`Backend`]) and
-/// never changes for the life of the process, so every query dispatches on
-/// this two-armed enum via the `query_*!` macros.
-///
-/// Cloning is cheap: `sqlx` pools are `Arc`-backed handles.
+/// The backend-tagged `sqlx` pool held inside a [`Db`]. Chosen once from
+/// `DATABASE_URL` (see [`Backend`]) and never changed for the process lifetime.
+/// Cloning is cheap — `sqlx` pools are `Arc`-backed handles.
 #[derive(Clone)]
-pub enum Db {
+pub enum DbInner {
     Sqlite(SqlitePool),
     Postgres(PgPool),
+}
+
+/// Scheduling priority of a [`Db`] handle. Every handle carries one; the default
+/// `User` handle lives in `AppState`, and background workers derive a
+/// `Background` handle via [`Db::background`].
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Priority {
+    /// Interactive, user-facing work (handlers, middleware).
+    User,
+    /// Background work (feed sync, summary worker, retention, backfill).
+    Background,
+}
+
+/// `SQLite` write-priority scheduler. `SQLite` serializes writers, so a background
+/// batch (a feed-sync entry upsert, a retention delete run) can make an
+/// interactive click wait on the single write lock. This restores the priority
+/// the pre-sqlx actor gave: background DB operations yield at their boundary
+/// while any interactive operation is in flight.
+///
+/// It is a thin admission gate, not a queue: `User` ops increment `inflight`
+/// for their duration; `Background` ops await `inflight == 0` before running.
+/// `PostgreSQL` has real writer concurrency (MVCC), so its handles never touch
+/// this — the gate is a no-op there.
+#[derive(Default)]
+struct SqliteSched {
+    /// Count of in-flight `User`-priority operations.
+    inflight: AtomicUsize,
+    /// Notified when `inflight` drops to zero, waking waiting background ops.
+    idle: Notify,
+}
+
+impl SqliteSched {
+    /// Register a `User` operation and return a guard that unregisters it (and
+    /// wakes background waiters when the last one finishes) on drop.
+    fn enter_user(self: &Arc<Self>) -> UserGuard {
+        self.inflight.fetch_add(1, Ordering::AcqRel);
+        UserGuard(self.clone())
+    }
+
+    /// Block until no `User` operation is in flight. Called by background ops
+    /// before they touch the write lock so interactive work goes first.
+    async fn wait_for_idle(&self) {
+        loop {
+            // Register for the wakeup *before* the final check so a
+            // notify_waiters() between the check and the await can't be lost.
+            let notified = self.idle.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
+            if self.inflight.load(Ordering::Acquire) == 0 {
+                return;
+            }
+            notified.await;
+        }
+    }
+}
+
+/// RAII marker for an in-flight `User` operation (see [`SqliteSched`]).
+pub struct UserGuard(Arc<SqliteSched>);
+
+impl Drop for UserGuard {
+    fn drop(&mut self) {
+        if self.0.inflight.fetch_sub(1, Ordering::AcqRel) == 1 {
+            // Last user op finished — let background work proceed.
+            self.0.idle.notify_waiters();
+        }
+    }
+}
+
+/// A boot-time-selected database handle: a backend pool plus a scheduling
+/// [`Priority`] and a shared `SQLite` write scheduler. Every query dispatches on
+/// the inner two-armed enum via the `query_*!` macros, which consult the
+/// priority/scheduler so background work yields to interactive work on `SQLite`.
+///
+/// Cloning is cheap (pool + `Arc` handles) and preserves the priority; use
+/// [`Db::background`] to derive a background-priority handle sharing the same
+/// pool and scheduler.
+#[derive(Clone)]
+pub struct Db {
+    inner: DbInner,
+    sched: Arc<SqliteSched>,
+    priority: Priority,
 }
 
 /// A backend-tagged transaction, the unit-of-work boundary for operations that
@@ -33,8 +114,15 @@ pub enum Db {
 /// tag edits). Inner model calls execute against `&mut Tx` via the `*_tx!`
 /// macros. Obtained from [`Db::begin`]; finished with [`Tx::commit`] or
 /// [`Tx::rollback`] (a dropped `Tx` rolls back).
+///
+/// The optional `_guard` on the `SQLite` variant holds the write-priority
+/// admission for the whole transaction: acquired at [`Db::begin`] (a background
+/// tx waits for interactive idle first) and released when the tx is dropped.
 pub enum Tx<'c> {
-    Sqlite(sqlx::Transaction<'c, Sqlite>),
+    Sqlite {
+        tx: sqlx::Transaction<'c, Sqlite>,
+        _guard: Option<UserGuard>,
+    },
     Postgres(sqlx::Transaction<'c, Postgres>),
 }
 
@@ -63,7 +151,7 @@ impl Db {
                     .max_connections(5)
                     .connect_with(opts)
                     .await?;
-                Db::Sqlite(pool)
+                DbInner::Sqlite(pool)
             }
             Backend::Postgres => {
                 // Pin every pooled connection to UTC. Entry timestamps are
@@ -84,8 +172,13 @@ impl Db {
                     })
                     .connect_with(opts)
                     .await?;
-                Db::Postgres(pool)
+                DbInner::Postgres(pool)
             }
+        };
+        let db = Db {
+            inner: db,
+            sched: Arc::new(SqliteSched::default()),
+            priority: Priority::User,
         };
         db.migrate().await?;
         Ok(db)
@@ -101,9 +194,51 @@ impl Db {
             .max_connections(1)
             .connect_with(opts)
             .await?;
-        let db = Db::Sqlite(pool);
+        let db = Db {
+            inner: DbInner::Sqlite(pool),
+            sched: Arc::new(SqliteSched::default()),
+            priority: Priority::User,
+        };
         db.migrate().await?;
         Ok(db)
+    }
+
+    /// The backend pool this handle dispatches to. Used by the `query_*!` macros
+    /// and the dynamic-query helpers to match on the concrete backend.
+    pub fn inner(&self) -> &DbInner {
+        &self.inner
+    }
+
+    /// `true` if this handle is backed by `PostgreSQL` (drives dialect forks).
+    pub fn is_postgres(&self) -> bool {
+        matches!(self.inner, DbInner::Postgres(_))
+    }
+
+    /// Derive a background-priority handle sharing this handle's pool and `SQLite`
+    /// scheduler. Background workers (feed sync, summary worker, retention,
+    /// backfill) call this once so their DB operations yield to interactive work
+    /// on `SQLite`. No-op effect on `PostgreSQL`.
+    pub fn background(&self) -> Db {
+        Db {
+            inner: self.inner.clone(),
+            sched: self.sched.clone(),
+            priority: Priority::Background,
+        }
+    }
+
+    /// Acquire this handle's write-priority admission for one operation. On
+    /// `SQLite` a `User` op returns a guard tracking it as in-flight; a
+    /// `Background` op first waits for interactive idle. On `PostgreSQL` (real
+    /// writer concurrency) this is a no-op. The `query_*!` macros hold the
+    /// returned guard across the query; [`Db::begin`] holds it across the tx.
+    pub async fn admit(&self) -> Option<UserGuard> {
+        if matches!(self.inner, DbInner::Sqlite(_)) {
+            match self.priority {
+                Priority::User => return Some(self.sched.enter_user()),
+                Priority::Background => self.sched.wait_for_idle().await,
+            }
+        }
+        None
     }
 
     /// Run the backend's embedded migrations. Migrations use `IF NOT EXISTS`,
@@ -111,25 +246,31 @@ impl Db {
     /// consolidated `0001` no-ops against already-present tables and is recorded
     /// in `_sqlx_migrations`.
     async fn migrate(&self) -> Result<(), sqlx::Error> {
-        match self {
-            Db::Sqlite(pool) => SQLITE_MIGRATOR.run(pool).await,
-            Db::Postgres(pool) => POSTGRES_MIGRATOR.run(pool).await,
+        match &self.inner {
+            DbInner::Sqlite(pool) => SQLITE_MIGRATOR.run(pool).await,
+            DbInner::Postgres(pool) => POSTGRES_MIGRATOR.run(pool).await,
         }
         .map_err(|e| sqlx::Error::Migrate(Box::new(e)))
     }
 
-    /// Begin a transaction on the underlying pool.
+    /// Begin a transaction on the underlying pool. The write-priority admission
+    /// is held for the whole transaction (a background tx waits for interactive
+    /// idle before starting).
     pub async fn begin(&self) -> Result<Tx<'_>, sqlx::Error> {
-        Ok(match self {
-            Db::Sqlite(pool) => Tx::Sqlite(pool.begin().await?),
-            Db::Postgres(pool) => Tx::Postgres(pool.begin().await?),
+        let guard = self.admit().await;
+        Ok(match &self.inner {
+            DbInner::Sqlite(pool) => Tx::Sqlite {
+                tx: pool.begin().await?,
+                _guard: guard,
+            },
+            DbInner::Postgres(pool) => Tx::Postgres(pool.begin().await?),
         })
     }
 
     /// Flush and close the pool. For `SQLite` this truncates the WAL first so no
     /// `-wal`/`-shm` sidecars linger after shutdown.
     pub async fn shutdown(&self) {
-        if let Db::Sqlite(pool) = self {
+        if let DbInner::Sqlite(pool) = &self.inner {
             info!("Executing WAL checkpoint before shutdown...");
             if let Err(e) = sqlx::query("PRAGMA wal_checkpoint(TRUNCATE);")
                 .execute(pool)
@@ -138,9 +279,9 @@ impl Db {
                 tracing::error!("WAL checkpoint failed: {e}");
             }
         }
-        match self {
-            Db::Sqlite(pool) => pool.close().await,
-            Db::Postgres(pool) => pool.close().await,
+        match &self.inner {
+            DbInner::Sqlite(pool) => pool.close().await,
+            DbInner::Postgres(pool) => pool.close().await,
         }
     }
 }
@@ -149,7 +290,7 @@ impl Tx<'_> {
     /// Commit the transaction.
     pub async fn commit(self) -> Result<(), sqlx::Error> {
         match self {
-            Tx::Sqlite(t) => t.commit().await,
+            Tx::Sqlite { tx, .. } => tx.commit().await,
             Tx::Postgres(t) => t.commit().await,
         }
     }
@@ -157,7 +298,7 @@ impl Tx<'_> {
     /// Roll the transaction back explicitly (dropping also rolls back).
     pub async fn rollback(self) -> Result<(), sqlx::Error> {
         match self {
-            Tx::Sqlite(t) => t.rollback().await,
+            Tx::Sqlite { tx, .. } => tx.rollback().await,
             Tx::Postgres(t) => t.rollback().await,
         }
     }
@@ -165,9 +306,9 @@ impl Tx<'_> {
 
 impl std::fmt::Debug for Db {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Db::Sqlite(_) => f.write_str("Db::Sqlite"),
-            Db::Postgres(_) => f.write_str("Db::Postgres"),
+        match self.inner {
+            DbInner::Sqlite(_) => write!(f, "Db::Sqlite({:?})", self.priority),
+            DbInner::Postgres(_) => write!(f, "Db::Postgres({:?})", self.priority),
         }
     }
 }
@@ -179,14 +320,14 @@ pub fn is_unique_violation(e: &sqlx::Error) -> bool {
     matches!(e, sqlx::Error::Database(db) if db.kind() == sqlx::error::ErrorKind::UniqueViolation)
 }
 
-/// Rewrite the SQLite-dialect fragments in a macro `$sql` literal to their
-/// PostgreSQL equivalents at dispatch time. Applied *only* in the Postgres arm
+/// Rewrite the `SQLite`-dialect fragments in a macro `$sql` literal to their
+/// `PostgreSQL` equivalents at dispatch time. Applied *only* in the Postgres arm
 /// of the `query_*!` / `db_execute!` macros so a model writes one SQL literal
 /// that runs correctly on both backends.
 ///
-/// Currently rewrites the SQLite scalar `datetime('now')` — which yields the
+/// Currently rewrites the `SQLite` scalar `datetime('now')` — which yields the
 /// `%Y-%m-%d %H:%M:%S` TEXT that the composite pagination cursor and the
-/// timestamp-column DEFAULTs depend on — to PostgreSQL `now()` (a `timestamptz`
+/// timestamp-column DEFAULTs depend on — to `PostgreSQL` `now()` (a `timestamptz`
 /// that, under the connection's pinned `TimeZone=UTC`, encodes to the same
 /// instant). The exact literal token is matched, so the comma-modifier forms
 /// (`datetime('now', '-25 hours')`, `datetime('now', $2)`) are deliberately
@@ -214,18 +355,24 @@ pub fn pg_rewrite(sql: &str) -> String {
 // derive serves both `SqliteRow` and `PgRow`). Each macro has a `_tx` sibling
 // that runs against `&mut Tx` for transactional composition.
 
+// Each non-tx macro binds `$db` once, takes the write-priority admission
+// (`admit()` — a User op registers as in-flight; a Background op waits for SQLite
+// interactive idle; no-op on PG), runs the query while holding it, then releases.
+
 /// `SELECT` exactly one row as `$ty`.
 #[macro_export]
 macro_rules! query_one {
     ($db:expr, $ty:ty, $sql:expr $(, $bind:expr)* $(,)?) => {{
-        match $db {
-            $crate::db::Db::Sqlite(pool) => {
+        let __db = $db;
+        let __guard = __db.admit().await;
+        let __r = match __db.inner() {
+            $crate::db::DbInner::Sqlite(pool) => {
                 #[allow(unused_mut)]
                 let mut q = ::sqlx::query_as::<::sqlx::Sqlite, $ty>($sql);
                 $( q = q.bind($bind); )*
                 q.fetch_one(pool).await
             }
-            $crate::db::Db::Postgres(pool) => {
+            $crate::db::DbInner::Postgres(pool) => {
                 #[allow(unused_mut)]
                 let mut q = ::sqlx::query_as::<::sqlx::Postgres, $ty>(
                     ::sqlx::AssertSqlSafe($crate::db::pg_rewrite($sql)),
@@ -233,7 +380,9 @@ macro_rules! query_one {
                 $( q = q.bind($bind); )*
                 q.fetch_one(pool).await
             }
-        }
+        };
+        ::core::mem::drop(__guard);
+        __r
     }};
 }
 
@@ -241,14 +390,16 @@ macro_rules! query_one {
 #[macro_export]
 macro_rules! query_opt {
     ($db:expr, $ty:ty, $sql:expr $(, $bind:expr)* $(,)?) => {{
-        match $db {
-            $crate::db::Db::Sqlite(pool) => {
+        let __db = $db;
+        let __guard = __db.admit().await;
+        let __r = match __db.inner() {
+            $crate::db::DbInner::Sqlite(pool) => {
                 #[allow(unused_mut)]
                 let mut q = ::sqlx::query_as::<::sqlx::Sqlite, $ty>($sql);
                 $( q = q.bind($bind); )*
                 q.fetch_optional(pool).await
             }
-            $crate::db::Db::Postgres(pool) => {
+            $crate::db::DbInner::Postgres(pool) => {
                 #[allow(unused_mut)]
                 let mut q = ::sqlx::query_as::<::sqlx::Postgres, $ty>(
                     ::sqlx::AssertSqlSafe($crate::db::pg_rewrite($sql)),
@@ -256,7 +407,9 @@ macro_rules! query_opt {
                 $( q = q.bind($bind); )*
                 q.fetch_optional(pool).await
             }
-        }
+        };
+        ::core::mem::drop(__guard);
+        __r
     }};
 }
 
@@ -264,14 +417,16 @@ macro_rules! query_opt {
 #[macro_export]
 macro_rules! query_all {
     ($db:expr, $ty:ty, $sql:expr $(, $bind:expr)* $(,)?) => {{
-        match $db {
-            $crate::db::Db::Sqlite(pool) => {
+        let __db = $db;
+        let __guard = __db.admit().await;
+        let __r = match __db.inner() {
+            $crate::db::DbInner::Sqlite(pool) => {
                 #[allow(unused_mut)]
                 let mut q = ::sqlx::query_as::<::sqlx::Sqlite, $ty>($sql);
                 $( q = q.bind($bind); )*
                 q.fetch_all(pool).await
             }
-            $crate::db::Db::Postgres(pool) => {
+            $crate::db::DbInner::Postgres(pool) => {
                 #[allow(unused_mut)]
                 let mut q = ::sqlx::query_as::<::sqlx::Postgres, $ty>(
                     ::sqlx::AssertSqlSafe($crate::db::pg_rewrite($sql)),
@@ -279,7 +434,9 @@ macro_rules! query_all {
                 $( q = q.bind($bind); )*
                 q.fetch_all(pool).await
             }
-        }
+        };
+        ::core::mem::drop(__guard);
+        __r
     }};
 }
 
@@ -287,14 +444,16 @@ macro_rules! query_all {
 #[macro_export]
 macro_rules! query_scalar {
     ($db:expr, $ty:ty, $sql:expr $(, $bind:expr)* $(,)?) => {{
-        match $db {
-            $crate::db::Db::Sqlite(pool) => {
+        let __db = $db;
+        let __guard = __db.admit().await;
+        let __r = match __db.inner() {
+            $crate::db::DbInner::Sqlite(pool) => {
                 #[allow(unused_mut)]
                 let mut q = ::sqlx::query_scalar::<::sqlx::Sqlite, $ty>($sql);
                 $( q = q.bind($bind); )*
                 q.fetch_one(pool).await
             }
-            $crate::db::Db::Postgres(pool) => {
+            $crate::db::DbInner::Postgres(pool) => {
                 #[allow(unused_mut)]
                 let mut q = ::sqlx::query_scalar::<::sqlx::Postgres, $ty>(
                     ::sqlx::AssertSqlSafe($crate::db::pg_rewrite($sql)),
@@ -302,7 +461,9 @@ macro_rules! query_scalar {
                 $( q = q.bind($bind); )*
                 q.fetch_one(pool).await
             }
-        }
+        };
+        ::core::mem::drop(__guard);
+        __r
     }};
 }
 
@@ -310,14 +471,16 @@ macro_rules! query_scalar {
 #[macro_export]
 macro_rules! db_execute {
     ($db:expr, $sql:expr $(, $bind:expr)* $(,)?) => {{
-        match $db {
-            $crate::db::Db::Sqlite(pool) => {
+        let __db = $db;
+        let __guard = __db.admit().await;
+        let __r = match __db.inner() {
+            $crate::db::DbInner::Sqlite(pool) => {
                 #[allow(unused_mut)]
                 let mut q = ::sqlx::query::<::sqlx::Sqlite>($sql);
                 $( q = q.bind($bind); )*
                 q.execute(pool).await.map(|r| r.rows_affected())
             }
-            $crate::db::Db::Postgres(pool) => {
+            $crate::db::DbInner::Postgres(pool) => {
                 #[allow(unused_mut)]
                 let mut q = ::sqlx::query::<::sqlx::Postgres>(
                     ::sqlx::AssertSqlSafe($crate::db::pg_rewrite($sql)),
@@ -325,7 +488,9 @@ macro_rules! db_execute {
                 $( q = q.bind($bind); )*
                 q.execute(pool).await.map(|r| r.rows_affected())
             }
-        }
+        };
+        ::core::mem::drop(__guard);
+        __r
     }};
 }
 
@@ -334,7 +499,7 @@ macro_rules! db_execute {
 macro_rules! query_one_tx {
     ($tx:expr, $ty:ty, $sql:expr $(, $bind:expr)* $(,)?) => {{
         match $tx {
-            $crate::db::Tx::Sqlite(t) => {
+            $crate::db::Tx::Sqlite { tx: t, .. } => {
                 #[allow(unused_mut)]
                 let mut q = ::sqlx::query_as::<::sqlx::Sqlite, $ty>($sql);
                 $( q = q.bind($bind); )*
@@ -357,7 +522,7 @@ macro_rules! query_one_tx {
 macro_rules! query_opt_tx {
     ($tx:expr, $ty:ty, $sql:expr $(, $bind:expr)* $(,)?) => {{
         match $tx {
-            $crate::db::Tx::Sqlite(t) => {
+            $crate::db::Tx::Sqlite { tx: t, .. } => {
                 #[allow(unused_mut)]
                 let mut q = ::sqlx::query_as::<::sqlx::Sqlite, $ty>($sql);
                 $( q = q.bind($bind); )*
@@ -380,7 +545,7 @@ macro_rules! query_opt_tx {
 macro_rules! query_all_tx {
     ($tx:expr, $ty:ty, $sql:expr $(, $bind:expr)* $(,)?) => {{
         match $tx {
-            $crate::db::Tx::Sqlite(t) => {
+            $crate::db::Tx::Sqlite { tx: t, .. } => {
                 #[allow(unused_mut)]
                 let mut q = ::sqlx::query_as::<::sqlx::Sqlite, $ty>($sql);
                 $( q = q.bind($bind); )*
@@ -403,7 +568,7 @@ macro_rules! query_all_tx {
 macro_rules! query_scalar_tx {
     ($tx:expr, $ty:ty, $sql:expr $(, $bind:expr)* $(,)?) => {{
         match $tx {
-            $crate::db::Tx::Sqlite(t) => {
+            $crate::db::Tx::Sqlite { tx: t, .. } => {
                 #[allow(unused_mut)]
                 let mut q = ::sqlx::query_scalar::<::sqlx::Sqlite, $ty>($sql);
                 $( q = q.bind($bind); )*
@@ -426,7 +591,7 @@ macro_rules! query_scalar_tx {
 macro_rules! db_execute_tx {
     ($tx:expr, $sql:expr $(, $bind:expr)* $(,)?) => {{
         match $tx {
-            $crate::db::Tx::Sqlite(t) => {
+            $crate::db::Tx::Sqlite { tx: t, .. } => {
                 #[allow(unused_mut)]
                 let mut q = ::sqlx::query::<::sqlx::Sqlite>($sql);
                 $( q = q.bind($bind); )*
@@ -442,4 +607,116 @@ macro_rules! db_execute_tx {
             }
         }
     }};
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicBool;
+    use std::time::Duration;
+
+    // The write-priority guarantee: a background op must not proceed past its
+    // admission while any user op is in flight. Asserted via ordering — the
+    // background task checks a flag that the test sets only after the user op is
+    // done, and can only observe it once the gate lets it through.
+    #[tokio::test]
+    async fn sched_background_yields_until_user_finishes() {
+        let sched = Arc::new(SqliteSched::default());
+        let user_done = Arc::new(AtomicBool::new(false));
+
+        let user = sched.enter_user();
+        let bg = {
+            let sched = sched.clone();
+            let user_done = user_done.clone();
+            tokio::spawn(async move {
+                sched.wait_for_idle().await;
+                assert!(
+                    user_done.load(Ordering::Acquire),
+                    "background proceeded before the user op finished"
+                );
+            })
+        };
+
+        // Let the background task reach (and park on) its wait.
+        tokio::task::yield_now().await;
+        // Publish "user finished" before releasing the gate; the background task
+        // is still parked (inflight > 0), so it can only wake after this.
+        user_done.store(true, Ordering::Release);
+        drop(user);
+
+        tokio::time::timeout(Duration::from_secs(1), bg)
+            .await
+            .expect("background should proceed once the user op finishes")
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn sched_idle_lets_background_through_immediately() {
+        let sched = Arc::new(SqliteSched::default());
+        // No user op in flight — must not block.
+        tokio::time::timeout(Duration::from_secs(1), sched.wait_for_idle())
+            .await
+            .expect("wait_for_idle must return immediately when idle");
+    }
+
+    #[tokio::test]
+    async fn sched_waits_for_all_users() {
+        let sched = Arc::new(SqliteSched::default());
+        let both_done = Arc::new(AtomicBool::new(false));
+
+        let g1 = sched.enter_user();
+        let g2 = sched.enter_user();
+        let bg = {
+            let sched = sched.clone();
+            let both_done = both_done.clone();
+            tokio::spawn(async move {
+                sched.wait_for_idle().await;
+                assert!(both_done.load(Ordering::Acquire));
+            })
+        };
+
+        tokio::task::yield_now().await;
+        drop(g1); // one still in flight → background stays gated
+        tokio::task::yield_now().await;
+        both_done.store(true, Ordering::Release);
+        drop(g2);
+
+        tokio::time::timeout(Duration::from_secs(1), bg)
+            .await
+            .expect("background proceeds only after the last user op")
+            .unwrap();
+    }
+
+    // The full Db path: a background handle's `admit()` gates behind a user
+    // handle's in-flight op on SQLite.
+    #[tokio::test]
+    async fn admit_gates_background_behind_user_on_sqlite() {
+        let db = Db::connect_in_memory().await.unwrap();
+        let bg = db.background();
+        let user_done = Arc::new(AtomicBool::new(false));
+
+        let user_guard = db.admit().await;
+        assert!(
+            user_guard.is_some(),
+            "user op on SQLite registers in-flight"
+        );
+
+        let task = {
+            let bg = bg.clone();
+            let user_done = user_done.clone();
+            tokio::spawn(async move {
+                let _g = bg.admit().await; // background: waits for idle
+                assert!(user_done.load(Ordering::Acquire));
+            })
+        };
+
+        tokio::task::yield_now().await;
+        user_done.store(true, Ordering::Release);
+        drop(user_guard);
+
+        tokio::time::timeout(Duration::from_secs(1), task)
+            .await
+            .expect("background admit proceeds after the user op finishes")
+            .unwrap();
+    }
 }

--- a/src/models/entry/filters.rs
+++ b/src/models/entry/filters.rs
@@ -46,9 +46,10 @@ pub(super) enum Dialect {
 
 impl Dialect {
     pub(super) fn from_db(db: &Db) -> Self {
-        match db {
-            Db::Sqlite(_) => Dialect::Sqlite,
-            Db::Postgres(_) => Dialect::Postgres,
+        if db.is_postgres() {
+            Dialect::Postgres
+        } else {
+            Dialect::Sqlite
         }
     }
 

--- a/src/models/entry/mod.rs
+++ b/src/models/entry/mod.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, SubsecRound, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::db::{Db, Tx};
+use crate::db::{Db, DbInner, Tx};
 use crate::error::{AppError, AppResult};
 use crate::utils::text::strip_to_search_text;
 use crate::{db_execute, db_execute_tx, query_all, query_opt, query_opt_tx, query_scalar};
@@ -206,8 +206,8 @@ async fn fetch_entries_with_feed(
     sql: String,
     binds: Vec<Bind>,
 ) -> Result<Vec<EntryWithFeed>, sqlx::Error> {
-    let rows = match db {
-        Db::Sqlite(pool) => {
+    let rows = match db.inner() {
+        DbInner::Sqlite(pool) => {
             let mut q = sqlx::query_as::<sqlx::Sqlite, EntryWithFeedRow>(sqlx::AssertSqlSafe(sql));
             for b in &binds {
                 q = match b {
@@ -218,7 +218,7 @@ async fn fetch_entries_with_feed(
             }
             q.fetch_all(pool).await?
         }
-        Db::Postgres(pool) => {
+        DbInner::Postgres(pool) => {
             let mut q =
                 sqlx::query_as::<sqlx::Postgres, EntryWithFeedRow>(sqlx::AssertSqlSafe(sql));
             for b in &binds {
@@ -235,8 +235,8 @@ async fn fetch_entries_with_feed(
 }
 
 async fn fetch_scalar_i64(db: &Db, sql: String, binds: Vec<Bind>) -> Result<i64, sqlx::Error> {
-    match db {
-        Db::Sqlite(pool) => {
+    match db.inner() {
+        DbInner::Sqlite(pool) => {
             let mut q = sqlx::query_scalar::<sqlx::Sqlite, i64>(sqlx::AssertSqlSafe(sql));
             for b in &binds {
                 q = match b {
@@ -247,7 +247,7 @@ async fn fetch_scalar_i64(db: &Db, sql: String, binds: Vec<Bind>) -> Result<i64,
             }
             q.fetch_one(pool).await
         }
-        Db::Postgres(pool) => {
+        DbInner::Postgres(pool) => {
             let mut q = sqlx::query_scalar::<sqlx::Postgres, i64>(sqlx::AssertSqlSafe(sql));
             for b in &binds {
                 q = match b {
@@ -267,8 +267,8 @@ async fn fetch_id_ts_rows(
     sql: String,
     binds: Vec<Bind>,
 ) -> Result<Vec<(i64, i64)>, sqlx::Error> {
-    match db {
-        Db::Sqlite(pool) => {
+    match db.inner() {
+        DbInner::Sqlite(pool) => {
             let mut q = sqlx::query_as::<sqlx::Sqlite, (i64, i64)>(sqlx::AssertSqlSafe(sql));
             for b in &binds {
                 q = match b {
@@ -279,7 +279,7 @@ async fn fetch_id_ts_rows(
             }
             q.fetch_all(pool).await
         }
-        Db::Postgres(pool) => {
+        DbInner::Postgres(pool) => {
             let mut q = sqlx::query_as::<sqlx::Postgres, (i64, i64)>(sqlx::AssertSqlSafe(sql));
             for b in &binds {
                 q = match b {
@@ -293,10 +293,12 @@ async fn fetch_id_ts_rows(
     }
 }
 
-/// Execute a runtime-built statement, returning rows affected.
+/// Execute a runtime-built statement, returning rows affected. A write path
+/// (mark-all-read), so it takes the write-priority admission for its duration.
 async fn exec_dynamic(db: &Db, sql: String, binds: Vec<Bind>) -> Result<u64, sqlx::Error> {
-    match db {
-        Db::Sqlite(pool) => {
+    let _guard = db.admit().await;
+    match db.inner() {
+        DbInner::Sqlite(pool) => {
             let mut q = sqlx::query::<sqlx::Sqlite>(sqlx::AssertSqlSafe(sql));
             for b in &binds {
                 q = match b {
@@ -307,7 +309,7 @@ async fn exec_dynamic(db: &Db, sql: String, binds: Vec<Bind>) -> Result<u64, sql
             }
             q.execute(pool).await.map(|r| r.rows_affected())
         }
-        Db::Postgres(pool) => {
+        DbInner::Postgres(pool) => {
             let mut q =
                 sqlx::query::<sqlx::Postgres>(sqlx::AssertSqlSafe(crate::db::pg_rewrite(&sql)));
             for b in &binds {
@@ -329,7 +331,7 @@ async fn exec_dynamic_tx(
     binds: Vec<Bind>,
 ) -> Result<u64, sqlx::Error> {
     match tx {
-        Tx::Sqlite(t) => {
+        Tx::Sqlite { tx: t, .. } => {
             let mut q = sqlx::query::<sqlx::Sqlite>(sqlx::AssertSqlSafe(sql));
             for b in &binds {
                 q = match b {
@@ -421,14 +423,14 @@ pub async fn fetch_sort_ts(
     // `Dialect::cursor_ts`.
     let ts_expr = Dialect::from_db(db).cursor_ts(column_expr);
     let sql = format!("SELECT {ts_expr} FROM entry WHERE id = $1");
-    let r = match db {
-        Db::Sqlite(pool) => {
+    let r = match db.inner() {
+        DbInner::Sqlite(pool) => {
             sqlx::query_scalar::<sqlx::Sqlite, Option<String>>(sqlx::AssertSqlSafe(sql))
                 .bind(entry_id)
                 .fetch_optional(pool)
                 .await
         }
-        Db::Postgres(pool) => {
+        DbInner::Postgres(pool) => {
             sqlx::query_scalar::<sqlx::Postgres, Option<String>>(sqlx::AssertSqlSafe(sql))
                 .bind(entry_id)
                 .fetch_optional(pool)
@@ -794,7 +796,7 @@ pub async fn prune_read_retention_batch(db: &Db, batch_size: usize) -> AppResult
     // `query_all_tx!` macro, so dispatch the fetch on the transaction's backend
     // directly.
     let victims: Vec<(i64, i64, String)> = match &mut tx {
-        Tx::Sqlite(t) => {
+        Tx::Sqlite { tx: t, .. } => {
             sqlx::query_as::<sqlx::Sqlite, (i64, i64, String)>(sqlx::AssertSqlSafe(sql))
                 .bind(batch_size as i64)
                 .fetch_all(&mut **t)
@@ -1324,8 +1326,8 @@ pub async fn find_neighbors(
          INNER JOIN category c ON f.category_id = c.id \
          WHERE e.id = $1 AND c.user_id = $2"
     );
-    let sort_time: Option<String> = match db {
-        Db::Sqlite(pool) => {
+    let sort_time: Option<String> = match db.inner() {
+        DbInner::Sqlite(pool) => {
             sqlx::query_scalar::<sqlx::Sqlite, Option<String>>(sqlx::AssertSqlSafe(sort_time_sql))
                 .bind(entry_id)
                 .bind(user_id)
@@ -1333,7 +1335,7 @@ pub async fn find_neighbors(
                 .await
                 .map(Option::flatten)
         }
-        Db::Postgres(pool) => {
+        DbInner::Postgres(pool) => {
             sqlx::query_scalar::<sqlx::Postgres, Option<String>>(sqlx::AssertSqlSafe(sort_time_sql))
                 .bind(entry_id)
                 .bind(user_id)
@@ -1449,8 +1451,8 @@ pub async fn find_neighbors(
     );
 
     async fn one(db: &Db, sql: String, binds: Vec<Bind>) -> Result<Option<i64>, sqlx::Error> {
-        match db {
-            Db::Sqlite(pool) => {
+        match db.inner() {
+            DbInner::Sqlite(pool) => {
                 let mut q = sqlx::query_scalar::<sqlx::Sqlite, i64>(sqlx::AssertSqlSafe(sql));
                 for b in &binds {
                     q = match b {
@@ -1461,7 +1463,7 @@ pub async fn find_neighbors(
                 }
                 q.fetch_optional(pool).await
             }
-            Db::Postgres(pool) => {
+            DbInner::Postgres(pool) => {
                 let mut q = sqlx::query_scalar::<sqlx::Postgres, i64>(sqlx::AssertSqlSafe(sql));
                 for b in &binds {
                     q = match b {
@@ -3245,8 +3247,8 @@ mod tests {
     /// are bound (one per `$N` placeholder).
     async fn explain_plan_for(db: &Db, sql: &str, n_params: usize) -> String {
         let explain_sql = format!("EXPLAIN QUERY PLAN {}", sql);
-        let rows: Vec<(i64, i64, i64, String)> = match db {
-            Db::Sqlite(pool) => {
+        let rows: Vec<(i64, i64, i64, String)> = match db.inner() {
+            DbInner::Sqlite(pool) => {
                 let mut q = sqlx::query_as::<sqlx::Sqlite, (i64, i64, i64, String)>(
                     sqlx::AssertSqlSafe(explain_sql),
                 );
@@ -3255,7 +3257,7 @@ mod tests {
                 }
                 q.fetch_all(pool).await.unwrap()
             }
-            Db::Postgres(_) => unreachable!("tests run against sqlite"),
+            DbInner::Postgres(_) => unreachable!("tests run against sqlite"),
         };
         rows.into_iter()
             .map(|r| r.3)

--- a/src/models/feed.rs
+++ b/src/models/feed.rs
@@ -4,7 +4,7 @@ use std::hash::{Hash, Hasher};
 use chrono::{DateTime, Utc};
 use serde::Serialize;
 
-use crate::db::{Db, Tx, is_unique_violation};
+use crate::db::{Db, DbInner, Tx, is_unique_violation};
 use crate::error::{AppError, AppResult};
 use crate::models::image;
 use crate::{db_execute, db_execute_tx, query_all, query_one, query_opt, query_scalar};
@@ -314,8 +314,8 @@ pub async fn owner_user_ids_for_feeds(db: &Db, feed_ids: &[i64]) -> AppResult<Ve
     const PREFIX: &str = "SELECT DISTINCT c.user_id \
          FROM feed f JOIN category c ON c.id = f.category_id WHERE f.id IN (";
     // Dynamic IN-list: one bound placeholder per id, built per backend.
-    let rows = match db {
-        Db::Sqlite(pool) => {
+    let rows = match db.inner() {
+        DbInner::Sqlite(pool) => {
             let mut qb = sqlx::QueryBuilder::<sqlx::Sqlite>::new(PREFIX);
             let mut sep = qb.separated(", ");
             for id in feed_ids {
@@ -324,7 +324,7 @@ pub async fn owner_user_ids_for_feeds(db: &Db, feed_ids: &[i64]) -> AppResult<Ve
             qb.push(")");
             qb.build_query_scalar::<i64>().fetch_all(pool).await
         }
-        Db::Postgres(pool) => {
+        DbInner::Postgres(pool) => {
             let mut qb = sqlx::QueryBuilder::<sqlx::Postgres>::new(PREFIX);
             let mut sep = qb.separated(", ");
             for id in feed_ids {

--- a/src/models/statistics.rs
+++ b/src/models/statistics.rs
@@ -1,6 +1,6 @@
 use chrono::NaiveDate;
 
-use crate::db::Db;
+use crate::db::{Db, DbInner};
 use crate::error::{AppError, AppResult};
 use crate::{query_all, query_scalar};
 
@@ -10,9 +10,10 @@ use crate::{query_all, query_scalar};
 /// HH24:MI:SS')` (UTC session) — a bare read would fail to decode a timestamptz
 /// into `String`. Mirrors `entry::filters::Dialect::cursor_ts`.
 fn ts_text(db: &Db, expr: &str) -> String {
-    match db {
-        Db::Sqlite(_) => expr.to_string(),
-        Db::Postgres(_) => format!("to_char({expr}, 'YYYY-MM-DD HH24:MI:SS')"),
+    if db.is_postgres() {
+        format!("to_char({expr}, 'YYYY-MM-DD HH24:MI:SS')")
+    } else {
+        expr.to_string()
     }
 }
 
@@ -260,9 +261,10 @@ pub async fn get_daily_read_counts(
     // SQLite's `DATE()` vs PG's `to_char(...)`. The range bounds are bound as
     // dates (see `parse_ymd`) so the raw `read_at >= $2 / < $3` comparison works
     // on both backends without wrapping the column.
-    let day_bucket = match db {
-        Db::Sqlite(_) => "DATE(e.read_at)".to_string(),
-        Db::Postgres(_) => "to_char(e.read_at, 'YYYY-MM-DD')".to_string(),
+    let day_bucket = if db.is_postgres() {
+        "to_char(e.read_at, 'YYYY-MM-DD')".to_string()
+    } else {
+        "DATE(e.read_at)".to_string()
     };
     let (from_d, to_d) = (parse_ymd(from), parse_ymd(to));
     let sql = format!(
@@ -276,8 +278,8 @@ pub async fn get_daily_read_counts(
          GROUP BY read_date \
          ORDER BY read_date"
     );
-    let rows: Vec<(String, i64)> = match db {
-        Db::Sqlite(pool) => {
+    let rows: Vec<(String, i64)> = match db.inner() {
+        DbInner::Sqlite(pool) => {
             sqlx::query_as::<sqlx::Sqlite, (String, i64)>(sqlx::AssertSqlSafe(sql))
                 .bind(user_id)
                 .bind(from_d)
@@ -285,7 +287,7 @@ pub async fn get_daily_read_counts(
                 .fetch_all(pool)
                 .await
         }
-        Db::Postgres(pool) => {
+        DbInner::Postgres(pool) => {
             sqlx::query_as::<sqlx::Postgres, (String, i64)>(sqlx::AssertSqlSafe(sql))
                 .bind(user_id)
                 .bind(from_d)
@@ -455,8 +457,8 @@ pub async fn get_admin_database_stats(db: &Db) -> AppResult<AdminDatabaseStats> 
     // page_size). PostgreSQL reports the on-disk database size via
     // `pg_database_size()`; it has no directly comparable freelist/reclaimable
     // figure (bloat is a VACUUM concern), so reclaimable is reported as 0.
-    let (db_size_bytes, reclaimable_bytes) = match db {
-        Db::Sqlite(pool) => {
+    let (db_size_bytes, reclaimable_bytes) = match db.inner() {
+        DbInner::Sqlite(pool) => {
             let page_count = sqlx::query_scalar::<_, i64>("PRAGMA page_count")
                 .fetch_one(pool)
                 .await
@@ -471,7 +473,7 @@ pub async fn get_admin_database_stats(db: &Db) -> AppResult<AdminDatabaseStats> 
                 .map_err(AppError::Database)?;
             (page_count * page_size, freelist * page_size)
         }
-        Db::Postgres(pool) => {
+        DbInner::Postgres(pool) => {
             let size = sqlx::query_scalar::<_, i64>("SELECT pg_database_size(current_database())")
                 .fetch_one(pool)
                 .await
@@ -493,26 +495,26 @@ pub async fn get_admin_database_stats(db: &Db) -> AppResult<AdminDatabaseStats> 
     // `try_parse_datetime` expects (to_char on PG — see `ts_text`).
     let min_sql = format!("SELECT {} FROM entry", ts_text(db, "MIN(created_at)"));
     let max_sql = format!("SELECT {} FROM entry", ts_text(db, "MAX(created_at)"));
-    let min_created: Option<String> = match db {
-        Db::Sqlite(pool) => {
+    let min_created: Option<String> = match db.inner() {
+        DbInner::Sqlite(pool) => {
             sqlx::query_scalar::<_, Option<String>>(sqlx::AssertSqlSafe(min_sql))
                 .fetch_one(pool)
                 .await
         }
-        Db::Postgres(pool) => {
+        DbInner::Postgres(pool) => {
             sqlx::query_scalar::<_, Option<String>>(sqlx::AssertSqlSafe(min_sql))
                 .fetch_one(pool)
                 .await
         }
     }
     .map_err(AppError::Database)?;
-    let max_created: Option<String> = match db {
-        Db::Sqlite(pool) => {
+    let max_created: Option<String> = match db.inner() {
+        DbInner::Sqlite(pool) => {
             sqlx::query_scalar::<_, Option<String>>(sqlx::AssertSqlSafe(max_sql))
                 .fetch_one(pool)
                 .await
         }
-        Db::Postgres(pool) => {
+        DbInner::Postgres(pool) => {
             sqlx::query_scalar::<_, Option<String>>(sqlx::AssertSqlSafe(max_sql))
                 .fetch_one(pool)
                 .await

--- a/src/models/webauthn_challenge.rs
+++ b/src/models/webauthn_challenge.rs
@@ -104,8 +104,8 @@ pub async fn find_and_delete_challenge(
 ) -> AppResult<WebauthnChallenge> {
     let now = Utc::now();
 
-    let row = match user_id {
-        Some(uid) => query_opt!(
+    let row = if let Some(uid) = user_id {
+        query_opt!(
             db,
             WebauthnChallengeRow,
             "SELECT id, challenge, user_id, challenge_type, state_data, created_at, expires_at \
@@ -115,8 +115,9 @@ pub async fn find_and_delete_challenge(
             uid,
             challenge_type.as_str(),
             now
-        ),
-        None => query_opt!(
+        )
+    } else {
+        query_opt!(
             db,
             WebauthnChallengeRow,
             "SELECT id, challenge, user_id, challenge_type, state_data, created_at, expires_at \
@@ -125,7 +126,7 @@ pub async fn find_and_delete_challenge(
              ORDER BY created_at DESC LIMIT 1",
             challenge_type.as_str(),
             now
-        ),
+        )
     }
     .map_err(AppError::Database)?
     .ok_or(AppError::ChallengeNotFound)?;

--- a/src/services/background.rs
+++ b/src/services/background.rs
@@ -20,6 +20,8 @@ pub fn start_background_sync(
     events: EventBus,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
+        // Background priority: DB operations yield to interactive work on SQLite.
+        let db = db.background();
         info!("Background sync task started");
 
         let mut ticker = interval(Duration::from_secs(60));

--- a/src/services/content_text_backfill.rs
+++ b/src/services/content_text_backfill.rs
@@ -62,6 +62,8 @@ pub async fn backfill_content_text_batch(db: &Db, batch_size: usize) -> AppResul
 /// mid-drain; remaining rows resume on the next start.
 pub fn start_content_text_backfill(db: Db, cancel_token: CancellationToken) -> JoinHandle<()> {
     tokio::spawn(async move {
+        // Background priority: DB operations yield to interactive work on SQLite.
+        let db = db.background();
         let total: i64 = match query_scalar!(
             &db,
             i64,

--- a/src/services/entry_retention.rs
+++ b/src/services/entry_retention.rs
@@ -26,6 +26,8 @@ pub fn start_retention_worker(
     cancel_token: CancellationToken,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
+        // Background priority: DB operations yield to interactive work on SQLite.
+        let db = db.background();
         tracing::info!("Retention worker started: interval={}h", interval_hours);
         let mut interval = tokio::time::interval(Duration::from_secs(interval_hours * 3600));
 

--- a/src/services/summary_cleanup.rs
+++ b/src/services/summary_cleanup.rs
@@ -20,6 +20,8 @@ pub fn start_cleanup_worker(
     cancel_token: CancellationToken,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
+        // Background priority: DB operations yield to interactive work on SQLite.
+        let db = db.background();
         tracing::info!(
             "Summary cleanup worker started: interval={}h, ttl={}h",
             interval_hours,

--- a/src/services/summary_worker.rs
+++ b/src/services/summary_worker.rs
@@ -74,6 +74,8 @@ pub fn start_summary_worker(
     events: EventBus,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
+        // Background priority: DB operations yield to interactive work on SQLite.
+        let db = db.background();
         tracing::info!("Summary worker started");
 
         loop {
@@ -271,6 +273,8 @@ pub async fn recover_incomplete_jobs(
     tx: mpsc::Sender<SummaryJob>,
     cache: Arc<SummaryCache>,
 ) -> usize {
+    // Startup recovery is background work; yield to interactive requests.
+    let db = db.background();
     let incomplete = match entry_summary::find_incomplete(&db).await {
         Ok(jobs) => jobs,
         Err(e) => {


### PR DESCRIPTION
## Summary

The pre-sqlx actor gave interactive requests priority over background work on SQLite's single writer; the Phase B cutover dropped it ("correct first"). This restores it in an sqlx-native form, **scoped to SQLite** — PostgreSQL has real writer concurrency (MVCC), so the gate is a no-op there and its hot path is untouched.

## Design

- `Db` becomes a `struct` wrapping the backend pool (`DbInner`) plus a scheduling `Priority` and a shared `SqliteSched`. `db.background()` derives a background-priority handle sharing the same pool/scheduler.
- `SqliteSched` is a thin **admission gate**: a `User` op registers as in-flight for its duration; a `Background` op awaits `inflight == 0` before running, so interactive work goes first. The `query_*!` / `db_execute!` macros take the admission around each op; `begin()` holds it for the whole transaction.
- The background workers (feed sync, summary worker + recovery, retention, summary cleanup, content-text backfill) tag themselves with `db.background()` — the only functional call-site change.

Reads under WAL don't block writes, so only the write path is gated (the macros + the dynamic mark-all-read helper); dynamic **read** helpers just dispatch on `db.inner()`.

This matches the old actor's granularity: a background op yields at its boundary but an already-running transaction isn't preempted mid-flight (the old biased-`select!` actor also ran each message to completion).

## Testing

- Deterministic unit tests prove the ordering guarantee — a background op only proceeds after the last in-flight user op finishes — at both the `SqliteSched` and the `Db::admit()` level (no timing/sleeps; asserts via a flag the gate can only observe once released).
- Full SQLite suite (**982**) and the live-PG integration test pass; `fmt` / `clippy -D warnings` / `deny` clean.

## Scope note

Deliberately SQLite-only (agreed): SQLite's single writer is the real contention; PostgreSQL doesn't need it. A capped PG background pool remains a possible future addition if a high-load multi-user PG deployment ever wants it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)