### PR TITLE
fix(css): center flash banner on wide touch layouts (iPad landscape)

### DIFF
--- a/e2e/features/responsive.feature
+++ b/e2e/features/responsive.feature
@@ -84,6 +84,9 @@ Feature: Responsive layout
     And the ".banner-dismiss" control is at least 44px wide
     And the ".banner-dismiss" control is at least 44px tall
 
+  Scenario: Flash banner is vertically centered on a wide touch tablet
+    Then the flash banner is vertically centered on a wide touch tablet
+
   @tablet
   Scenario: Sidebar is a drawer on tablet
     Given I am viewing on a tablet screen

--- a/e2e/steps/responsive.steps.js
+++ b/e2e/steps/responsive.steps.js
@@ -237,6 +237,52 @@ When("a flash banner is shown", async ({ page }) => {
   await expect(page.locator(".banner")).toBeVisible();
 });
 
+Then(
+  "the flash banner is vertically centered on a wide touch tablet",
+  async ({ browser, page, serverUrl }) => {
+    // Reproduce iPad-landscape: a WIDE (>1024px, so the persistent split layout
+    // rather than the mobile drawer) TOUCH viewport. Touch triggers
+    // `@media (hover: none)`, which bumps `.banner-dismiss` to 44px tall; the
+    // base `.banner { align-items: start }` then pinned the message to the top
+    // of the inflated grid row while the `align-self: center` timestamp sat
+    // lower — the visible misalignment + blank space. `hover: none` cannot be
+    // faked via viewport size or page.emulateMedia, so spin a dedicated
+    // hasTouch context (reusing the signed-in cookies) at 1180px.
+    const ctx = await browser.newContext({
+      viewport: { width: 1180, height: 820 },
+      hasTouch: true,
+    });
+    try {
+      await ctx.addCookies(await page.context().cookies());
+      const tp = await ctx.newPage();
+      await tp.goto(`${serverUrl}/`);
+      await tp.evaluate(() => window.flash.show("success", "Marked as unread."));
+      const banner = tp.locator(".banner").first();
+      await expect(banner).toBeVisible();
+      const m = await banner.evaluate((n) => {
+        const centerY = (sel) => {
+          const r = n.querySelector(sel).getBoundingClientRect();
+          return r.y + r.height / 2;
+        };
+        const d = n.querySelector(".banner-dismiss").getBoundingClientRect();
+        return {
+          msg: centerY(".banner-message"),
+          time: centerY(".banner-time"),
+          dismissW: d.width,
+          dismissH: d.height,
+        };
+      });
+      // Message and timestamp share the row's vertical center.
+      expect(Math.abs(m.msg - m.time)).toBeLessThanOrEqual(1.5);
+      // Dismiss keeps a full 44px tap target on BOTH axes at this width.
+      expect(m.dismissW).toBeGreaterThanOrEqual(44);
+      expect(m.dismissH).toBeGreaterThanOrEqual(44);
+    } finally {
+      await ctx.close();
+    }
+  },
+);
+
 Then("the flash banner sits below the hamburger", async ({ page }) => {
   const toggle = await page.locator(".sidebar-toggle").boundingBox();
   const banner = await page.locator(".banner").first().boundingBox();

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -3196,6 +3196,18 @@ summary {
 
     .sidebar-item { min-height: var(--touch-min); }
 
+    /* The 44px dismiss button (above) makes the banner grid row taller than a
+       single line of text; center every cell (overriding the base
+       align-items:start) and drop the icon's first-line offset so the dot
+       centers too. Give the dismiss its full 44px tap target on both axes —
+       base .banner-dismiss is 22px and only min-height fired above, so on wide
+       touch layouts it would otherwise stay 22px wide. Mirrors the
+       max-width:1024px block for wide touch devices (e.g. iPad landscape) that
+       keep the persistent split layout instead of the mobile drawer. */
+    .banner { align-items: center; }
+    .banner-icon { margin-top: 0; }
+    .banner-dismiss { min-width: var(--touch-min); }
+
     /* Summary-box mono links stay inline; expand their hit area via padding. */
     .summary-actions .rp-action {
         min-height: 0;


### PR DESCRIPTION
## Problem

On iPad Air 11" landscape (1180px CSS width, a touch device) the flash/notification banner rendered with the message text pinned to the **top** of a tall row, leaving a large blank space below, and the message was **not vertically aligned** with the right-side timestamp.


## Root cause

- On touch devices `@media (hover: none)` bumps every `button` — including `.banner-dismiss` — to `min-height: 44px`, inflating the `.banner` grid row to 44px.
- The compensating "center every cell" override (`.banner { align-items: center }` + `.banner-icon { margin-top: 0 }`) only lived in `@media (max-width: 1024px)`.
- iPad landscape is 1180px > 1024px, so it keeps the persistent split view (not the mobile drawer) and **skips** that override: the message stays top-aligned (`align-items: start`) while the `align-self: center` timestamp sits lower.

Measured before fix (1180×820, hasTouch): message center `top=10.0` vs timestamp `top=21.3`; `.banner-dismiss` was `22×44`.

## Fix

Move the centering into the same `@media (hover: none)` block that creates the tall row, so cause and compensation are tied to one condition and can't drift apart:

```css
.banner { align-items: center; }
.banner-icon { margin-top: 0; }
.banner-dismiss { min-width: var(--touch-min); }
```

The third line also gives the dismiss its full 44px tap target on **both** axes at wide touch widths (base is 22px; only `min-height` fired via the bare-`button` rule), keeping a WCAG 2.5.5-sized control.

After fix: message center `21.6` ≈ timestamp `21.3`; dismiss `44×44`.

## Tests

Added an e2e regression `Flash banner is vertically centered on a wide touch tablet` using a dedicated `hasTouch` context at 1180px (`hover: none` can't be faked via viewport / `emulateMedia`). It asserts the message and timestamp share the row's vertical center (±1.5px) and the dismiss stays `44×44`.

- With the fix → passes; reverting the CSS → **fails** (12.5px misalignment), confirming the test catches the regression.
- All flash-related scenarios pass.

## Notes

- README screenshots are unaffected: `e2e/scripts/screenshots.js` captures at 1920×1080 **without** `hasTouch` (`hover: hover`), so these rules never apply there — no screenshot regeneration needed.
- The `Entry-list filter bar stays on one row at 1400x900` scenario fails on a clean `main` too (non-touch, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
