### PR TITLE
test: fix flaky read-back race in test_entry_fragment_renders_reading_pane

### DIFF
--- a/tests/handlers_test.rs
+++ b/tests/handlers_test.rs
@@ -3520,15 +3520,24 @@ async fn test_entry_fragment_renders_reading_pane() {
         html.contains(r##"data-swap-target="#sidebar-unread""##),
         "response must include a multi-target sidebar block"
     );
-    // The mark-as-read write is now async (user_detached); a user() read-back
-    // is FIFO-ordered behind it, so it observes the applied write.
-    let read_at: Option<String> = rdrs::query_scalar!(
-        &app.db,
-        Option<String>,
-        "SELECT read_at FROM entry WHERE id = $1",
-        entry_id
-    )
-    .unwrap();
+    // The mark-as-read write is dispatched off the critical path via a detached
+    // `tokio::spawn` (fire-and-forget), so it may not have committed by the time
+    // the response returns — there is no ordering guarantee between it and this
+    // read-back. Poll until the write lands rather than assuming it already has.
+    let mut read_at: Option<String> = None;
+    for _ in 0..100 {
+        read_at = rdrs::query_scalar!(
+            &app.db,
+            Option<String>,
+            "SELECT read_at FROM entry WHERE id = $1",
+            entry_id
+        )
+        .unwrap();
+        if read_at.is_some() {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
     assert!(read_at.is_some(), "entry must be marked read after open");
 }
 


### PR DESCRIPTION
## Problem

`test_entry_fragment_renders_reading_pane` failed on the post-merge `main` CI run for #372 (`coverage` job), while passing on the PR — a classic non-deterministic flake.

```
tests/handlers_test.rs:3532: panicked: "entry must be marked read after open"
```

## Root cause

`entry_fragment` (`src/handlers/entries.rs`) dispatches the mark-as-read write **off the critical path via a detached `tokio::spawn`** (fire-and-forget), so the response can return before the write commits. The test did a single read-back immediately after, relying on a **stale comment** that claimed a `user_detached` write is "FIFO-ordered behind" a subsequent `user()` read. That mechanism no longer exists — it became a plain `tokio::spawn` during the sqlx cutover — so the `SELECT read_at` races the detached write and intermittently observes `NULL`.

## Fix

Poll the read-back for up to ~1s until the write lands, instead of assuming an ordering the detached task does not provide. This matches the **intentional** fire-and-forget production behavior (a user observes the write on a later request, not synchronously). **No production code change.**

Ran the test **40×** locally with zero failures; `cargo fmt` + `clippy` clean.