### PR TITLE
docs: sync architecture/README/spec with shipped multi-DB layer

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -31,8 +31,7 @@ src/
 ├── version.rs           # Build version information
 │
 ├── db/
-│   ├── schema.rs        # SQLite schema initialization
-│   └── pool.rs          # Priority-based database connection pool
+│   └── pool.rs          # Dual-backend (SQLite/PostgreSQL) sqlx pool + SQLite write-priority scheduler
 │
 ├── models/              # Data models and database operations
 │   ├── user.rs          # User accounts
@@ -131,7 +130,7 @@ Defines all HTTP routes and builds the Axum application with:
 ### Configuration (`config.rs`)
 
 Loads settings from environment variables:
-- `DATABASE_URL` - SQLite file path
+- `DATABASE_URL` - Database backend: a file path or `sqlite://` URL (SQLite, the zero-config default) or a `postgres://` URL (PostgreSQL); chosen once at startup
 - `SERVER_PORT` - HTTP port
 - `SIGNUP_ENABLED` / `MULTI_USER_ENABLED` - Registration settings
 - `IMAGE_PROXY_SECRET` - HMAC secret for image proxy
@@ -153,11 +152,11 @@ Custom `AppError` type that maps to appropriate HTTP responses:
 
 ## Data Layer
 
-### Database (`db/schema.rs`)
+### Schema & Migrations (`migrations/`)
 
-Schema migrations are tracked using `PRAGMA user_version`. Each migration runs once and advances the version number, replacing the previous ad-hoc `ALTER TABLE` approach.
+Migrations are embedded per backend under `migrations/sqlite/` and `migrations/postgres/` and run at startup via `sqlx::migrate!` for the active backend. The two dialects are kept schema-equivalent; the genuine differences (e.g. non-id `INTEGER` columns are `BIGINT` on PostgreSQL, `GENERATED ALWAYS AS IDENTITY` ids) are isolated in the Postgres migration.
 
-SQLite schema with 11 tables:
+The schema has 11 tables:
 
 | Table | Purpose |
 |-------|---------|
@@ -175,12 +174,9 @@ SQLite schema with 11 tables:
 
 ### Connection Pool (`db/pool.rs`)
 
-`DbPool` manages two SQLite connections under WAL mode:
+`struct Db` wraps `enum DbInner { Sqlite(SqlitePool), Postgres(PgPool) }` — a single sqlx pool for whichever backend `DATABASE_URL` selected at startup. Every query flows through the `query_*!` / `db_execute!` dispatch macros, so SQL and binds are written once; the few genuine dialect differences are isolated behind `entry::filters::Dialect` and the `pg_rewrite` shim (`datetime('now')`→`now()`, `to_char` cursor comparisons, `make_interval`, quoted `"user"`). PG connections pin `TimeZone=UTC` so timestamp-string cursors stay byte-identical to SQLite.
 
-- **Write connection** - Handles all INSERT/UPDATE/DELETE operations via `user()` and `background()` methods
-- **Read-only connection** - Handles SELECT queries via `read_user()` and `read_background()` methods, with `PRAGMA query_only=ON` for safety
-
-Both connections use priority-based scheduling: user requests are always processed before background tasks (e.g., feed sync).
+**Write-priority scheduling (SQLite only).** SQLite has a single writer under WAL, so background writes must yield to interactive ones. `Db` carries a `Priority` (`User` by default in `AppState`; background workers call `db.background()`) and a shared `SqliteSched`: `admit()` gates a background write until no `User` write is in flight. Reads are never gated (WAL readers don't block the writer). On PostgreSQL this is a no-op — MVCC has real writer concurrency.
 
 ### Models
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ All configuration is done via environment variables:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `DATABASE_URL` | `rdrs.sqlite3` | SQLite database file path |
+| `DATABASE_URL` | `rdrs.sqlite3` | Database location. A file path or `sqlite://` URL selects SQLite (zero-config default); a `postgres://` URL selects PostgreSQL. The backend is chosen once at startup. |
 | `SERVER_PORT` | `3000` | HTTP server port |
 | `SIGNUP_ENABLED` | `false` | Allow new user registration |
 | `MULTI_USER_ENABLED` | `false` | Allow multiple users (requires signup enabled) |

--- a/docs/superpowers/specs/2026-07-07-multi-db-sqlx-migration.md
+++ b/docs/superpowers/specs/2026-07-07-multi-db-sqlx-migration.md
@@ -1,11 +1,13 @@
 # Multi-Database Support (SQLite + PostgreSQL) via sqlx — Migration Design
 
 **Date:** 2026-07-07
-**Branches:** `chore/sqlx-multi-db-spike` (feasibility spike, pushed), `refactor/db-repo-seam` (Phase A)
-**Status:** Phases A & B merged. **Phase C landed** (2026-07-07): PostgreSQL is
-runtime-enabled and validated against live PG 17 by `tests/postgres_test.rs`
-(env-gated on `TEST_DATABASE_URL`) plus a CI Postgres service lane. SQLite remains
-the zero-config default.
+**Status:** **Complete — all phases merged to `main` (2026-07-07).** PostgreSQL is
+runtime-enabled and validated against live PG 17 by `tests/postgres_test.rs` (env-gated
+on `TEST_DATABASE_URL`) plus a CI Postgres service lane; SQLite remains the zero-config
+default. Landed as: Phase A (#366) → Phase B rusqlite→sqlx cutover (#367) → Phase C PG
+enablement (#368) → Phase D PG cursor sargability (#369) → SQLite write-priority scheduler
+restored (#370). The `chore/sqlx-multi-db-spike` feasibility branch and `spike/` crate have
+been removed now that their findings are folded into the shipped code.
 
 ## Goal
 
@@ -188,6 +190,17 @@ column, so the same query becomes an index range scan (*Index Cond*, 4 buffers, 
 that won't parse falls back to the correct `to_char` comparison; SQLite is unchanged (raw
 TEXT comparison). Guarded by DB-free unit tests in `entry/filters.rs` and validated against
 live PG (the full join query plan shows `Index Cond`).
+
+### SQLite write-priority scheduler (#370, landed 2026-07-07)
+
+Phase B's cutover dropped the rusqlite-era write-priority scheduling; #370 restores it in
+the sqlx world, scoped to what actually needs it. Unlike the spike sketch above (which
+imagined per-backend pools), the shipped design gates **only SQLite writes**: `Db` carries
+a `Priority` (`User` by default; workers call `db.background()`) and a shared `SqliteSched`
+whose `admit()` holds a background write until no `User` write is in flight. Reads are never
+gated — WAL readers don't block the single writer. On PostgreSQL it is a no-op (MVCC has
+real writer concurrency). Covered by deterministic, sleep-free async ordering unit tests in
+`db/pool.rs`.
 
 ## Risks to watch (Phase B)
 1. **`INDEXED BY` removal** — SQLite perf crutches; build equivalent (incl. partial)


### PR DESCRIPTION
## Summary

Documentation-only follow-up to the multi-database work (#366–#370). Three docs still described the pre-migration rusqlite world; this brings them in line with what actually shipped.

## Changes

- **ARCHITECTURE.md**
  - Directory tree: drop the removed `db/schema.rs`; describe `db/pool.rs` as the dual-backend sqlx pool + SQLite write-priority scheduler.
  - `DATABASE_URL`: now documents SQLite (path / `sqlite://`) **or** PostgreSQL (`postgres://`), chosen at startup.
  - "Database" section → "Schema & Migrations": per-backend embedded migrations via `sqlx::migrate!` instead of `PRAGMA user_version` in the deleted `db/schema.rs`.
  - "Connection Pool": `struct Db` over `enum DbInner { Sqlite(SqlitePool), Postgres(PgPool) }`, dispatch macros, `Dialect` / `pg_rewrite` forks, UTC pinning, and the SQLite-only write-priority scheduler (no-op on PG).
- **README.md**: `DATABASE_URL` config row now mentions the PostgreSQL option.
- **spec** (`2026-07-07-multi-db-sqlx-migration.md`): header status → **Complete** with the #366–#370 landing sequence and spike-branch removal; new landed note for the #370 scheduler restore, correcting the spike's never-shipped per-backend-pool sketch.

No code, tests, or UI touched.