### PR TITLE
feat(search): boolean query language on the global /search page

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -37,7 +37,7 @@ src/
 │   ├── user.rs          # User accounts
 │   ├── session.rs       # Session management
 │   ├── feed.rs          # RSS feeds
-│   ├── entry/           # Feed entries (mod.rs + filters.rs query builder)
+│   ├── entry/           # Feed entries (mod.rs + filters.rs query builder + query.rs boolean search parser)
 │   ├── entry_summary.rs # Article summaries
 │   ├── category.rs      # Feed categories
 │   ├── image.rs         # Image storage
@@ -186,6 +186,15 @@ Each model provides:
 - Query methods for common access patterns
 
 Example: `Feed` model provides `find_by_user`, `create`, `update`, `delete`, `find_due_for_sync`.
+
+The global `/search` page accepts a boolean query language (`is:`, `feed:`,
+`category:`, `title:`, `author:`, `before:`, `after:`, `AND`/`OR`/`NOT`,
+parenthesized grouping, quoting, and `-` negation), parsed by
+`models/entry/query.rs` into a `QueryNode` AST and set on `EntryFilter.query`;
+`filters::render_query` renders that AST to SQL per-`Dialect`, still matching
+via `LIKE`/`ILIKE` (no full-text search index). Scoped, per-view search (feed,
+category, starred, etc.) is unaffected and continues to use the plain
+substring `EntryFilter.search` field.
 
 ## HTTP Layer
 

--- a/docs/superpowers/plans/2026-07-08-search-query-syntax.md
+++ b/docs/superpowers/plans/2026-07-08-search-query-syntax.md
@@ -1,0 +1,1286 @@
+# Search Query Syntax Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a hand-written boolean query-language parser to the global `/search` page so users can combine field filters (`is:`, `feed:`, `category:`, `title:`, `author:`, `before:`, `after:`), booleans (`AND`/`OR`/`NOT`), grouping, quoting, and `-` negation in one search box.
+
+**Architecture:** A new pure module `src/models/entry/query.rs` (tokenizer → recursive-descent parser → `QueryNode` AST, dates validated with `chrono`). `EntryFilter` gains a `query: Option<QueryNode>` field. `filters.rs` gains `render_query()` that recursively turns the AST into a parenthesized `WHERE` fragment through the existing `Dialect` seam, `AND`-combined into the query by `apply_filter_conditions`. The `/search` handler parses `q`, either sets `EntryFilter.query` or renders an inline error; `search.html` shows the error banner plus a `<details>` syntax-help panel. Backend matching stays `LIKE`/`ILIKE` — no FTS.
+
+**Tech Stack:** Rust, Axum, Askama, sqlx (dual SQLite/Postgres), `chrono` (already a dependency), nextest.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-08-search-query-syntax-design.md` (authoritative for grammar/semantics).
+- No new third-party dependencies. `chrono` is already present; use it for dates.
+- Tests run with `cargo nextest run` (never `cargo test`). Use `RDRS_FAST_HASH=1` for auth-heavy suites (not needed here but harmless).
+- `cargo fmt` before every commit; `cargo clippy --all-targets -- -D warnings` must pass (warnings fail CI).
+- All commits GPG-signed (default; do not pass `--no-gpg-sign`). Stage files explicitly by name — never `git add -A`/`git add .`.
+- Work stays on branch `feat/search-query-syntax`.
+- Scope: global `/search` only. Do NOT touch scoped/category/feed search, the `?` keyboard-help overlay, or add any DB index (analysis in spec §7 confirms existing indexes cover every index-able predicate).
+- `/search` is not among the four README screenshots, so no screenshot regeneration is required.
+
+---
+
+### Task 1: Query AST, tokenizer, and recursive-descent parser
+
+**Files:**
+- Create: `src/models/entry/query.rs`
+- Modify: `src/models/entry/mod.rs:9` (add `pub mod query;`)
+
+**Interfaces:**
+- Produces (public API other tasks consume):
+  - `pub enum QueryNode { And(Box<QueryNode>, Box<QueryNode>), Or(Box<QueryNode>, Box<QueryNode>), Not(Box<QueryNode>), Text(String), Field { field: TextField, value: String }, Source { kind: SourceKind, value: String }, Status(Status), Date { bound: DateBound, date: chrono::NaiveDate } }` — derives `Debug, Clone, PartialEq, Eq`.
+  - `pub enum TextField { Title, Author }`, `pub enum SourceKind { Feed, Category }`, `pub enum Status { Unread, Read, Starred }`, `pub enum DateBound { Before, After }` — each `Debug, Clone, Copy, PartialEq, Eq`.
+  - `pub struct ParseError { pub position: usize, pub message: String }` — `Debug, Clone, PartialEq, Eq`. `position` is a **byte** offset into the input.
+  - `pub fn parse(input: &str) -> Result<QueryNode, ParseError>`
+  - `pub fn free_text_terms(node: &QueryNode) -> Vec<String>` — free-text + `title:` values (skips negated subtrees), for result highlighting.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the bottom of the new file `src/models/entry/query.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::NaiveDate;
+
+    fn t(s: &str) -> QueryNode { s.to_string().pipe_text() }
+    trait PipeText { fn pipe_text(self) -> QueryNode; }
+    impl PipeText for String { fn pipe_text(self) -> QueryNode { QueryNode::Text(self) } }
+
+    #[test]
+    fn single_free_text() {
+        assert_eq!(parse("rust").unwrap(), QueryNode::Text("rust".into()));
+    }
+
+    #[test]
+    fn implicit_and_between_terms() {
+        assert_eq!(
+            parse("rust go").unwrap(),
+            QueryNode::And(Box::new(t("rust")), Box::new(t("go")))
+        );
+    }
+
+    #[test]
+    fn or_lower_precedence_than_and() {
+        // `a b OR c` => (a AND b) OR c
+        let got = parse("a b OR c").unwrap();
+        assert_eq!(
+            got,
+            QueryNode::Or(
+                Box::new(QueryNode::And(Box::new(t("a")), Box::new(t("b")))),
+                Box::new(t("c"))
+            )
+        );
+    }
+
+    #[test]
+    fn parentheses_override_precedence() {
+        // `a AND (b OR c)`
+        let got = parse("a AND (b OR c)").unwrap();
+        assert_eq!(
+            got,
+            QueryNode::And(
+                Box::new(t("a")),
+                Box::new(QueryNode::Or(Box::new(t("b")), Box::new(t("c"))))
+            )
+        );
+    }
+
+    #[test]
+    fn not_keyword_and_dash_negation() {
+        assert_eq!(parse("NOT rust").unwrap(), QueryNode::Not(Box::new(t("rust"))));
+        assert_eq!(parse("-rust").unwrap(), QueryNode::Not(Box::new(t("rust"))));
+    }
+
+    #[test]
+    fn dash_inside_word_is_literal_text() {
+        assert_eq!(parse("cross-platform").unwrap(), QueryNode::Text("cross-platform".into()));
+    }
+
+    #[test]
+    fn dash_with_trailing_space_is_literal() {
+        // `- rust` => "-" AND "rust"
+        assert_eq!(
+            parse("- rust").unwrap(),
+            QueryNode::And(Box::new(t("-")), Box::new(t("rust")))
+        );
+    }
+
+    #[test]
+    fn status_filter() {
+        assert_eq!(parse("is:unread").unwrap(), QueryNode::Status(Status::Unread));
+        assert_eq!(parse("IS:Starred").unwrap(), QueryNode::Status(Status::Starred));
+    }
+
+    #[test]
+    fn unknown_is_value_errors() {
+        assert!(parse("is:archived").is_err());
+    }
+
+    #[test]
+    fn source_and_field_filters() {
+        assert_eq!(
+            parse("feed:rust").unwrap(),
+            QueryNode::Source { kind: SourceKind::Feed, value: "rust".into() }
+        );
+        assert_eq!(
+            parse("author:jane").unwrap(),
+            QueryNode::Field { field: TextField::Author, value: "jane".into() }
+        );
+    }
+
+    #[test]
+    fn quoted_value_with_spaces() {
+        assert_eq!(
+            parse("feed:\"Rust Blog\"").unwrap(),
+            QueryNode::Source { kind: SourceKind::Feed, value: "Rust Blog".into() }
+        );
+    }
+
+    #[test]
+    fn quoted_keyword_is_literal_text() {
+        assert_eq!(parse("\"and\"").unwrap(), QueryNode::Text("and".into()));
+    }
+
+    #[test]
+    fn colon_in_non_field_is_literal_text() {
+        assert_eq!(
+            parse("http://example.com").unwrap(),
+            QueryNode::Text("http://example.com".into())
+        );
+    }
+
+    #[test]
+    fn date_filters_parse() {
+        assert_eq!(
+            parse("after:2026-01-01").unwrap(),
+            QueryNode::Date { bound: DateBound::After, date: NaiveDate::from_ymd_opt(2026, 1, 1).unwrap() }
+        );
+    }
+
+    #[test]
+    fn bad_date_errors() {
+        let e = parse("before:yesterday").unwrap_err();
+        assert!(e.message.contains("YYYY-MM-DD"));
+    }
+
+    #[test]
+    fn unbalanced_paren_errors() {
+        let e = parse("(rust OR go").unwrap_err();
+        assert!(e.message.contains("'('"));
+    }
+
+    #[test]
+    fn trailing_operator_errors() {
+        assert!(parse("rust OR").is_err());
+    }
+
+    #[test]
+    fn stray_close_paren_errors() {
+        assert!(parse("rust)").is_err());
+    }
+
+    #[test]
+    fn free_text_terms_collects_text_and_title_skips_negated() {
+        let ast = parse("rust title:axum -go is:unread").unwrap();
+        let mut terms = free_text_terms(&ast);
+        terms.sort();
+        assert_eq!(terms, vec!["axum".to_string(), "rust".to_string()]);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo nextest run -p rdrs query::tests 2>&1 | head -40` (adjust `-p` to the crate name if different; the module path is `models::entry::query::tests`).
+Expected: FAIL to compile — `parse`, `QueryNode`, etc. not defined.
+
+- [ ] **Step 3: Implement the module**
+
+Write the full implementation at the top of `src/models/entry/query.rs` (above the `#[cfg(test)] mod tests`):
+
+```rust
+//! Boolean query-language parser for the global `/search` page.
+//!
+//! Grammar (authoritative copy in the design spec):
+//!   or   := and { "OR" and }
+//!   and  := not { ["AND"] not }        // implicit AND between adjacent atoms
+//!   not  := {"NOT"|"-"} atom
+//!   atom := "(" or ")" | field ":" value | text
+//!
+//! Pure string → AST; no DB access. Dates are validated here via `chrono`.
+//! `NOT` / `AND` / `OR` are case-insensitive keywords (quote to search them
+//! literally). A `token:` is a filter only when `token` is a known field name.
+
+use chrono::NaiveDate;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum QueryNode {
+    And(Box<QueryNode>, Box<QueryNode>),
+    Or(Box<QueryNode>, Box<QueryNode>),
+    Not(Box<QueryNode>),
+    Text(String),
+    Field { field: TextField, value: String },
+    Source { kind: SourceKind, value: String },
+    Status(Status),
+    Date { bound: DateBound, date: NaiveDate },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TextField { Title, Author }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SourceKind { Feed, Category }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Status { Unread, Read, Starred }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DateBound { Before, After }
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParseError {
+    /// Byte offset into the input where the error was detected.
+    pub position: usize,
+    pub message: String,
+}
+
+/// Collect free-text and `title:` values for result highlighting. Negated
+/// subtrees are skipped (we do not highlight terms the user excluded).
+pub fn free_text_terms(node: &QueryNode) -> Vec<String> {
+    let mut out = Vec::new();
+    collect_terms(node, &mut out);
+    out
+}
+
+fn collect_terms(node: &QueryNode, out: &mut Vec<String>) {
+    match node {
+        QueryNode::And(a, b) | QueryNode::Or(a, b) => {
+            collect_terms(a, out);
+            collect_terms(b, out);
+        }
+        QueryNode::Not(_) => {}
+        QueryNode::Text(s) => out.push(s.clone()),
+        QueryNode::Field { field: TextField::Title, value } => out.push(value.clone()),
+        _ => {}
+    }
+}
+
+pub fn parse(input: &str) -> Result<QueryNode, ParseError> {
+    let toks = lex(input)?;
+    if toks.is_empty() {
+        return Err(ParseError { position: 0, message: "查詢是空的".into() });
+    }
+    let mut p = Parser { toks: &toks, pos: 0, end: input.len() };
+    let node = p.parse_or()?;
+    if p.pos < toks.len() {
+        return Err(ParseError {
+            position: toks[p.pos].pos,
+            message: "多餘的字元（可能是多出的 ')'）".into(),
+        });
+    }
+    Ok(node)
+}
+
+// ---- Field kinds (lexer-internal) --------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Field { Is, Feed, Category, Title, Author, Before, After }
+
+impl Field {
+    fn from_name(s: &str) -> Option<Field> {
+        match s.to_ascii_lowercase().as_str() {
+            "is" => Some(Field::Is),
+            "feed" => Some(Field::Feed),
+            "category" => Some(Field::Category),
+            "title" => Some(Field::Title),
+            "author" => Some(Field::Author),
+            "before" => Some(Field::Before),
+            "after" => Some(Field::After),
+            _ => None,
+        }
+    }
+    fn label(self) -> &'static str {
+        match self {
+            Field::Is => "'is:'",
+            Field::Feed => "'feed:'",
+            Field::Category => "'category:'",
+            Field::Title => "'title:'",
+            Field::Author => "'author:'",
+            Field::Before => "'before:'",
+            Field::After => "'after:'",
+        }
+    }
+}
+
+// ---- Tokenizer ---------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Tok {
+    LParen,
+    RParen,
+    And,
+    Or,
+    Not,
+    Minus,
+    Filter(Field, String),
+    Text(String),
+}
+
+struct Spanned {
+    tok: Tok,
+    pos: usize,
+}
+
+fn lex(input: &str) -> Result<Vec<Spanned>, ParseError> {
+    let chars: Vec<(usize, char)> = input.char_indices().collect();
+    let n = chars.len();
+    let mut out = Vec::new();
+    let mut k = 0;
+    while k < n {
+        let (bpos, c) = chars[k];
+        if c.is_whitespace() {
+            k += 1;
+            continue;
+        }
+        match c {
+            '(' => { out.push(Spanned { tok: Tok::LParen, pos: bpos }); k += 1; }
+            ')' => { out.push(Spanned { tok: Tok::RParen, pos: bpos }); k += 1; }
+            '"' => {
+                let (val, nk) = read_quoted(&chars, input, k)?;
+                out.push(Spanned { tok: Tok::Text(val), pos: bpos });
+                k = nk;
+            }
+            '-' => {
+                // Tight negation only when the next char exists and is neither
+                // whitespace nor ')'. Otherwise a literal "-" text token.
+                let neg = k + 1 < n && {
+                    let d = chars[k + 1].1;
+                    !d.is_whitespace() && d != ')'
+                };
+                out.push(Spanned {
+                    tok: if neg { Tok::Minus } else { Tok::Text("-".into()) },
+                    pos: bpos,
+                });
+                k += 1;
+            }
+            _ => {
+                // Word run until whitespace / '(' / ')' / '"'.
+                let mut e = k;
+                while e < n {
+                    let d = chars[e].1;
+                    if d.is_whitespace() || d == '(' || d == ')' || d == '"' {
+                        break;
+                    }
+                    e += 1;
+                }
+                let start_byte = bpos;
+                let end_byte = if e < n { chars[e].0 } else { input.len() };
+                let head = &input[start_byte..end_byte];
+
+                if let Some((name, rest)) = head.split_once(':') {
+                    if let Some(field) = Field::from_name(name) {
+                        if !rest.is_empty() {
+                            out.push(Spanned { tok: Tok::Filter(field, rest.to_string()), pos: bpos });
+                            k = e;
+                            continue;
+                        } else if e < n && chars[e].1 == '"' {
+                            // `field:"quoted value"` — value is the tight quote.
+                            let (val, nk) = read_quoted(&chars, input, e)?;
+                            out.push(Spanned { tok: Tok::Filter(field, val), pos: bpos });
+                            k = nk;
+                            continue;
+                        } else {
+                            // `field:` with no value — parser rejects.
+                            out.push(Spanned { tok: Tok::Filter(field, String::new()), pos: bpos });
+                            k = e;
+                            continue;
+                        }
+                    }
+                }
+
+                let tok = match head.to_ascii_lowercase().as_str() {
+                    "and" => Tok::And,
+                    "or" => Tok::Or,
+                    "not" => Tok::Not,
+                    _ => Tok::Text(head.to_string()),
+                };
+                out.push(Spanned { tok, pos: bpos });
+                k = e;
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Read a `"..."` phrase; `chars[k]` must be the opening quote. Returns the
+/// inner content and the char index just past the closing quote.
+fn read_quoted(chars: &[(usize, char)], input: &str, k: usize) -> Result<(String, usize), ParseError> {
+    let open_byte = chars[k].0;
+    let content_start = chars.get(k + 1).map(|x| x.0).unwrap_or_else(|| input.len());
+    let mut e = k + 1;
+    while e < chars.len() {
+        if chars[e].1 == '"' {
+            let content_end = chars[e].0;
+            return Ok((input[content_start..content_end].to_string(), e + 1));
+        }
+        e += 1;
+    }
+    Err(ParseError { position: open_byte, message: "引號未關閉".into() })
+}
+
+// ---- Parser ------------------------------------------------------------
+
+struct Parser<'a> {
+    toks: &'a [Spanned],
+    pos: usize,
+    end: usize,
+}
+
+fn starts_atom(t: &Tok) -> bool {
+    matches!(t, Tok::LParen | Tok::Filter(_, _) | Tok::Text(_) | Tok::Not | Tok::Minus)
+}
+
+impl<'a> Parser<'a> {
+    fn peek(&self) -> Option<&Tok> {
+        self.toks.get(self.pos).map(|s| &s.tok)
+    }
+    fn peek_pos(&self) -> usize {
+        self.toks.get(self.pos).map(|s| s.pos).unwrap_or(self.end)
+    }
+    fn bump(&mut self) -> &Spanned {
+        let s = &self.toks[self.pos];
+        self.pos += 1;
+        s
+    }
+
+    fn parse_or(&mut self) -> Result<QueryNode, ParseError> {
+        let mut left = self.parse_and()?;
+        while matches!(self.peek(), Some(Tok::Or)) {
+            self.bump();
+            let right = self.parse_and()?;
+            left = QueryNode::Or(Box::new(left), Box::new(right));
+        }
+        Ok(left)
+    }
+
+    fn parse_and(&mut self) -> Result<QueryNode, ParseError> {
+        let mut left = self.parse_not()?;
+        loop {
+            match self.peek() {
+                Some(Tok::And) => {
+                    self.bump();
+                    let right = self.parse_not()?;
+                    left = QueryNode::And(Box::new(left), Box::new(right));
+                }
+                Some(t) if starts_atom(t) => {
+                    let right = self.parse_not()?;
+                    left = QueryNode::And(Box::new(left), Box::new(right));
+                }
+                _ => break, // Or, RParen, or EOF
+            }
+        }
+        Ok(left)
+    }
+
+    fn parse_not(&mut self) -> Result<QueryNode, ParseError> {
+        if matches!(self.peek(), Some(Tok::Not) | Some(Tok::Minus)) {
+            self.bump();
+            let inner = self.parse_not()?;
+            return Ok(QueryNode::Not(Box::new(inner)));
+        }
+        self.parse_atom()
+    }
+
+    fn parse_atom(&mut self) -> Result<QueryNode, ParseError> {
+        match self.peek() {
+            Some(Tok::LParen) => {
+                let open_pos = self.peek_pos();
+                self.bump();
+                let inner = self.parse_or()?;
+                if !matches!(self.peek(), Some(Tok::RParen)) {
+                    return Err(ParseError { position: open_pos, message: "括號不對稱：'(' 未關閉".into() });
+                }
+                self.bump();
+                Ok(inner)
+            }
+            Some(Tok::Filter(_, _)) => {
+                let pos = self.peek_pos();
+                let (field, value) = match &self.bump().tok {
+                    Tok::Filter(f, v) => (*f, v.clone()),
+                    _ => unreachable!(),
+                };
+                node_from_filter(field, &value, pos)
+            }
+            Some(Tok::Text(_)) => {
+                let s = match &self.bump().tok {
+                    Tok::Text(s) => s.clone(),
+                    _ => unreachable!(),
+                };
+                Ok(QueryNode::Text(s))
+            }
+            _ => Err(ParseError { position: self.peek_pos(), message: "此處需要一個搜尋條件".into() }),
+        }
+    }
+}
+
+fn node_from_filter(field: Field, value: &str, pos: usize) -> Result<QueryNode, ParseError> {
+    if value.is_empty() {
+        return Err(ParseError { position: pos, message: format!("{} 後面需要一個值", field.label()) });
+    }
+    match field {
+        Field::Is => match value.to_ascii_lowercase().as_str() {
+            "unread" => Ok(QueryNode::Status(Status::Unread)),
+            "read" => Ok(QueryNode::Status(Status::Read)),
+            "starred" => Ok(QueryNode::Status(Status::Starred)),
+            other => Err(ParseError {
+                position: pos,
+                message: format!("未知的 is: 值「{other}」（可用 unread / read / starred）"),
+            }),
+        },
+        Field::Feed => Ok(QueryNode::Source { kind: SourceKind::Feed, value: value.to_string() }),
+        Field::Category => Ok(QueryNode::Source { kind: SourceKind::Category, value: value.to_string() }),
+        Field::Title => Ok(QueryNode::Field { field: TextField::Title, value: value.to_string() }),
+        Field::Author => Ok(QueryNode::Field { field: TextField::Author, value: value.to_string() }),
+        Field::Before | Field::After => {
+            let date = NaiveDate::parse_from_str(value, "%Y-%m-%d").map_err(|_| ParseError {
+                position: pos,
+                message: format!("{} 需要 YYYY-MM-DD 格式的日期", field.label()),
+            })?;
+            let bound = if field == Field::Before { DateBound::Before } else { DateBound::After };
+            Ok(QueryNode::Date { bound, date })
+        }
+    }
+}
+```
+
+Also register the module — edit `src/models/entry/mod.rs:9`, changing `mod filters;` block to add above/below it:
+
+```rust
+pub mod query;
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo nextest run models::entry::query`
+Expected: PASS (all Task 1 tests green).
+
+Then: `cargo fmt && cargo clippy --all-targets -- -D warnings 2>&1 | tail -5`
+Expected: no warnings.
+
+Note: the test helper uses a tiny `PipeText` trait to keep assertions short; if clippy objects to it, inline `QueryNode::Text("...".into())` instead.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/models/entry/query.rs src/models/entry/mod.rs
+git commit -m "feat(search): add boolean query-language parser (AST + lexer)"
+```
+
+---
+
+### Task 2: `EntryFilter.query` + AST→SQL rendering (`filters.rs`)
+
+**Files:**
+- Modify: `src/models/entry/mod.rs:59-75` (add `query` field to `EntryFilter`)
+- Modify: `src/models/entry/filters.rs` (add `render_query`, `like_contains`, `Dialect::ci_like_esc`; call render in `apply_filter_conditions`; extend `is_no_entry_side_predicate`)
+
+**Interfaces:**
+- Consumes from Task 1: `QueryNode`, `TextField`, `SourceKind`, `Status`, `DateBound` from `super::query`.
+- Produces: `EntryFilter.query: Option<QueryNode>` (set by Task 4); `render_query` invoked internally by `apply_filter_conditions`, so all `list_by_user`/`count_by_user` callers gain query support with `query: None` a no-op.
+
+- [ ] **Step 1: Write the failing SQL-shape tests**
+
+Add these tests inside the existing `#[cfg(test)] mod tests` in `src/models/entry/filters.rs` (alongside the dialect tests):
+
+```rust
+use super::super::query::{parse as parse_query};
+
+fn render(qs: &str, dialect: Dialect) -> (String, Vec<Bind>) {
+    let ast = parse_query(qs).expect("valid query");
+    let mut binds = Vec::new();
+    let frag = render_query(&ast, &mut binds, dialect);
+    (frag, binds)
+}
+
+#[test]
+fn render_status_unread_sqlite() {
+    let (frag, binds) = render("is:unread", Dialect::Sqlite);
+    assert_eq!(frag, "e.read_at IS NULL");
+    assert!(binds.is_empty());
+}
+
+#[test]
+fn render_free_text_matches_title_and_content_with_escape() {
+    let (frag, binds) = render("rust", Dialect::Sqlite);
+    assert_eq!(
+        frag,
+        "(e.title LIKE $1 ESCAPE '\\' OR e.content_text LIKE $1 ESCAPE '\\')"
+    );
+    assert!(matches!(&binds[0], Bind::Text(s) if s == "%rust%"));
+}
+
+#[test]
+fn render_free_text_pg_uses_ilike() {
+    let (frag, _) = render("rust", Dialect::Postgres);
+    assert_eq!(
+        frag,
+        "(e.title ILIKE $1 ESCAPE '\\' OR e.content_text ILIKE $1 ESCAPE '\\')"
+    );
+}
+
+#[test]
+fn render_like_wildcards_are_escaped() {
+    let (_, binds) = render("50%", Dialect::Sqlite);
+    assert!(matches!(&binds[0], Bind::Text(s) if s == "%50\\%%"));
+}
+
+#[test]
+fn render_feed_and_author_columns() {
+    let (feed, _) = render("feed:news", Dialect::Sqlite);
+    assert_eq!(feed, "f.title LIKE $1 ESCAPE '\\'");
+    let (author, _) = render("author:jane", Dialect::Sqlite);
+    assert_eq!(author, "e.author LIKE $1 ESCAPE '\\'");
+}
+
+#[test]
+fn render_boolean_nesting_and_bind_numbering() {
+    // `(rust OR go) AND is:unread` — two text binds, status has none.
+    let (frag, binds) = render("(rust OR go) AND is:unread", Dialect::Sqlite);
+    assert_eq!(
+        frag,
+        "(((e.title LIKE $1 ESCAPE '\\' OR e.content_text LIKE $1 ESCAPE '\\') \
+OR (e.title LIKE $2 ESCAPE '\\' OR e.content_text LIKE $2 ESCAPE '\\')) AND e.read_at IS NULL)"
+    );
+    assert_eq!(binds.len(), 2);
+}
+
+#[test]
+fn render_not_wraps() {
+    let (frag, _) = render("-is:read", Dialect::Sqlite);
+    assert_eq!(frag, "(NOT e.read_at IS NOT NULL)");
+}
+
+#[test]
+fn render_after_date_sqlite_epoch_and_int_bind() {
+    let (frag, binds) = render("after:2026-01-01", Dialect::Sqlite);
+    assert_eq!(
+        frag,
+        "CAST(strftime('%s', COALESCE(e.published_at, e.created_at)) AS INTEGER) >= $1"
+    );
+    // 2026-01-01T00:00:00Z
+    assert!(matches!(binds[0], Bind::Int(1_767_225_600)));
+}
+
+#[test]
+fn render_before_uses_lt_and_pg_epoch() {
+    let (frag, _) = render("before:2026-01-01", Dialect::Postgres);
+    assert_eq!(
+        frag,
+        "EXTRACT(EPOCH FROM COALESCE(e.published_at, e.created_at))::bigint < $1"
+    );
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo nextest run models::entry::filters 2>&1 | head -30`
+Expected: FAIL to compile — `render_query`, `ci_like_esc` not defined.
+
+- [ ] **Step 3: Implement the rendering**
+
+3a. Add the `query` field to `EntryFilter` in `src/models/entry/mod.rs` (inside the struct at lines 59-75; `#[serde(skip)]` because it is set programmatically, never deserialized from a form):
+
+```rust
+    /// Parsed boolean query AST for the global `/search` page. Set by the
+    /// search handler from the `?q=` string; `None` on every other list path
+    /// (a no-op). Rendered to SQL by `filters::render_query`.
+    #[serde(skip)]
+    pub query: Option<query::QueryNode>,
+```
+
+3b. In `src/models/entry/filters.rs`, extend the imports at the top (the `use super::{...}` line) to add the query types:
+
+```rust
+use super::query::{DateBound, QueryNode, SourceKind, Status, TextField};
+```
+
+3c. Add the `ci_like_esc` method to `impl Dialect` (next to `ci_like`):
+
+```rust
+    /// Case-insensitive `LIKE` with an explicit backslash `ESCAPE` clause, so
+    /// user `%` / `_` / `\` (escaped by `like_contains`) match literally.
+    /// SQLite's `LIKE` is already ASCII-case-insensitive, so no `COLLATE`
+    /// suffix is needed; PostgreSQL uses `ILIKE`.
+    fn ci_like_esc(self, column: &str, placeholder: usize) -> String {
+        match self {
+            Dialect::Sqlite => format!("{column} LIKE ${placeholder} ESCAPE '\\'"),
+            Dialect::Postgres => format!("{column} ILIKE ${placeholder} ESCAPE '\\'"),
+        }
+    }
+```
+
+3d. Add the renderer and the escape helper (e.g. just below `apply_filter_conditions`):
+
+```rust
+/// Escape a user value for a `LIKE '%...%'` contains-match: backslash-escape
+/// the LIKE metacharacters `\`, `%`, `_` (paired with an `ESCAPE '\'` clause)
+/// and wrap in `%...%`.
+fn like_contains(value: &str) -> String {
+    let mut esc = String::with_capacity(value.len() + 2);
+    esc.push('%');
+    for c in value.chars() {
+        if matches!(c, '\\' | '%' | '_') {
+            esc.push('\\');
+        }
+        esc.push(c);
+    }
+    esc.push('%');
+    esc
+}
+
+/// Recursively render a parsed query AST into a parenthesized WHERE fragment,
+/// pushing one `Bind` per leaf that needs a value. Dispatches dialect-specific
+/// SQL through `Dialect`.
+pub(super) fn render_query(node: &QueryNode, binds: &mut Vec<Bind>, dialect: Dialect) -> String {
+    match node {
+        QueryNode::And(a, b) => format!(
+            "({} AND {})",
+            render_query(a, binds, dialect),
+            render_query(b, binds, dialect)
+        ),
+        QueryNode::Or(a, b) => format!(
+            "({} OR {})",
+            render_query(a, binds, dialect),
+            render_query(b, binds, dialect)
+        ),
+        QueryNode::Not(a) => format!("(NOT {})", render_query(a, binds, dialect)),
+        QueryNode::Text(t) => {
+            let idx = binds.len() + 1;
+            let frag = format!(
+                "({} OR {})",
+                dialect.ci_like_esc("e.title", idx),
+                dialect.ci_like_esc("e.content_text", idx)
+            );
+            binds.push(Bind::Text(like_contains(t)));
+            frag
+        }
+        QueryNode::Field { field, value } => {
+            let col = match field {
+                TextField::Title => "e.title",
+                TextField::Author => "e.author",
+            };
+            let idx = binds.len() + 1;
+            let frag = dialect.ci_like_esc(col, idx);
+            binds.push(Bind::Text(like_contains(value)));
+            frag
+        }
+        QueryNode::Source { kind, value } => {
+            let col = match kind {
+                SourceKind::Feed => "f.title",
+                SourceKind::Category => "c.name",
+            };
+            let idx = binds.len() + 1;
+            let frag = dialect.ci_like_esc(col, idx);
+            binds.push(Bind::Text(like_contains(value)));
+            frag
+        }
+        QueryNode::Status(s) => match s {
+            Status::Unread => "e.read_at IS NULL".to_string(),
+            Status::Read => "e.read_at IS NOT NULL".to_string(),
+            Status::Starred => "e.starred_at IS NOT NULL".to_string(),
+        },
+        QueryNode::Date { bound, date } => {
+            let epoch = dialect.epoch("COALESCE(e.published_at, e.created_at)");
+            let secs = date
+                .and_hms_opt(0, 0, 0)
+                .expect("valid midnight")
+                .and_utc()
+                .timestamp();
+            let idx = binds.len() + 1;
+            let cmp = match bound {
+                DateBound::After => ">=",
+                DateBound::Before => "<",
+            };
+            let frag = format!("{epoch} {cmp} ${idx}");
+            binds.push(Bind::Int(secs));
+            frag
+        }
+    }
+}
+```
+
+3e. Wire it into `apply_filter_conditions` — add at the END of that function's body (after the `has_summary` block, before the closing brace at line ~231):
+
+```rust
+    if let Some(ref q) = filter.query {
+        conditions.push(render_query(q, binds, dialect));
+    }
+```
+
+3f. Extend `is_no_entry_side_predicate` (line 118) to include the new field, so a query-only search doesn't get forced onto `idx_entry_sort_ts`:
+
+```rust
+        && filter.has_summary.is_none()
+        && filter.query.is_none()
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `cargo nextest run models::entry::filters`
+Expected: PASS (new render tests + existing dialect tests all green).
+
+Then: `cargo fmt && cargo clippy --all-targets -- -D warnings 2>&1 | tail -5`
+Expected: no warnings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/models/entry/filters.rs src/models/entry/mod.rs
+git commit -m "feat(search): render query AST to SQL via the Dialect seam"
+```
+
+---
+
+### Task 3: End-to-end integration tests against real SQLite
+
+**Files:**
+- Modify: `src/models/entry/mod.rs` (extend the existing `#[cfg(test)] mod tests` search section, ~line 2017)
+
+**Interfaces:**
+- Consumes: `query::parse`, `EntryFilter { query, .. }`, `list_by_user` — all from earlier tasks.
+- Produces: confidence that parsed queries return the correct rows on a live DB.
+
+- [ ] **Step 1: Write the failing integration tests**
+
+Add to the search test module in `src/models/entry/mod.rs`. Reuse whatever fixture/setup helper the neighboring search tests use (e.g. `test_search_entries_by_title` at line 2017 shows the pattern: create a pool, a user/category/feed, upsert entries, then call `list_by_user`). Mirror that helper here — do not invent a new one. Example shape (adapt names to the existing helpers):
+
+```rust
+#[tokio::test]
+async fn query_is_unread_returns_only_unread() {
+    let ctx = setup_search_fixture().await; // existing helper used by sibling tests
+    // ctx seeds: entry "alpha" unread, entry "beta" read (read_at set).
+    let filter = EntryFilter {
+        query: Some(query::parse("is:unread").unwrap()),
+        ..Default::default()
+    };
+    let rows = list_by_user(&ctx.db, ctx.user_id, &filter, EntrySortOrder::PublishedAt, 50, 0)
+        .await
+        .unwrap();
+    let titles: Vec<_> = rows.iter().filter_map(|r| r.entry.title.clone()).collect();
+    assert!(titles.iter().any(|t| t == "alpha"));
+    assert!(!titles.iter().any(|t| t == "beta"));
+}
+
+#[tokio::test]
+async fn query_boolean_and_negation() {
+    let ctx = setup_search_fixture().await;
+    // "rust" unread, "rust weekly" read, "go" unread.
+    let filter = EntryFilter {
+        query: Some(query::parse("rust -is:read").unwrap()),
+        ..Default::default()
+    };
+    let rows = list_by_user(&ctx.db, ctx.user_id, &filter, EntrySortOrder::PublishedAt, 50, 0)
+        .await
+        .unwrap();
+    let titles: Vec<_> = rows.iter().filter_map(|r| r.entry.title.clone()).collect();
+    assert!(titles.iter().any(|t| t == "rust"));
+    assert!(!titles.iter().any(|t| t == "rust weekly")); // read → excluded
+    assert!(!titles.iter().any(|t| t == "go"));          // no "rust" → excluded
+}
+
+#[tokio::test]
+async fn query_feed_name_fuzzy_match() {
+    let ctx = setup_search_fixture().await; // feed titled "Rust Blog"
+    let filter = EntryFilter {
+        query: Some(query::parse("feed:rust").unwrap()),
+        ..Default::default()
+    };
+    let rows = list_by_user(&ctx.db, ctx.user_id, &filter, EntrySortOrder::PublishedAt, 50, 0)
+        .await
+        .unwrap();
+    assert!(!rows.is_empty());
+}
+
+#[tokio::test]
+async fn query_after_date_filters() {
+    let ctx = setup_search_fixture().await; // "old" published 2025, "new" published 2026
+    let filter = EntryFilter {
+        query: Some(query::parse("after:2026-01-01").unwrap()),
+        ..Default::default()
+    };
+    let rows = list_by_user(&ctx.db, ctx.user_id, &filter, EntrySortOrder::PublishedAt, 50, 0)
+        .await
+        .unwrap();
+    let titles: Vec<_> = rows.iter().filter_map(|r| r.entry.title.clone()).collect();
+    assert!(titles.iter().any(|t| t == "new"));
+    assert!(!titles.iter().any(|t| t == "old"));
+}
+
+#[tokio::test]
+async fn query_escapes_literal_percent() {
+    let ctx = setup_search_fixture().await; // entry titled "50% off", entry "50 dollars"
+    let filter = EntryFilter {
+        query: Some(query::parse("\"50%\"").unwrap()),
+        ..Default::default()
+    };
+    let rows = list_by_user(&ctx.db, ctx.user_id, &filter, EntrySortOrder::PublishedAt, 50, 0)
+        .await
+        .unwrap();
+    let titles: Vec<_> = rows.iter().filter_map(|r| r.entry.title.clone()).collect();
+    assert!(titles.iter().any(|t| t == "50% off"));
+    assert!(!titles.iter().any(|t| t == "50 dollars")); // literal %, not wildcard
+}
+```
+
+Note: the exact fixture helper name (`setup_search_fixture`) and its returned struct (`ctx.db`, `ctx.user_id`) MUST be replaced with whatever the sibling search tests already use. Read `test_search_entries_by_title` (mod.rs:2017) and `test_search_combined_with_filters` (mod.rs:2153) first and copy their setup verbatim; extend the seed data with the extra entries/feeds those new assertions need.
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cargo nextest run models::entry::tests::query_ 2>&1 | head -40`
+Expected: FAIL — either compile (helper name) until you align with the existing fixture, then assertion failures if seed data is missing. Fix the fixture wiring until they compile and fail only where the feature is exercised.
+
+- [ ] **Step 3: Make them pass**
+
+No new production code should be needed (Tasks 1-2 implement the behavior). If a test fails, debug via `superpowers:systematic-debugging` — likely a seed-data or fixture-alignment issue, not a logic gap. Adjust seed data / assertions.
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `cargo nextest run models::entry::tests`
+Expected: PASS (new query integration tests + all existing search tests).
+
+Then: `cargo fmt && cargo clippy --all-targets -- -D warnings 2>&1 | tail -5`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/models/entry/mod.rs
+git commit -m "test(search): integration coverage for parsed query filters (SQLite)"
+```
+
+---
+
+### Task 4: `/search` handler wiring, error banner, and syntax-help panel
+
+**Files:**
+- Modify: `src/handlers/pages/mod.rs:1735-1808` (`search_page`) and `:2791` (`SearchTemplate` — add `error` field)
+- Modify: `templates/search.html` (error banner + `<details>` help panel; branch on `error`)
+- Modify: `static/css/app.css` (append `.search-syntax-help` / `.search-error` styles)
+
+**Interfaces:**
+- Consumes: `entry::query::{parse, free_text_terms}`, `EntryFilter { query, .. }`.
+- Produces: `/search` renders results for a valid query, or an inline error (no results) for an invalid one; a collapsed help panel is always present.
+
+- [ ] **Step 1: Write the failing handler test**
+
+Add a handler-level test. If `src/handlers/pages/mod.rs` (or a sibling `tests` module) already has SSR handler tests that build an app/router and hit routes, mirror that. Otherwise add a focused test that calls `entry::query::parse` through the same code path by extracting the parse+error formatting into a small helper and testing it. Preferred (integration) form, adapted to the repo's existing handler-test harness:
+
+```rust
+#[tokio::test]
+async fn search_invalid_query_shows_error_no_results() {
+    let app = test_app().await; // existing harness used by other handler tests
+    let resp = app.get("/search?q=%28rust%20OR").await; // "(rust OR" url-encoded
+    let body = resp.text().await;
+    assert!(body.contains("搜尋語法錯誤"));
+    assert!(!body.contains("data-testid=\"search-results\""));
+}
+
+#[tokio::test]
+async fn search_valid_query_renders_results_area() {
+    let app = test_app_with_seed().await; // seeded with a matching entry
+    let resp = app.get("/search?q=is%3Aunread").await;
+    let body = resp.text().await;
+    assert!(!body.contains("搜尋語法錯誤"));
+}
+```
+
+If no such handler harness exists, instead unit-test a new pure helper `fn parse_or_error(q: &str) -> Result<entry::query::QueryNode, String>` (returning the formatted `搜尋語法錯誤（第 N 字）：…` string) and call it from the handler. Add the test next to the helper.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo nextest run search_ 2>&1 | head -30`
+Expected: FAIL (route/handler not yet parsing; `error` field missing).
+
+- [ ] **Step 3: Implement the handler + template + CSS**
+
+3a. Add the `error` field to `SearchTemplate` (`src/handlers/pages/mod.rs:2791`):
+
+```rust
+pub struct SearchTemplate {
+    pub title: &'static str,
+    pub git_version: &'static str,
+    pub layout: AppLayoutContext,
+    pub q: String,
+    pub error: Option<String>,
+    pub results: Vec<SearchResultView>,
+}
+```
+
+3b. Rewrite the body of `search_page` (`mod.rs:1740-1808`) — replace the `results` computation and the returned template:
+
+```rust
+    let layout = build_app_layout(&state, &auth_user, &flash).await;
+    let q = query.q.unwrap_or_default().trim().to_string();
+    let user_id = auth_user.user.id;
+
+    let mut error: Option<String> = None;
+    let results = if q.is_empty() {
+        Vec::new()
+    } else {
+        match entry::query::parse(&q) {
+            Err(e) => {
+                // Byte offset → 1-based character position for the message.
+                let char_pos = q.get(..e.position).map(|p| p.chars().count()).unwrap_or(0) + 1;
+                error = Some(format!("搜尋語法錯誤（第 {char_pos} 字）：{}", e.message));
+                Vec::new()
+            }
+            Ok(ast) => {
+                let terms = entry::query::free_text_terms(&ast);
+                let needle = terms.first().cloned().unwrap_or_default();
+                let filter = entry::EntryFilter {
+                    query: Some(ast),
+                    ..Default::default()
+                };
+                const LIMIT: i64 = 50;
+                let rows = entry::list_by_user(
+                    &state.db,
+                    user_id,
+                    &filter,
+                    entry::EntrySortOrder::PublishedAt,
+                    LIMIT,
+                    0,
+                )
+                .await
+                .unwrap_or_default();
+                rows.into_iter()
+                    .map(|e| {
+                        let title = e
+                            .entry
+                            .title
+                            .clone()
+                            .unwrap_or_else(|| "(no title)".to_string());
+                        let snippet = build_snippet(
+                            e.entry.content.as_deref().or(e.entry.summary.as_deref()),
+                            &needle,
+                            200,
+                        );
+                        let (published_relative, published_at_iso) =
+                            format_relative_time(e.entry.published_at);
+                        SearchResultView {
+                            entry_id: e.entry.id,
+                            title_html: highlight_html(&title, &needle),
+                            feed_title: e.feed_title.clone().unwrap_or_else(|| e.feed_url.clone()),
+                            published_relative,
+                            published_at_iso,
+                            snippet_html: highlight_html(&snippet, &needle),
+                        }
+                    })
+                    .collect()
+            }
+        }
+    };
+
+    (
+        flash,
+        SearchTemplate {
+            title: "Search",
+            git_version: crate::GIT_VERSION,
+            layout,
+            q,
+            error,
+            results,
+        },
+    )
+```
+
+(Note: `highlight_html`/`build_snippet` already no-op on an empty `needle` — verified in `search_text.rs` — so a pure structured query like `is:unread` renders escaped titles and leading snippets.)
+
+3c. Update `templates/search.html` — insert the syntax-help `<details>` right after the `</form>`/`<script>` block (after line 31), and branch on `error` for the results region. Replace the `{% if q.is_empty() %} … {% endif %}` block (lines 33-62) with:
+
+```html
+                <details class="search-syntax-help">
+                    <summary>Search syntax</summary>
+                    <div class="search-syntax-help-body">
+                        <ul>
+                            <li><code>is:unread</code> / <code>is:read</code> / <code>is:starred</code> — by status</li>
+                            <li><code>feed:name</code> / <code>category:name</code> — by source (fuzzy, case-insensitive)</li>
+                            <li><code>title:word</code> / <code>author:name</code> — by field</li>
+                            <li><code>before:2026-01-01</code> / <code>after:2026-01-01</code> — by date (UTC)</li>
+                            <li><code>AND</code> <code>OR</code> <code>NOT</code> and <code>(&nbsp;)</code> — combine; adjacent words imply AND</li>
+                            <li><code>-term</code> — exclude; <code>"exact phrase"</code> — quote (also for values with spaces, e.g. <code>feed:"Rust Blog"</code>)</li>
+                        </ul>
+                    </div>
+                </details>
+
+                {% if let Some(err) = error %}
+                    <div class="search-error" role="alert" data-testid="search-error">{{ err }}</div>
+                {% else if q.is_empty() %}
+                    <div class="empty-state">
+                        <h2 class="empty-state-title">Search your library</h2>
+                        <p class="empty-state-text">Type a keyword and press <kbd class="empty-state-kbd">Enter</kbd> to find entries by title or content.</p>
+                    </div>
+                {% else if results.is_empty() %}
+                    <div class="empty-state" data-testid="search-empty">
+                        <h2 class="empty-state-title">No matches</h2>
+                        <p class="empty-state-text">Nothing matched &ldquo;{{ q }}&rdquo;. Try another keyword or check the spelling.</p>
+                    </div>
+                {% else %}
+                    <ul class="search-results" data-testid="search-results">
+                        {% for r in results %}
+                            <li class="search-result">
+                                <a href="/entries/{{ r.entry_id }}" class="search-result-title">{{ r.title_html|safe }}</a>
+                                <div class="search-result-meta">
+                                    <span class="muted">{{ r.feed_title }}</span>
+                                    {% if !r.published_relative.is_empty() %}
+                                        <span class="muted">&middot;
+                                            {% if !r.published_at_iso.is_empty() %}<time datetime="{{ r.published_at_iso }}">{{ r.published_relative }}</time>{% else %}{{ r.published_relative }}{% endif %}
+                                        </span>
+                                    {% endif %}
+                                </div>
+                                {% if !r.snippet_html.is_empty() %}
+                                    <p class="search-result-snippet">{{ r.snippet_html|safe }}</p>
+                                {% endif %}
+                            </li>
+                        {% endfor %}
+                    </ul>
+                {% endif %}
+```
+
+3d. Append to `static/css/app.css` (reuse existing tokens; the `<details>`/`summary` base styling at `app.css:2005-2008` already applies):
+
+```css
+.search-syntax-help {
+    margin: var(--space-sm) 0 var(--space-md);
+    font-size: var(--font-sm);
+}
+.search-syntax-help-body ul {
+    margin: var(--space-xs) 0 0;
+    padding-left: var(--space-lg);
+    color: var(--color-text-muted);
+}
+.search-syntax-help-body li {
+    margin: var(--space-2xs) 0;
+}
+.search-syntax-help-body code {
+    font-family: var(--font-mono, monospace);
+}
+.search-error {
+    margin: var(--space-md) 0;
+    padding: var(--space-sm) var(--space-md);
+    border-radius: var(--radius-md);
+    background: var(--color-danger-bg, #fde8e8);
+    color: var(--color-danger-text, #9b1c1c);
+}
+```
+
+Note: verify the exact token names against the top of `app.css` (`--space-*`, `--font-*`, `--radius-*`, `--color-danger-*`). If a token doesn't exist, substitute the nearest existing one or a literal — check what `.feed-http-hint` and existing alert/flash styles use and match them.
+
+- [ ] **Step 4: Rebuild and run tests**
+
+Because CSS/templates are embedded via `include_str!`, rebuild first:
+
+Run: `cargo build && cargo nextest run search_`
+Expected: PASS.
+
+Then: `cargo fmt && cargo clippy --all-targets -- -D warnings 2>&1 | tail -5`
+
+Manual smoke (optional, per `/run` skill): start the app, visit `/search?q=(rust OR` → error banner; `/search?q=is:unread rust` → results; expand the "Search syntax" panel.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/handlers/pages/mod.rs templates/search.html static/css/app.css
+git commit -m "feat(search): parse query on /search with error banner and syntax help"
+```
+
+---
+
+### Task 5: Postgres parity tests + documentation
+
+**Files:**
+- Modify: `tests/postgres_test.rs` (add 1-2 query cases; env-gated, runs on the CI Postgres lane)
+- Modify: `ARCHITECTURE.md` (update the search description)
+
+**Interfaces:**
+- Consumes: everything above; validates the PG `ILIKE` + epoch path against a live server.
+
+- [ ] **Step 1: Write the failing Postgres tests**
+
+Mirror the existing env-gated pattern in `tests/postgres_test.rs` (it already validates PG list paths). Add:
+
+```rust
+#[tokio::test]
+async fn pg_query_is_unread_and_free_text() {
+    let Some(db) = pg_db_from_env().await else { return }; // existing skip-if-no-DSN guard
+    // seed a user/category/feed + one unread entry titled "rust news"
+    // ... (reuse the file's existing seed helpers) ...
+    let filter = rdrs::models::entry::EntryFilter {
+        query: Some(rdrs::models::entry::query::parse("is:unread rust").unwrap()),
+        ..Default::default()
+    };
+    let rows = rdrs::models::entry::list_by_user(
+        &db, user_id, &filter, rdrs::models::entry::EntrySortOrder::PublishedAt, 50, 0,
+    ).await.unwrap();
+    assert!(rows.iter().any(|r| r.entry.title.as_deref() == Some("rust news")));
+}
+
+#[tokio::test]
+async fn pg_query_after_date() {
+    let Some(db) = pg_db_from_env().await else { return };
+    // seed "old" (2025) + "new" (2026)
+    let filter = rdrs::models::entry::EntryFilter {
+        query: Some(rdrs::models::entry::query::parse("after:2026-01-01").unwrap()),
+        ..Default::default()
+    };
+    let rows = rdrs::models::entry::list_by_user(
+        &db, user_id, &filter, rdrs::models::entry::EntrySortOrder::PublishedAt, 50, 0,
+    ).await.unwrap();
+    assert!(rows.iter().any(|r| r.entry.title.as_deref() == Some("new")));
+    assert!(!rows.iter().any(|r| r.entry.title.as_deref() == Some("old")));
+}
+```
+
+Replace `pg_db_from_env` / seed helpers / the crate name (`rdrs`) with whatever the existing file uses — read the top of `tests/postgres_test.rs` first and copy its conventions verbatim (including how it exposes `query`/`EntryFilter`; you may need `pub mod query;` to already be `pub`, which Task 1 ensures).
+
+- [ ] **Step 2: Run to verify (skips without a DSN)**
+
+Run: `cargo nextest run --test postgres_test 2>&1 | tail -20`
+Expected: PASS-or-skip locally (no DSN → the guard returns early). On the CI Postgres lane they execute for real.
+
+If you have a local Postgres, set the env DSN the file expects (grep the file for the var name) and run again to see them actually exercise the PG path.
+
+- [ ] **Step 3: Update the docs**
+
+Edit `ARCHITECTURE.md` — find the search/entry-filter description and update it from "single case-insensitive `LIKE '%q%'` over title + content" to note that the **global `/search`** page now accepts a boolean query language (`is:`/`feed:`/`category:`/`title:`/`author:`/`before:`/`after:`, `AND`/`OR`/`NOT`, grouping, quoting, `-` negation) parsed by `models/entry/query.rs` into a `QueryNode` AST and rendered to SQL by `filters::render_query`; backend matching remains `LIKE`/`ILIKE` (no FTS); scoped views still use the plain-substring `search` field. Keep it to 2-4 sentences consistent with the file's style.
+
+- [ ] **Step 4: Verify build + full suite**
+
+Run: `cargo fmt && cargo clippy --all-targets -- -D warnings && cargo nextest run 2>&1 | tail -20`
+Expected: fmt clean, no clippy warnings, all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/postgres_test.rs ARCHITECTURE.md
+git commit -m "test(search): Postgres parity for query filters; docs update"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §2 grammar/semantics → Task 1 (lexer + parser + all semantic rules; tests cover precedence, implicit AND, `-` tightness, `field:` disambiguation, quoting, dates, errors). ✅
+- §3 AST + `EntryFilter.query` + `parse()` → Task 1 (AST, `parse`, `free_text_terms`) + Task 2 (field). ✅
+- §4 AST→SQL via Dialect, LIKE escaping, joins, AND-combine → Task 2. ✅
+- §5 error handling (GET, no FlashRedirect, error banner, no results) → Task 4. ✅
+- §6 `<details>` syntax-help panel → Task 4. ✅
+- §7 indexing (no new index; verify PG parity) → no index tasks (by design); PG parity verified in Task 5. ✅
+- §8 test plan (parser unit, SQL-shape both dialects, SQLite integration, PG env-gated, handler) → Tasks 1-5. ✅
+- §9 docs (ARCHITECTURE.md) → Task 5. ✅
+
+**Placeholder scan:** Integration/handler/PG tests intentionally defer to the repo's existing fixture helpers (named explicitly with instructions to copy sibling patterns verbatim) rather than inventing parallel harnesses — this is a real instruction, not a TBD. All production code is spelled out in full.
+
+**Type consistency:** `QueryNode` variant names, `TextField`/`SourceKind`/`Status`/`DateBound`, `parse`, `free_text_terms`, `render_query(node, binds, dialect)`, `ci_like_esc`, `like_contains`, and `EntryFilter.query` are used identically across Tasks 1-5. `render_query` signature matches its call site in `apply_filter_conditions`. Bind numbering uses `binds.len() + 1` consistently with the existing builders.

--- a/docs/superpowers/specs/2026-07-08-search-query-syntax-design.md
+++ b/docs/superpowers/specs/2026-07-08-search-query-syntax-design.md
@@ -1,0 +1,230 @@
+# Search Query Syntax — Design Spec
+
+- **Date:** 2026-07-08
+- **Status:** Approved (pending implementation)
+- **Scope:** Introduce a boolean query-language parser for the global `/search`
+  page. Backend matching stays `LIKE`/`ILIKE` (no full-text search this round).
+
+## 1. Motivation & Current State
+
+Today "search" is a single free-text string matched as a case-insensitive
+substring (`LIKE '%q%'` on SQLite, `ILIKE` on Postgres) against `entry.title`
+and `entry.content_text` only (`src/models/entry/filters.rs:207-217`). There is
+**no query grammar** — no field operators, booleans, quoting, or negation.
+Structured filters (`unread_only`, `starred_only`, `feed_id`, `category_id`, …)
+are populated from separate query params / routes, never parsed from the search
+text.
+
+This spec adds a real query language so users can express, in one search box:
+field filters, boolean logic, grouping, negation, and quoted phrases — parsed
+into the existing structured filtering layer.
+
+**Non-goals (explicitly out of scope):**
+- Full-text search (FTS5 / `tsvector`). Free-text remains a `%v%` scan.
+- Applying the syntax to the scoped per-view search (`_entries_layout.html`)
+  or category/feed pages. Global `/search` only.
+- A third-party parser dependency (`winnow`/`chumsky`). Hand-written, zero deps.
+
+## 2. Grammar (EBNF) & Semantics
+
+Operator precedence, high → low: `NOT` > `AND` (implicit or explicit) > `OR`.
+Parentheses override. Adjacent terms with no operator are an implicit `AND`.
+
+```ebnf
+query    = or_expr ;
+or_expr  = and_expr { "OR" and_expr } ;
+and_expr = not_expr { [ "AND" ] not_expr } ;   (* omitted operator = implicit AND *)
+not_expr = { "NOT" | "-" } atom ;              (* NOT keyword or tight "-" negates *)
+atom     = "(" or_expr ")" | filter | text ;
+filter   = field ":" value ;
+field    = "is" | "feed" | "category" | "title" | "author" | "before" | "after" ;
+value    = quoted | bare ;
+text     = quoted | bare ;
+quoted   = '"' { char - '"' } '"' ;
+bare     = { char - ( space | '(' | ')' | '"' ) } ;
+```
+
+### Semantic rules
+
+| Rule | Behavior |
+|---|---|
+| Keyword case | `AND`/`OR`/`NOT` are case-insensitive operators. To search them literally, quote: `"and"`. |
+| Field-name case | Field names (`is`, `feed`, …) are case-insensitive. |
+| `field:` trigger | A `token:` is a filter **only** when `token` is a known field name; otherwise the whole token (colon included) is free text. `http://example.com` → `http` is unknown → literal text. |
+| Free text | Matches `title OR content_text` (unchanged from today). |
+| `title:` / `author:` | Single-column case-insensitive substring. `author` is **newly** searchable. |
+| `is:` | `unread` → `read_at IS NULL`; `read` → `read_at IS NOT NULL`; `starred` → `starred_at IS NOT NULL`. Unknown value → `ParseError`. |
+| `feed:` / `category:` | Case-insensitive substring on `feed.title` / `category.name`. One term may match multiple sources (implicit OR over the matched set). |
+| `before:` / `after:` | Value is `YYYY-MM-DD`, interpreted in **UTC** (the app pins `TimeZone=UTC`). `after:D` → `COALESCE(published_at, created_at) >= D 00:00`; `before:D` → `< D 00:00`. |
+| `-` negation | `-` negates only when **tight** against an atom (no whitespace) at an atom position: `-is:read`, `-rust`, `-(a OR b)`. `cross-platform` is one text token (`-` mid-token). `- rust` (space) → `-` is a literal text token. Literal `-rust` → quote it: `"-rust"`. |
+| Value quoting | Values with spaces need quotes: `feed:"Rust Blog"`, `title:"exact words"`. |
+
+### Examples
+
+- `is:unread rust` → unread AND (title/content contains rust)
+- `is:starred (rust OR go) -is:read` → starred AND (rust OR go) AND NOT read
+- `feed:"Hacker News" after:2026-01-01 title:rust`
+
+## 3. AST & Parser (`src/models/entry/query.rs`, new module)
+
+Hand-written tokenizer + recursive-descent parser + AST, ~250–350 lines,
+zero new dependencies (`chrono` — already a dependency — validates dates).
+
+```rust
+pub enum QueryNode {
+    And(Box<QueryNode>, Box<QueryNode>),
+    Or(Box<QueryNode>, Box<QueryNode>),
+    Not(Box<QueryNode>),
+    Text(String),                               // free text → title OR content_text
+    Field { field: TextField, value: String },  // TextField::{Title, Author}
+    Source { kind: SourceKind, value: String },  // SourceKind::{Feed, Category}
+    Status(Status),                             // Status::{Unread, Read, Starred}
+    Date { bound: DateBound, date: NaiveDate },  // DateBound::{Before, After}
+}
+
+pub struct ParseError { pub position: usize, pub message: String }
+
+pub fn parse(input: &str) -> Result<QueryNode, ParseError>;
+```
+
+- **Tokenizer** emits `Word / Quoted / LParen / RParen / And / Or / Not / Minus /
+  FieldColon(field)`, each carrying its byte offset (for error positioning).
+- **Parser** is four mutually-recursive functions mirroring `or_expr /
+  and_expr / not_expr / atom`.
+- **Date validation** happens at parse time via
+  `NaiveDate::parse_from_str(v, "%Y-%m-%d")`; failure → `ParseError`.
+
+`EntryFilter` (`src/models/entry/mod.rs:59`) gains one field:
+
+```rust
+pub query: Option<QueryNode>,   // global /search only; existing `search: Option<String>` unchanged for scoped views
+```
+
+## 4. AST → SQL (`src/models/entry/filters.rs`)
+
+New recursive function alongside `apply_filter_conditions`, dispatching through
+the existing `Dialect` seam:
+
+```rust
+fn render_query(node: &QueryNode, dialect: Dialect, binds: &mut Vec<Bind>) -> String
+```
+
+Produces a parenthesized WHERE fragment; each leaf pushes its binds. SQLite
+shown (Postgres uses `ILIKE` and its own epoch form):
+
+| Node | SQL fragment |
+|---|---|
+| `And(a,b)` | `(<a> AND <b>)` |
+| `Or(a,b)` | `(<a> OR <b>)` |
+| `Not(a)` | `(NOT <a>)` |
+| `Text(t)` | `(e.title LIKE $n ESCAPE '\' COLLATE NOCASE OR e.content_text LIKE $n ESCAPE '\' COLLATE NOCASE)` |
+| `Field{Title,v}` | `e.title LIKE $n ESCAPE '\' COLLATE NOCASE` |
+| `Field{Author,v}` | `e.author LIKE $n ESCAPE '\' COLLATE NOCASE` (author newly searched) |
+| `Source{Feed,v}` | `f.title LIKE $n ESCAPE '\' COLLATE NOCASE` |
+| `Source{Category,v}` | `c.name LIKE $n ESCAPE '\' COLLATE NOCASE` |
+| `Status(Unread)` | `e.read_at IS NULL` (read → `IS NOT NULL`; starred → `e.starred_at IS NOT NULL`) |
+| `Date{After,d}` | `COALESCE(e.published_at, e.created_at) >= <epoch(d)>` (before → `<`) |
+
+- **LIKE wildcard escaping:** user-supplied `%` / `_` / `\` are escaped and an
+  explicit `ESCAPE '\'` clause is emitted, so a search for a literal `%` is a
+  literal. (The current single-string path does *not* escape — a pre-existing
+  minor bug we do not carry into the new path.)
+- **Joins:** `feed`/`category` predicates rely on the `f`/`c` aliases already
+  joined by `list_by_user`. If a backend's query lacks the join, add it.
+- When the global `/search` handler sets `filter.query`, `render_query`'s output
+  is `AND`-combined into the WHERE clause. The legacy `filter.search` path is not
+  used on the global page; scoped views keep using it unchanged.
+
+## 5. Error Handling & UI Wiring
+
+`/search` is a `GET` page (not a POST → no `FlashRedirect`). In `search_page`
+(`src/handlers/pages/mod.rs:1735`):
+
+```
+q empty            → current behavior (no search)
+parse(q) == Ok(a)  → EntryFilter.query = Some(a) → normal listing
+parse(q) == Err(e) → do NOT run the query; render the page with
+                     error = Some("搜尋語法錯誤（第 {e.position} 字）：{e.message}")
+```
+
+- `search.html` gains an `error: Option<String>` field; when `Some`, an error
+  banner renders below the input and the results area stays empty.
+- Message examples: `括號不對稱：'(' 未關閉`, `'before:' 需要 YYYY-MM-DD 格式的日期`,
+  `'OR' 後面缺少搜尋條件`.
+- **Screenshot impact:** the error banner only appears on invalid input; the
+  four README screenshots (unread list + reading pane; keyboard-help overlay)
+  do not include `/search`, so no regeneration is required. The search input
+  `placeholder` is left unchanged this round.
+
+## 6. Discoverability — Syntax Help Panel
+
+Users must be able to discover the syntax without prior knowledge. Reuse the
+existing native `<details>/<summary>` disclosure pattern
+(`templates/feed_edit.html:36-38`, CSS `app.css:2010-2019`).
+
+- Add a collapsed-by-default `<details class="search-syntax-help">` beneath the
+  `/search` input in `templates/search.html`. `<summary>` reads e.g. "Search
+  syntax". Expanded body lists each operator with a one-line example
+  (`is:unread`, `feed:"…"`, `title:` / `author:`, `before:` / `after:`,
+  `AND`/`OR`/`NOT`, `-`, quoting).
+- Reuses existing disclosure CSS; a small amount of list styling may be added
+  under a new `.search-syntax-help` selector in `app.css`.
+- Not added to the `?` keyboard-help overlay (that overlay is keyboard
+  shortcuts, and it *is* captured in screenshots — changing it would force a
+  screenshot regen). This is listed as an optional follow-up.
+- `/search` is not among the four README screenshots, so the panel does not
+  require screenshot regeneration.
+
+## 7. Indexing & Performance
+
+**Conclusion: no new index is added, by design.** Verified against
+`migrations/sqlite/0001_initial.sql:79-94`.
+
+| New predicate | Index needed | Present today |
+|---|---|---|
+| `is:unread` / `is:read` (`read_at IS [NOT] NULL`) | `read_at` | ✅ `idx_entry_read_at` + partial `idx_entry_unread_sort` / `idx_entry_read_sort` |
+| `is:starred` (`starred_at IS NOT NULL`) | `starred_at` | ✅ `idx_entry_starred_at` + `idx_entry_starred_sort` |
+| `before:` / `after:` (`COALESCE(published_at, created_at)` compare) | expression index on that COALESCE | ✅ `idx_entry_sort_ts` (exact match — this is why the date filter uses COALESCE) |
+| `feed:` / `category:` (`f.title` / `c.name LIKE '%v%'`) | none | feed/category are tiny per-user tables; scan is negligible |
+| free text / `title:` / `author:` (`LIKE '%v%'`) | **none possible** | leading-wildcard LIKE cannot use a B-tree index — unchanged full scan from today; only FTS (out of scope) would help |
+
+Rationale:
+- Index-able predicates (status, date) hit existing indexes → no regression.
+- Non-index-able predicates are leading-wildcard `LIKE` scans; adding indexes
+  would **not** help and would only slow writes, so we deliberately add none.
+  This is the same cost profile as today's search.
+- **Verification item:** confirm `migrations/postgres/0001_initial.sql` mirrors
+  these indexes (multi-db parity).
+
+## 8. Testing Plan (TDD)
+
+1. **Tokenizer / parser unit tests** (`query.rs` `#[cfg(test)]`):
+   precedence (`NOT` > `AND` > `OR`), implicit AND, parentheses; `-` tightness
+   (`-is:read` negates, `cross-platform` unaffected, `- rust` literal); `field:`
+   disambiguation (`feed:rust` filter vs `http://x` text); quoted values and
+   literal `"and"`; date parse (valid + `before:yesterday` error); error paths
+   (unbalanced parens, `OR` missing operand, trailing operator).
+2. **SQL-shape tests** (`filters.rs`, mirroring existing dialect tests
+   `319-421`): assert the WHERE fragment for representative ASTs, **SQLite and
+   Postgres each** (`LIKE … ESCAPE COLLATE NOCASE` vs `ILIKE`; both epoch forms).
+3. **Integration tests** (extend the search test module in `entry/mod.rs`,
+   against real SQLite): seed feeds/categories/entries; verify result sets for
+   each operator and boolean/negation combos; verify `%` literal escaping.
+4. **Postgres path** (env-gated `tests/postgres_test.rs`): 1–2 query cases
+   validating `ILIKE` + epoch.
+5. **Handler test** (`/search`): invalid query → error banner, no results;
+   valid query → results.
+
+## 9. Documentation
+
+Per repo convention (update existing, do not create new docs beyond this spec):
+- Update `ARCHITECTURE.md`'s search description (single `LIKE` substring →
+  global `/search` boolean query syntax).
+- This spec is the syntax reference.
+
+## 10. Optional Follow-ups (not this round)
+
+- `-` short-negation is included; FTS5 / `tsvector` relevance search is not.
+- Syntax help in the `?` keyboard-help overlay.
+- Apply the syntax to scoped / category / feed search surfaces.
+- Search-input `placeholder` example text.

--- a/docs/superpowers/specs/2026-07-08-search-query-syntax-design.md
+++ b/docs/superpowers/specs/2026-07-08-search-query-syntax-design.md
@@ -117,14 +117,22 @@ shown (Postgres uses `ILIKE` and its own epoch form):
 | `And(a,b)` | `(<a> AND <b>)` |
 | `Or(a,b)` | `(<a> OR <b>)` |
 | `Not(a)` | `(NOT <a>)` |
-| `Text(t)` | `(e.title LIKE $n ESCAPE '\' COLLATE NOCASE OR e.content_text LIKE $n ESCAPE '\' COLLATE NOCASE)` |
-| `Field{Title,v}` | `e.title LIKE $n ESCAPE '\' COLLATE NOCASE` |
-| `Field{Author,v}` | `e.author LIKE $n ESCAPE '\' COLLATE NOCASE` (author newly searched) |
-| `Source{Feed,v}` | `f.title LIKE $n ESCAPE '\' COLLATE NOCASE` |
-| `Source{Category,v}` | `c.name LIKE $n ESCAPE '\' COLLATE NOCASE` |
+| `Text(t)` | `COALESCE((e.title LIKE $n ESCAPE '\' OR e.content_text LIKE $n ESCAPE '\'), <false>)` |
+| `Field{Title,v}` | `COALESCE(e.title LIKE $n ESCAPE '\', <false>)` |
+| `Field{Author,v}` | `COALESCE(e.author LIKE $n ESCAPE '\', <false>)` (author newly searched) |
+| `Source{Feed,v}` | `COALESCE(f.title LIKE $n ESCAPE '\', <false>)` |
+| `Source{Category,v}` | `COALESCE(c.name LIKE $n ESCAPE '\', <false>)` |
 | `Status(Unread)` | `e.read_at IS NULL` (read → `IS NOT NULL`; starred → `e.starred_at IS NOT NULL`) |
 | `Date{After,d}` | `COALESCE(e.published_at, e.created_at) >= <epoch(d)>` (before → `<`) |
 
+Postgres uses `ILIKE`; SQLite's `LIKE` is already ASCII-case-insensitive, so no
+`COLLATE NOCASE` suffix is emitted.
+
+- **Null-safe leaves:** each `LIKE` leaf is wrapped in `COALESCE(<expr>, <false>)`
+  (`<false>` = `0` on SQLite, `FALSE` on Postgres) so a `NULL` column reads as
+  `FALSE`, not `NULL`. This makes the predicate two-valued: positive matches are
+  unaffected, and a negated filter such as `-author:jane` correctly *includes*
+  entries whose `author` is `NULL` instead of silently dropping them.
 - **LIKE wildcard escaping:** user-supplied `%` / `_` / `\` are escaped and an
   explicit `ESCAPE '\'` clause is emitted, so a search for a literal `%` is a
   literal. (The current single-string path does *not* escape — a pre-existing
@@ -144,13 +152,15 @@ shown (Postgres uses `ILIKE` and its own epoch form):
 q empty            → current behavior (no search)
 parse(q) == Ok(a)  → EntryFilter.query = Some(a) → normal listing
 parse(q) == Err(e) → do NOT run the query; render the page with
-                     error = Some("搜尋語法錯誤（第 {e.position} 字）：{e.message}")
+                     error = Some("Search syntax error (near character {char_pos}): {e.message}")
 ```
 
 - `search.html` gains an `error: Option<String>` field; when `Some`, an error
   banner renders below the input and the results area stays empty.
-- Message examples: `括號不對稱：'(' 未關閉`, `'before:' 需要 YYYY-MM-DD 格式的日期`,
-  `'OR' 後面缺少搜尋條件`.
+- Messages are English, to match the English `/search` UI. Examples:
+  `Unbalanced parentheses: '(' is not closed`, `'before:' expects a date like
+  YYYY-MM-DD`, `Expected a search term here`. (`char_pos` is the 1-based
+  character position derived from the parser's byte offset `e.position`.)
 - **Screenshot impact:** the error banner only appears on invalid input; the
   four README screenshots (unread list + reading pane; keyboard-help overlay)
   do not include `/search`, so no regeneration is required. The search input
@@ -184,7 +194,7 @@ existing native `<details>/<summary>` disclosure pattern
 |---|---|---|
 | `is:unread` / `is:read` (`read_at IS [NOT] NULL`) | `read_at` | ✅ `idx_entry_read_at` + partial `idx_entry_unread_sort` / `idx_entry_read_sort` |
 | `is:starred` (`starred_at IS NOT NULL`) | `starred_at` | ✅ `idx_entry_starred_at` + `idx_entry_starred_sort` |
-| `before:` / `after:` (`COALESCE(published_at, created_at)` compare) | expression index on that COALESCE | ✅ `idx_entry_sort_ts` (exact match — this is why the date filter uses COALESCE) |
+| `before:` / `after:` (`COALESCE(published_at, created_at)` compare) | expression index on that COALESCE | ✅ `idx_entry_sort_ts` on `COALESCE(published_at, created_at)` — same expression the `ORDER BY` already uses. Note: the emitted predicate wraps it in an epoch cast (`CAST(strftime('%s', COALESCE(...)) AS INTEGER)`), so the WHERE clause is not a verbatim index seek; this matches the pre-existing `apply_time_conditions` pattern, so there is no regression and no new index is warranted. |
 | `feed:` / `category:` (`f.title` / `c.name LIKE '%v%'`) | none | feed/category are tiny per-user tables; scan is negligible |
 | free text / `title:` / `author:` (`LIKE '%v%'`) | **none possible** | leading-wildcard LIKE cannot use a B-tree index — unchanged full scan from today; only FTS (out of scope) would help |
 
@@ -206,7 +216,8 @@ Rationale:
    (unbalanced parens, `OR` missing operand, trailing operator).
 2. **SQL-shape tests** (`filters.rs`, mirroring existing dialect tests
    `319-421`): assert the WHERE fragment for representative ASTs, **SQLite and
-   Postgres each** (`LIKE … ESCAPE COLLATE NOCASE` vs `ILIKE`; both epoch forms).
+   Postgres each** (`COALESCE(… LIKE … ESCAPE '\', 0)` vs `COALESCE(… ILIKE …
+   ESCAPE '\', FALSE)`; both epoch forms).
 3. **Integration tests** (extend the search test module in `entry/mod.rs`,
    against real SQLite): seed feeds/categories/entries; verify result sets for
    each operator and boolean/negation combos; verify `%` literal escaping.

--- a/src/handlers/entry.rs
+++ b/src/handlers/entry.rs
@@ -63,6 +63,7 @@ pub async fn get_entry_neighbors(
         has_summary: query.has_summary,
         search: None,
         read_after: query.read_after,
+        ..Default::default()
     };
     let neighbors = entry::find_neighbors(&state.db, user_id, id, &filter).await?;
     Ok(Json(neighbors))

--- a/src/handlers/pages/mod.rs
+++ b/src/handlers/pages/mod.rs
@@ -1742,57 +1742,63 @@ pub async fn search_page(
     let q = query.q.unwrap_or_default().trim().to_string();
     let user_id = auth_user.user.id;
 
+    let mut error: Option<String> = None;
     let results = if q.is_empty() {
         Vec::new()
     } else {
-        let q_for_filter = q.clone();
-        async {
-            let filter = entry::EntryFilter {
-                search: Some(q_for_filter.clone()),
-                ..Default::default()
-            };
-            // SQL now matches stored plain text (content_text), so every
-            // returned row is a real visible match — no phantom re-filter.
-            const LIMIT: i64 = 50;
-            let rows = entry::list_by_user(
-                &state.db,
-                user_id,
-                &filter,
-                entry::EntrySortOrder::PublishedAt,
-                LIMIT,
-                0,
-            )
-            .await?;
-            let out: Vec<SearchResultView> = rows
-                .into_iter()
-                .map(|e| {
-                    let title = e
-                        .entry
-                        .title
-                        .clone()
-                        .unwrap_or_else(|| "(no title)".to_string());
-                    let snippet = build_snippet(
-                        e.entry.content.as_deref().or(e.entry.summary.as_deref()),
-                        &q_for_filter,
-                        200,
-                    );
-                    let (published_relative, published_at_iso) =
-                        format_relative_time(e.entry.published_at);
-                    SearchResultView {
-                        entry_id: e.entry.id,
-                        title_html: highlight_html(&title, &q_for_filter),
-                        feed_title: e.feed_title.clone().unwrap_or_else(|| e.feed_url.clone()),
-                        published_relative,
-                        published_at_iso,
-                        snippet_html: highlight_html(&snippet, &q_for_filter),
-                    }
-                })
-                .collect();
-            Ok::<_, AppError>(out)
+        match entry::query::parse(&q) {
+            Err(e) => {
+                // Byte offset → 1-based character position for the message.
+                let char_pos = q.get(..e.position).map_or(0, |p| p.chars().count()) + 1;
+                error = Some(format!("搜尋語法錯誤（第 {char_pos} 字）：{}", e.message));
+                Vec::new()
+            }
+            Ok(ast) => {
+                let terms = entry::query::free_text_terms(&ast);
+                let needle = terms.first().cloned().unwrap_or_default();
+                let filter = entry::EntryFilter {
+                    query: Some(ast),
+                    ..Default::default()
+                };
+                // SQL now matches stored plain text (content_text), so every
+                // returned row is a real visible match — no phantom re-filter.
+                const LIMIT: i64 = 50;
+                let rows = entry::list_by_user(
+                    &state.db,
+                    user_id,
+                    &filter,
+                    entry::EntrySortOrder::PublishedAt,
+                    LIMIT,
+                    0,
+                )
+                .await
+                .unwrap_or_default();
+                rows.into_iter()
+                    .map(|e| {
+                        let title = e
+                            .entry
+                            .title
+                            .clone()
+                            .unwrap_or_else(|| "(no title)".to_string());
+                        let snippet = build_snippet(
+                            e.entry.content.as_deref().or(e.entry.summary.as_deref()),
+                            &needle,
+                            200,
+                        );
+                        let (published_relative, published_at_iso) =
+                            format_relative_time(e.entry.published_at);
+                        SearchResultView {
+                            entry_id: e.entry.id,
+                            title_html: highlight_html(&title, &needle),
+                            feed_title: e.feed_title.clone().unwrap_or_else(|| e.feed_url.clone()),
+                            published_relative,
+                            published_at_iso,
+                            snippet_html: highlight_html(&snippet, &needle),
+                        }
+                    })
+                    .collect()
+            }
         }
-        .await
-        .ok()
-        .unwrap_or_default()
     };
 
     (
@@ -1802,6 +1808,7 @@ pub async fn search_page(
             git_version: crate::GIT_VERSION,
             layout,
             q,
+            error,
             results,
         },
     )
@@ -2793,6 +2800,7 @@ pub struct SearchTemplate {
     pub git_version: &'static str,
     pub layout: AppLayoutContext,
     pub q: String,
+    pub error: Option<String>,
     pub results: Vec<SearchResultView>,
 }
 

--- a/src/handlers/pages/mod.rs
+++ b/src/handlers/pages/mod.rs
@@ -1750,7 +1750,10 @@ pub async fn search_page(
             Err(e) => {
                 // Byte offset → 1-based character position for the message.
                 let char_pos = q.get(..e.position).map_or(0, |p| p.chars().count()) + 1;
-                error = Some(format!("搜尋語法錯誤（第 {char_pos} 字）：{}", e.message));
+                error = Some(format!(
+                    "Search syntax error (near character {char_pos}): {}",
+                    e.message
+                ));
                 Vec::new()
             }
             Ok(ast) => {

--- a/src/models/entry/filters.rs
+++ b/src/models/entry/filters.rs
@@ -12,6 +12,7 @@ use chrono::{DateTime, Utc};
 
 use crate::db::Db;
 
+use super::query::{DateBound, QueryNode, SourceKind, Status, TextField};
 use super::{ContinuationCursor, EntryFilter, EntrySortOrder};
 
 /// A positional bind value for the dynamically-built entry queries. Applied in
@@ -60,6 +61,17 @@ impl Dialect {
         match self {
             Dialect::Sqlite => format!("{column} LIKE ${placeholder} COLLATE NOCASE"),
             Dialect::Postgres => format!("{column} ILIKE ${placeholder}"),
+        }
+    }
+
+    /// Case-insensitive `LIKE` with an explicit backslash `ESCAPE` clause, so
+    /// user `%` / `_` / `\` (escaped by `like_contains`) match literally.
+    /// `SQLite`'s `LIKE` is already ASCII-case-insensitive, so no `COLLATE`
+    /// suffix is needed; `PostgreSQL` uses `ILIKE`.
+    fn ci_like_esc(self, column: &str, placeholder: usize) -> String {
+        match self {
+            Dialect::Sqlite => format!("{column} LIKE ${placeholder} ESCAPE '\\'"),
+            Dialect::Postgres => format!("{column} ILIKE ${placeholder} ESCAPE '\\'"),
         }
     }
 
@@ -123,6 +135,7 @@ pub(super) fn is_no_entry_side_predicate(filter: &EntryFilter) -> bool {
         && !filter.read_only
         && filter.search.is_none()
         && filter.has_summary.is_none()
+        && filter.query.is_none()
 }
 
 /// `SQLite` index hint (a leading `" INDEXED BY ..."` fragment, or `""`) for
@@ -228,6 +241,96 @@ pub(super) fn apply_filter_conditions(
             );
         }
     }
+
+    if let Some(ref q) = filter.query {
+        conditions.push(render_query(q, binds, dialect));
+    }
+}
+
+/// Escape a user value for a `LIKE '%...%'` contains-match: backslash-escape
+/// the LIKE metacharacters `\`, `%`, `_` (paired with an `ESCAPE '\'` clause)
+/// and wrap in `%...%`.
+fn like_contains(value: &str) -> String {
+    let mut esc = String::with_capacity(value.len() + 2);
+    esc.push('%');
+    for c in value.chars() {
+        if matches!(c, '\\' | '%' | '_') {
+            esc.push('\\');
+        }
+        esc.push(c);
+    }
+    esc.push('%');
+    esc
+}
+
+/// Recursively render a parsed query AST into a parenthesized WHERE fragment,
+/// pushing one `Bind` per leaf that needs a value. Dispatches dialect-specific
+/// SQL through `Dialect`.
+pub(super) fn render_query(node: &QueryNode, binds: &mut Vec<Bind>, dialect: Dialect) -> String {
+    match node {
+        QueryNode::And(a, b) => format!(
+            "({} AND {})",
+            render_query(a, binds, dialect),
+            render_query(b, binds, dialect)
+        ),
+        QueryNode::Or(a, b) => format!(
+            "({} OR {})",
+            render_query(a, binds, dialect),
+            render_query(b, binds, dialect)
+        ),
+        QueryNode::Not(a) => format!("(NOT {})", render_query(a, binds, dialect)),
+        QueryNode::Text(t) => {
+            let idx = binds.len() + 1;
+            let frag = format!(
+                "({} OR {})",
+                dialect.ci_like_esc("e.title", idx),
+                dialect.ci_like_esc("e.content_text", idx)
+            );
+            binds.push(Bind::Text(like_contains(t)));
+            frag
+        }
+        QueryNode::Field { field, value } => {
+            let col = match field {
+                TextField::Title => "e.title",
+                TextField::Author => "e.author",
+            };
+            let idx = binds.len() + 1;
+            let frag = dialect.ci_like_esc(col, idx);
+            binds.push(Bind::Text(like_contains(value)));
+            frag
+        }
+        QueryNode::Source { kind, value } => {
+            let col = match kind {
+                SourceKind::Feed => "f.title",
+                SourceKind::Category => "c.name",
+            };
+            let idx = binds.len() + 1;
+            let frag = dialect.ci_like_esc(col, idx);
+            binds.push(Bind::Text(like_contains(value)));
+            frag
+        }
+        QueryNode::Status(s) => match s {
+            Status::Unread => "e.read_at IS NULL".to_string(),
+            Status::Read => "e.read_at IS NOT NULL".to_string(),
+            Status::Starred => "e.starred_at IS NOT NULL".to_string(),
+        },
+        QueryNode::Date { bound, date } => {
+            let epoch = dialect.epoch("COALESCE(e.published_at, e.created_at)");
+            let secs = date
+                .and_hms_opt(0, 0, 0)
+                .expect("valid midnight")
+                .and_utc()
+                .timestamp();
+            let idx = binds.len() + 1;
+            let cmp = match bound {
+                DateBound::After => ">=",
+                DateBound::Before => "<",
+            };
+            let frag = format!("{epoch} {cmp} ${idx}");
+            binds.push(Bind::Int(secs));
+            frag
+        }
+    }
 }
 
 /// Apply time range conditions (ot = oldest timestamp, nt = newest timestamp, in seconds).
@@ -318,7 +421,93 @@ pub(super) fn apply_continuation_condition(
 
 #[cfg(test)]
 mod tests {
+    use super::super::query::parse as parse_query;
     use super::*;
+
+    fn render(qs: &str, dialect: Dialect) -> (String, Vec<Bind>) {
+        let ast = parse_query(qs).expect("valid query");
+        let mut binds = Vec::new();
+        let frag = render_query(&ast, &mut binds, dialect);
+        (frag, binds)
+    }
+
+    #[test]
+    fn render_status_unread_sqlite() {
+        let (frag, binds) = render("is:unread", Dialect::Sqlite);
+        assert_eq!(frag, "e.read_at IS NULL");
+        assert!(binds.is_empty());
+    }
+
+    #[test]
+    fn render_free_text_matches_title_and_content_with_escape() {
+        let (frag, binds) = render("rust", Dialect::Sqlite);
+        assert_eq!(
+            frag,
+            "(e.title LIKE $1 ESCAPE '\\' OR e.content_text LIKE $1 ESCAPE '\\')"
+        );
+        assert!(matches!(&binds[0], Bind::Text(s) if s == "%rust%"));
+    }
+
+    #[test]
+    fn render_free_text_pg_uses_ilike() {
+        let (frag, _) = render("rust", Dialect::Postgres);
+        assert_eq!(
+            frag,
+            "(e.title ILIKE $1 ESCAPE '\\' OR e.content_text ILIKE $1 ESCAPE '\\')"
+        );
+    }
+
+    #[test]
+    fn render_like_wildcards_are_escaped() {
+        let (_, binds) = render("50%", Dialect::Sqlite);
+        assert!(matches!(&binds[0], Bind::Text(s) if s == "%50\\%%"));
+    }
+
+    #[test]
+    fn render_feed_and_author_columns() {
+        let (feed, _) = render("feed:news", Dialect::Sqlite);
+        assert_eq!(feed, "f.title LIKE $1 ESCAPE '\\'");
+        let (author, _) = render("author:jane", Dialect::Sqlite);
+        assert_eq!(author, "e.author LIKE $1 ESCAPE '\\'");
+    }
+
+    #[test]
+    fn render_boolean_nesting_and_bind_numbering() {
+        // `(rust OR go) AND is:unread` — two text binds, status has none.
+        let (frag, binds) = render("(rust OR go) AND is:unread", Dialect::Sqlite);
+        assert_eq!(
+            frag,
+            "(((e.title LIKE $1 ESCAPE '\\' OR e.content_text LIKE $1 ESCAPE '\\') \
+OR (e.title LIKE $2 ESCAPE '\\' OR e.content_text LIKE $2 ESCAPE '\\')) AND e.read_at IS NULL)"
+        );
+        assert_eq!(binds.len(), 2);
+    }
+
+    #[test]
+    fn render_not_wraps() {
+        let (frag, _) = render("-is:read", Dialect::Sqlite);
+        assert_eq!(frag, "(NOT e.read_at IS NOT NULL)");
+    }
+
+    #[test]
+    fn render_after_date_sqlite_epoch_and_int_bind() {
+        let (frag, binds) = render("after:2026-01-01", Dialect::Sqlite);
+        assert_eq!(
+            frag,
+            "CAST(strftime('%s', COALESCE(e.published_at, e.created_at)) AS INTEGER) >= $1"
+        );
+        // 2026-01-01T00:00:00Z
+        assert!(matches!(binds[0], Bind::Int(1_767_225_600)));
+    }
+
+    #[test]
+    fn render_before_uses_lt_and_pg_epoch() {
+        let (frag, _) = render("before:2026-01-01", Dialect::Postgres);
+        assert_eq!(
+            frag,
+            "EXTRACT(EPOCH FROM COALESCE(e.published_at, e.created_at))::bigint < $1"
+        );
+    }
 
     #[test]
     fn test_unread_hint_uses_unread_sort_index() {

--- a/src/models/entry/filters.rs
+++ b/src/models/entry/filters.rs
@@ -117,6 +117,17 @@ impl Dialect {
         }
     }
 
+    /// Boolean FALSE literal: `0` on `SQLite` (LIKE yields 0/1 integers),
+    /// `FALSE` on `PostgreSQL` (LIKE yields a boolean). Used to make LIKE
+    /// leaves two-valued via COALESCE so a NULL column reads as FALSE
+    /// (not NULL) and negation includes NULL-column rows.
+    fn bool_false(self) -> &'static str {
+        match self {
+            Dialect::Sqlite => "0",
+            Dialect::Postgres => "FALSE",
+        }
+    }
+
     /// A query-planner index hint. `SQLite` honours `INDEXED BY`; `PostgreSQL` has
     /// no per-query hint, so the fragment collapses to empty.
     pub(super) fn index_hint(self, sqlite_hint: &'static str) -> &'static str {
@@ -281,10 +292,15 @@ pub(super) fn render_query(node: &QueryNode, binds: &mut Vec<Bind>, dialect: Dia
         QueryNode::Not(a) => format!("(NOT {})", render_query(a, binds, dialect)),
         QueryNode::Text(t) => {
             let idx = binds.len() + 1;
+            // COALESCE makes the leaf two-valued: a NULL title/content_text
+            // reads as FALSE (not NULL), so a negated free-text term (`-foo`)
+            // correctly includes rows where both columns are NULL instead of
+            // being dropped by `NOT (NULL OR NULL)` = NULL.
             let frag = format!(
-                "({} OR {})",
+                "COALESCE(({} OR {}), {})",
                 dialect.ci_like_esc("e.title", idx),
-                dialect.ci_like_esc("e.content_text", idx)
+                dialect.ci_like_esc("e.content_text", idx),
+                dialect.bool_false()
             );
             binds.push(Bind::Text(like_contains(t)));
             frag
@@ -295,7 +311,13 @@ pub(super) fn render_query(node: &QueryNode, binds: &mut Vec<Bind>, dialect: Dia
                 TextField::Author => "e.author",
             };
             let idx = binds.len() + 1;
-            let frag = dialect.ci_like_esc(col, idx);
+            // See QueryNode::Text above: COALESCE makes a NULL column (e.g. a
+            // missing author) read as FALSE so `-author:jane` includes it.
+            let frag = format!(
+                "COALESCE({}, {})",
+                dialect.ci_like_esc(col, idx),
+                dialect.bool_false()
+            );
             binds.push(Bind::Text(like_contains(value)));
             frag
         }
@@ -305,7 +327,13 @@ pub(super) fn render_query(node: &QueryNode, binds: &mut Vec<Bind>, dialect: Dia
                 SourceKind::Category => "c.name",
             };
             let idx = binds.len() + 1;
-            let frag = dialect.ci_like_esc(col, idx);
+            // See QueryNode::Text above: COALESCE makes a NULL column
+            // two-valued for correct negation.
+            let frag = format!(
+                "COALESCE({}, {})",
+                dialect.ci_like_esc(col, idx),
+                dialect.bool_false()
+            );
             binds.push(Bind::Text(like_contains(value)));
             frag
         }
@@ -443,7 +471,7 @@ mod tests {
         let (frag, binds) = render("rust", Dialect::Sqlite);
         assert_eq!(
             frag,
-            "(e.title LIKE $1 ESCAPE '\\' OR e.content_text LIKE $1 ESCAPE '\\')"
+            "COALESCE((e.title LIKE $1 ESCAPE '\\' OR e.content_text LIKE $1 ESCAPE '\\'), 0)"
         );
         assert!(matches!(&binds[0], Bind::Text(s) if s == "%rust%"));
     }
@@ -453,7 +481,7 @@ mod tests {
         let (frag, _) = render("rust", Dialect::Postgres);
         assert_eq!(
             frag,
-            "(e.title ILIKE $1 ESCAPE '\\' OR e.content_text ILIKE $1 ESCAPE '\\')"
+            "COALESCE((e.title ILIKE $1 ESCAPE '\\' OR e.content_text ILIKE $1 ESCAPE '\\'), FALSE)"
         );
     }
 
@@ -466,9 +494,9 @@ mod tests {
     #[test]
     fn render_feed_and_author_columns() {
         let (feed, _) = render("feed:news", Dialect::Sqlite);
-        assert_eq!(feed, "f.title LIKE $1 ESCAPE '\\'");
+        assert_eq!(feed, "COALESCE(f.title LIKE $1 ESCAPE '\\', 0)");
         let (author, _) = render("author:jane", Dialect::Sqlite);
-        assert_eq!(author, "e.author LIKE $1 ESCAPE '\\'");
+        assert_eq!(author, "COALESCE(e.author LIKE $1 ESCAPE '\\', 0)");
     }
 
     #[test]
@@ -477,8 +505,8 @@ mod tests {
         let (frag, binds) = render("(rust OR go) AND is:unread", Dialect::Sqlite);
         assert_eq!(
             frag,
-            "(((e.title LIKE $1 ESCAPE '\\' OR e.content_text LIKE $1 ESCAPE '\\') \
-OR (e.title LIKE $2 ESCAPE '\\' OR e.content_text LIKE $2 ESCAPE '\\')) AND e.read_at IS NULL)"
+            "((COALESCE((e.title LIKE $1 ESCAPE '\\' OR e.content_text LIKE $1 ESCAPE '\\'), 0) \
+OR COALESCE((e.title LIKE $2 ESCAPE '\\' OR e.content_text LIKE $2 ESCAPE '\\'), 0)) AND e.read_at IS NULL)"
         );
         assert_eq!(binds.len(), 2);
     }

--- a/src/models/entry/mod.rs
+++ b/src/models/entry/mod.rs
@@ -2272,6 +2272,285 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn query_is_unread_returns_only_unread() {
+        let db = setup_db().await;
+        let user_id = create_test_user(&db, "testuser").await;
+        let category_id = create_test_category(&db, user_id, "Tech").await;
+        let feed_id = create_test_feed(&db, category_id, "https://example.com/feed.xml").await;
+
+        let (alpha, _) = upsert_entry(
+            &db,
+            feed_id,
+            "guid-alpha",
+            Some("alpha"),
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        let (beta, _) = upsert_entry(
+            &db,
+            feed_id,
+            "guid-beta",
+            Some("beta"),
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        mark_as_read(&db, beta.id).await.unwrap();
+        assert!(alpha.read_at.is_none());
+
+        let filter = EntryFilter {
+            query: Some(query::parse("is:unread").unwrap()),
+            ..Default::default()
+        };
+        let results = list_by_user(&db, user_id, &filter, EntrySortOrder::default(), 50, 0)
+            .await
+            .unwrap();
+        let titles: Vec<_> = results
+            .iter()
+            .filter_map(|r| r.entry.title.clone())
+            .collect();
+        assert!(titles.iter().any(|t| t == "alpha"));
+        assert!(!titles.iter().any(|t| t == "beta"));
+    }
+
+    #[tokio::test]
+    async fn query_boolean_and_negation() {
+        let db = setup_db().await;
+        let user_id = create_test_user(&db, "testuser").await;
+        let category_id = create_test_category(&db, user_id, "Tech").await;
+        let feed_id = create_test_feed(&db, category_id, "https://example.com/feed.xml").await;
+
+        upsert_entry(
+            &db,
+            feed_id,
+            "guid-rust",
+            Some("rust"),
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        let (rust_weekly, _) = upsert_entry(
+            &db,
+            feed_id,
+            "guid-rust-weekly",
+            Some("rust weekly"),
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        mark_as_read(&db, rust_weekly.id).await.unwrap();
+        upsert_entry(
+            &db,
+            feed_id,
+            "guid-go",
+            Some("go"),
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let filter = EntryFilter {
+            query: Some(query::parse("rust -is:read").unwrap()),
+            ..Default::default()
+        };
+        let results = list_by_user(&db, user_id, &filter, EntrySortOrder::default(), 50, 0)
+            .await
+            .unwrap();
+        let titles: Vec<_> = results
+            .iter()
+            .filter_map(|r| r.entry.title.clone())
+            .collect();
+        assert!(titles.iter().any(|t| t == "rust"));
+        assert!(!titles.iter().any(|t| t == "rust weekly")); // read -> excluded
+        assert!(!titles.iter().any(|t| t == "go")); // no "rust" -> excluded
+    }
+
+    #[tokio::test]
+    async fn query_feed_name_fuzzy_match() {
+        let db = setup_db().await;
+        let user_id = create_test_user(&db, "testuser").await;
+        let category_id = create_test_category(&db, user_id, "Tech").await;
+        let rust_feed_id = feed::create_feed(
+            &db,
+            &feed::CreateFeedParams {
+                category_id,
+                url: "https://example.com/rust-blog.xml",
+                title: Some("Rust Blog"),
+                description: None,
+                site_url: None,
+                custom_user_agent: None,
+                http2_disabled: None,
+                custom_referrer: None,
+            },
+        )
+        .await
+        .unwrap()
+        .id;
+        let other_feed_id =
+            create_test_feed(&db, category_id, "https://example.com/other.xml").await;
+
+        upsert_entry(
+            &db,
+            rust_feed_id,
+            "guid-1",
+            Some("Post from Rust Blog"),
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        upsert_entry(
+            &db,
+            other_feed_id,
+            "guid-2",
+            Some("Post from other feed"),
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let filter = EntryFilter {
+            query: Some(query::parse("feed:rust").unwrap()),
+            ..Default::default()
+        };
+        let results = list_by_user(&db, user_id, &filter, EntrySortOrder::default(), 50, 0)
+            .await
+            .unwrap();
+        assert!(!results.is_empty());
+        assert!(
+            results
+                .iter()
+                .all(|r| r.entry.title.as_deref() == Some("Post from Rust Blog"))
+        );
+    }
+
+    #[tokio::test]
+    async fn query_after_date_filters() {
+        let db = setup_db().await;
+        let user_id = create_test_user(&db, "testuser").await;
+        let category_id = create_test_category(&db, user_id, "Tech").await;
+        let feed_id = create_test_feed(&db, category_id, "https://example.com/feed.xml").await;
+
+        upsert_entry(
+            &db,
+            feed_id,
+            "guid-old",
+            Some("old"),
+            None,
+            None,
+            None,
+            None,
+            Some(chrono::Utc.with_ymd_and_hms(2025, 6, 1, 0, 0, 0).unwrap()),
+        )
+        .await
+        .unwrap();
+        upsert_entry(
+            &db,
+            feed_id,
+            "guid-new",
+            Some("new"),
+            None,
+            None,
+            None,
+            None,
+            Some(chrono::Utc.with_ymd_and_hms(2026, 3, 1, 0, 0, 0).unwrap()),
+        )
+        .await
+        .unwrap();
+
+        let filter = EntryFilter {
+            query: Some(query::parse("after:2026-01-01").unwrap()),
+            ..Default::default()
+        };
+        let results = list_by_user(&db, user_id, &filter, EntrySortOrder::default(), 50, 0)
+            .await
+            .unwrap();
+        let titles: Vec<_> = results
+            .iter()
+            .filter_map(|r| r.entry.title.clone())
+            .collect();
+        assert!(titles.iter().any(|t| t == "new"));
+        assert!(!titles.iter().any(|t| t == "old"));
+    }
+
+    #[tokio::test]
+    async fn query_escapes_literal_percent() {
+        let db = setup_db().await;
+        let user_id = create_test_user(&db, "testuser").await;
+        let category_id = create_test_category(&db, user_id, "Tech").await;
+        let feed_id = create_test_feed(&db, category_id, "https://example.com/feed.xml").await;
+
+        upsert_entry(
+            &db,
+            feed_id,
+            "guid-off",
+            Some("50% off"),
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        upsert_entry(
+            &db,
+            feed_id,
+            "guid-dollars",
+            Some("50 dollars"),
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let filter = EntryFilter {
+            query: Some(query::parse("\"50%\"").unwrap()),
+            ..Default::default()
+        };
+        let results = list_by_user(&db, user_id, &filter, EntrySortOrder::default(), 50, 0)
+            .await
+            .unwrap();
+        let titles: Vec<_> = results
+            .iter()
+            .filter_map(|r| r.entry.title.clone())
+            .collect();
+        assert!(titles.iter().any(|t| t == "50% off"));
+        assert!(!titles.iter().any(|t| t == "50 dollars")); // literal %, not wildcard
+    }
+
+    #[tokio::test]
     async fn search_matches_plain_text_across_tags_not_attributes() {
         let db = setup_db().await;
         let user_id = create_test_user(&db, "testuser").await;

--- a/src/models/entry/mod.rs
+++ b/src/models/entry/mod.rs
@@ -2386,6 +2386,73 @@ mod tests {
         assert!(!titles.iter().any(|t| t == "go")); // no "rust" -> excluded
     }
 
+    // M1 regression: `NOT (NULL LIKE ...)` is NULL (not TRUE), so a naive
+    // `(NOT e.author LIKE ...)` would silently exclude every NULL-author row.
+    // The COALESCE(..., 0/FALSE) wrapper makes the leaf two-valued so negation
+    // correctly includes rows where the filtered column is NULL.
+    #[tokio::test]
+    async fn query_negated_author_includes_null_author_entries() {
+        let db = setup_db().await;
+        let user_id = create_test_user(&db, "testuser").await;
+        let category_id = create_test_category(&db, user_id, "Tech").await;
+        let feed_id = create_test_feed(&db, category_id, "https://example.com/feed.xml").await;
+
+        upsert_entry(
+            &db,
+            feed_id,
+            "guid-jane",
+            Some("jane's post"),
+            None,
+            None,
+            None,
+            Some("jane"),
+            None,
+        )
+        .await
+        .unwrap();
+        upsert_entry(
+            &db,
+            feed_id,
+            "guid-bob",
+            Some("bob's post"),
+            None,
+            None,
+            None,
+            Some("bob"),
+            None,
+        )
+        .await
+        .unwrap();
+        upsert_entry(
+            &db,
+            feed_id,
+            "guid-anon",
+            Some("anonymous post"),
+            None,
+            None,
+            None,
+            None, // no author (NULL)
+            None,
+        )
+        .await
+        .unwrap();
+
+        let filter = EntryFilter {
+            query: Some(query::parse("-author:jane").unwrap()),
+            ..Default::default()
+        };
+        let results = list_by_user(&db, user_id, &filter, EntrySortOrder::default(), 50, 0)
+            .await
+            .unwrap();
+        let titles: Vec<_> = results
+            .iter()
+            .filter_map(|r| r.entry.title.clone())
+            .collect();
+        assert!(titles.iter().any(|t| t == "bob's post"));
+        assert!(titles.iter().any(|t| t == "anonymous post")); // NULL author -> included
+        assert!(!titles.iter().any(|t| t == "jane's post"));
+    }
+
     #[tokio::test]
     async fn query_feed_name_fuzzy_match() {
         let db = setup_db().await;

--- a/src/models/entry/mod.rs
+++ b/src/models/entry/mod.rs
@@ -73,6 +73,11 @@ pub struct EntryFilter {
     /// to entries the reader just finished during this page view. Ignored
     /// when `unread_only` is false.
     pub read_after: Option<String>,
+    /// Parsed boolean query AST for the global `/search` page. Set by the
+    /// search handler from the `?q=` string; `None` on every other list path
+    /// (a no-op). Rendered to SQL by `filters::render_query`.
+    #[serde(skip)]
+    pub query: Option<query::QueryNode>,
 }
 
 /// Pagination cursor. The wire format on the API is opaque to clients; we

--- a/src/models/entry/mod.rs
+++ b/src/models/entry/mod.rs
@@ -7,6 +7,7 @@ use crate::utils::text::strip_to_search_text;
 use crate::{db_execute, db_execute_tx, query_all, query_opt, query_opt_tx, query_scalar};
 
 mod filters;
+pub mod query;
 use filters::{
     Bind, Dialect, apply_continuation_condition, apply_filter_conditions, apply_time_conditions,
     published_sort_entry_hint,

--- a/src/models/entry/query.rs
+++ b/src/models/entry/query.rs
@@ -1,0 +1,630 @@
+//! Boolean query-language parser for the global `/search` page.
+//!
+//! Grammar (authoritative copy in the design spec):
+//!   or   := and { "OR" and }
+//!   and  := not { ["AND"] not }        // implicit AND between adjacent atoms
+//!   not  := {"NOT"|"-"} atom
+//!   atom := "(" or ")" | field ":" value | text
+//!
+//! Pure string → AST; no DB access. Dates are validated here via `chrono`.
+//! `NOT` / `AND` / `OR` are case-insensitive keywords (quote to search them
+//! literally). A `token:` is a filter only when `token` is a known field name.
+
+use chrono::NaiveDate;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum QueryNode {
+    And(Box<QueryNode>, Box<QueryNode>),
+    Or(Box<QueryNode>, Box<QueryNode>),
+    Not(Box<QueryNode>),
+    Text(String),
+    Field { field: TextField, value: String },
+    Source { kind: SourceKind, value: String },
+    Status(Status),
+    Date { bound: DateBound, date: NaiveDate },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TextField {
+    Title,
+    Author,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SourceKind {
+    Feed,
+    Category,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Status {
+    Unread,
+    Read,
+    Starred,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DateBound {
+    Before,
+    After,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParseError {
+    /// Byte offset into the input where the error was detected.
+    pub position: usize,
+    pub message: String,
+}
+
+/// Collect free-text and `title:` values for result highlighting. Negated
+/// subtrees are skipped (we do not highlight terms the user excluded).
+pub fn free_text_terms(node: &QueryNode) -> Vec<String> {
+    let mut out = Vec::new();
+    collect_terms(node, &mut out);
+    out
+}
+
+fn collect_terms(node: &QueryNode, out: &mut Vec<String>) {
+    match node {
+        QueryNode::And(a, b) | QueryNode::Or(a, b) => {
+            collect_terms(a, out);
+            collect_terms(b, out);
+        }
+        QueryNode::Text(s) => out.push(s.clone()),
+        QueryNode::Field {
+            field: TextField::Title,
+            value,
+        } => out.push(value.clone()),
+        // `Not(_)` (negated subtrees) and all other node kinds contribute no terms.
+        _ => {}
+    }
+}
+
+pub fn parse(input: &str) -> Result<QueryNode, ParseError> {
+    let toks = lex(input)?;
+    if toks.is_empty() {
+        return Err(ParseError {
+            position: 0,
+            message: "查詢是空的".into(),
+        });
+    }
+    let mut p = Parser {
+        toks: &toks,
+        pos: 0,
+        end: input.len(),
+    };
+    let node = p.parse_or()?;
+    if p.pos < toks.len() {
+        return Err(ParseError {
+            position: toks[p.pos].pos,
+            message: "多餘的字元（可能是多出的 ')'）".into(),
+        });
+    }
+    Ok(node)
+}
+
+// ---- Field kinds (lexer-internal) --------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Field {
+    Is,
+    Feed,
+    Category,
+    Title,
+    Author,
+    Before,
+    After,
+}
+
+impl Field {
+    fn from_name(s: &str) -> Option<Field> {
+        match s.to_ascii_lowercase().as_str() {
+            "is" => Some(Field::Is),
+            "feed" => Some(Field::Feed),
+            "category" => Some(Field::Category),
+            "title" => Some(Field::Title),
+            "author" => Some(Field::Author),
+            "before" => Some(Field::Before),
+            "after" => Some(Field::After),
+            _ => None,
+        }
+    }
+    fn label(self) -> &'static str {
+        match self {
+            Field::Is => "'is:'",
+            Field::Feed => "'feed:'",
+            Field::Category => "'category:'",
+            Field::Title => "'title:'",
+            Field::Author => "'author:'",
+            Field::Before => "'before:'",
+            Field::After => "'after:'",
+        }
+    }
+}
+
+// ---- Tokenizer ---------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Tok {
+    LParen,
+    RParen,
+    And,
+    Or,
+    Not,
+    Minus,
+    Filter(Field, String),
+    Text(String),
+}
+
+struct Spanned {
+    tok: Tok,
+    pos: usize,
+}
+
+fn lex(input: &str) -> Result<Vec<Spanned>, ParseError> {
+    let chars: Vec<(usize, char)> = input.char_indices().collect();
+    let n = chars.len();
+    let mut out = Vec::new();
+    let mut k = 0;
+    while k < n {
+        let (bpos, c) = chars[k];
+        if c.is_whitespace() {
+            k += 1;
+            continue;
+        }
+        match c {
+            '(' => {
+                out.push(Spanned {
+                    tok: Tok::LParen,
+                    pos: bpos,
+                });
+                k += 1;
+            }
+            ')' => {
+                out.push(Spanned {
+                    tok: Tok::RParen,
+                    pos: bpos,
+                });
+                k += 1;
+            }
+            '"' => {
+                let (val, nk) = read_quoted(&chars, input, k)?;
+                out.push(Spanned {
+                    tok: Tok::Text(val),
+                    pos: bpos,
+                });
+                k = nk;
+            }
+            '-' => {
+                // Tight negation only when the next char exists and is neither
+                // whitespace nor ')'. Otherwise a literal "-" text token.
+                let neg = k + 1 < n && {
+                    let d = chars[k + 1].1;
+                    !d.is_whitespace() && d != ')'
+                };
+                out.push(Spanned {
+                    tok: if neg {
+                        Tok::Minus
+                    } else {
+                        Tok::Text("-".into())
+                    },
+                    pos: bpos,
+                });
+                k += 1;
+            }
+            _ => {
+                // Word run until whitespace / '(' / ')' / '"'.
+                let mut e = k;
+                while e < n {
+                    let d = chars[e].1;
+                    if d.is_whitespace() || d == '(' || d == ')' || d == '"' {
+                        break;
+                    }
+                    e += 1;
+                }
+                let start_byte = bpos;
+                let end_byte = if e < n { chars[e].0 } else { input.len() };
+                let head = &input[start_byte..end_byte];
+
+                if let Some((name, rest)) = head.split_once(':')
+                    && let Some(field) = Field::from_name(name)
+                {
+                    if !rest.is_empty() {
+                        out.push(Spanned {
+                            tok: Tok::Filter(field, rest.to_string()),
+                            pos: bpos,
+                        });
+                        k = e;
+                        continue;
+                    } else if e < n && chars[e].1 == '"' {
+                        // `field:"quoted value"` — value is the tight quote.
+                        let (val, nk) = read_quoted(&chars, input, e)?;
+                        out.push(Spanned {
+                            tok: Tok::Filter(field, val),
+                            pos: bpos,
+                        });
+                        k = nk;
+                        continue;
+                    } else {
+                        // `field:` with no value — parser rejects.
+                        out.push(Spanned {
+                            tok: Tok::Filter(field, String::new()),
+                            pos: bpos,
+                        });
+                        k = e;
+                        continue;
+                    }
+                }
+
+                let tok = match head.to_ascii_lowercase().as_str() {
+                    "and" => Tok::And,
+                    "or" => Tok::Or,
+                    "not" => Tok::Not,
+                    _ => Tok::Text(head.to_string()),
+                };
+                out.push(Spanned { tok, pos: bpos });
+                k = e;
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Read a `"..."` phrase; `chars[k]` must be the opening quote. Returns the
+/// inner content and the char index just past the closing quote.
+fn read_quoted(
+    chars: &[(usize, char)],
+    input: &str,
+    k: usize,
+) -> Result<(String, usize), ParseError> {
+    let open_byte = chars[k].0;
+    let content_start = chars.get(k + 1).map_or(input.len(), |x| x.0);
+    let mut e = k + 1;
+    while e < chars.len() {
+        if chars[e].1 == '"' {
+            let content_end = chars[e].0;
+            return Ok((input[content_start..content_end].to_string(), e + 1));
+        }
+        e += 1;
+    }
+    Err(ParseError {
+        position: open_byte,
+        message: "引號未關閉".into(),
+    })
+}
+
+// ---- Parser ------------------------------------------------------------
+
+struct Parser<'a> {
+    toks: &'a [Spanned],
+    pos: usize,
+    end: usize,
+}
+
+fn starts_atom(t: &Tok) -> bool {
+    matches!(
+        t,
+        Tok::LParen | Tok::Filter(_, _) | Tok::Text(_) | Tok::Not | Tok::Minus
+    )
+}
+
+impl<'a> Parser<'a> {
+    fn peek(&self) -> Option<&Tok> {
+        self.toks.get(self.pos).map(|s| &s.tok)
+    }
+    fn peek_pos(&self) -> usize {
+        self.toks.get(self.pos).map_or(self.end, |s| s.pos)
+    }
+    fn bump(&mut self) -> &Spanned {
+        let s = &self.toks[self.pos];
+        self.pos += 1;
+        s
+    }
+
+    fn parse_or(&mut self) -> Result<QueryNode, ParseError> {
+        let mut left = self.parse_and()?;
+        while matches!(self.peek(), Some(Tok::Or)) {
+            self.bump();
+            let right = self.parse_and()?;
+            left = QueryNode::Or(Box::new(left), Box::new(right));
+        }
+        Ok(left)
+    }
+
+    fn parse_and(&mut self) -> Result<QueryNode, ParseError> {
+        let mut left = self.parse_not()?;
+        loop {
+            match self.peek() {
+                Some(Tok::And) => {
+                    self.bump();
+                    let right = self.parse_not()?;
+                    left = QueryNode::And(Box::new(left), Box::new(right));
+                }
+                Some(t) if starts_atom(t) => {
+                    let right = self.parse_not()?;
+                    left = QueryNode::And(Box::new(left), Box::new(right));
+                }
+                _ => break, // Or, RParen, or EOF
+            }
+        }
+        Ok(left)
+    }
+
+    fn parse_not(&mut self) -> Result<QueryNode, ParseError> {
+        if matches!(self.peek(), Some(Tok::Not | Tok::Minus)) {
+            self.bump();
+            let inner = self.parse_not()?;
+            return Ok(QueryNode::Not(Box::new(inner)));
+        }
+        self.parse_atom()
+    }
+
+    fn parse_atom(&mut self) -> Result<QueryNode, ParseError> {
+        match self.peek() {
+            Some(Tok::LParen) => {
+                let open_pos = self.peek_pos();
+                self.bump();
+                let inner = self.parse_or()?;
+                if !matches!(self.peek(), Some(Tok::RParen)) {
+                    return Err(ParseError {
+                        position: open_pos,
+                        message: "括號不對稱：'(' 未關閉".into(),
+                    });
+                }
+                self.bump();
+                Ok(inner)
+            }
+            Some(Tok::Filter(_, _)) => {
+                let pos = self.peek_pos();
+                let (field, value) = match &self.bump().tok {
+                    Tok::Filter(f, v) => (*f, v.clone()),
+                    _ => unreachable!(),
+                };
+                node_from_filter(field, &value, pos)
+            }
+            Some(Tok::Text(_)) => {
+                let s = match &self.bump().tok {
+                    Tok::Text(s) => s.clone(),
+                    _ => unreachable!(),
+                };
+                Ok(QueryNode::Text(s))
+            }
+            _ => Err(ParseError {
+                position: self.peek_pos(),
+                message: "此處需要一個搜尋條件".into(),
+            }),
+        }
+    }
+}
+
+fn node_from_filter(field: Field, value: &str, pos: usize) -> Result<QueryNode, ParseError> {
+    if value.is_empty() {
+        return Err(ParseError {
+            position: pos,
+            message: format!("{} 後面需要一個值", field.label()),
+        });
+    }
+    match field {
+        Field::Is => match value.to_ascii_lowercase().as_str() {
+            "unread" => Ok(QueryNode::Status(Status::Unread)),
+            "read" => Ok(QueryNode::Status(Status::Read)),
+            "starred" => Ok(QueryNode::Status(Status::Starred)),
+            other => Err(ParseError {
+                position: pos,
+                message: format!("未知的 is: 值「{other}」（可用 unread / read / starred）"),
+            }),
+        },
+        Field::Feed => Ok(QueryNode::Source {
+            kind: SourceKind::Feed,
+            value: value.to_string(),
+        }),
+        Field::Category => Ok(QueryNode::Source {
+            kind: SourceKind::Category,
+            value: value.to_string(),
+        }),
+        Field::Title => Ok(QueryNode::Field {
+            field: TextField::Title,
+            value: value.to_string(),
+        }),
+        Field::Author => Ok(QueryNode::Field {
+            field: TextField::Author,
+            value: value.to_string(),
+        }),
+        Field::Before | Field::After => {
+            let date =
+                NaiveDate::parse_from_str(value, "%Y-%m-%d").map_err(|_parse_err| ParseError {
+                    position: pos,
+                    message: format!("{} 需要 YYYY-MM-DD 格式的日期", field.label()),
+                })?;
+            let bound = if field == Field::Before {
+                DateBound::Before
+            } else {
+                DateBound::After
+            };
+            Ok(QueryNode::Date { bound, date })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::NaiveDate;
+
+    fn t(s: &str) -> QueryNode {
+        s.to_string().pipe_text()
+    }
+    trait PipeText {
+        fn pipe_text(self) -> QueryNode;
+    }
+    impl PipeText for String {
+        fn pipe_text(self) -> QueryNode {
+            QueryNode::Text(self)
+        }
+    }
+
+    #[test]
+    fn single_free_text() {
+        assert_eq!(parse("rust").unwrap(), QueryNode::Text("rust".into()));
+    }
+
+    #[test]
+    fn implicit_and_between_terms() {
+        assert_eq!(
+            parse("rust go").unwrap(),
+            QueryNode::And(Box::new(t("rust")), Box::new(t("go")))
+        );
+    }
+
+    #[test]
+    fn or_lower_precedence_than_and() {
+        // `a b OR c` => (a AND b) OR c
+        let got = parse("a b OR c").unwrap();
+        assert_eq!(
+            got,
+            QueryNode::Or(
+                Box::new(QueryNode::And(Box::new(t("a")), Box::new(t("b")))),
+                Box::new(t("c"))
+            )
+        );
+    }
+
+    #[test]
+    fn parentheses_override_precedence() {
+        // `a AND (b OR c)`
+        let got = parse("a AND (b OR c)").unwrap();
+        assert_eq!(
+            got,
+            QueryNode::And(
+                Box::new(t("a")),
+                Box::new(QueryNode::Or(Box::new(t("b")), Box::new(t("c"))))
+            )
+        );
+    }
+
+    #[test]
+    fn not_keyword_and_dash_negation() {
+        assert_eq!(
+            parse("NOT rust").unwrap(),
+            QueryNode::Not(Box::new(t("rust")))
+        );
+        assert_eq!(parse("-rust").unwrap(), QueryNode::Not(Box::new(t("rust"))));
+    }
+
+    #[test]
+    fn dash_inside_word_is_literal_text() {
+        assert_eq!(
+            parse("cross-platform").unwrap(),
+            QueryNode::Text("cross-platform".into())
+        );
+    }
+
+    #[test]
+    fn dash_with_trailing_space_is_literal() {
+        // `- rust` => "-" AND "rust"
+        assert_eq!(
+            parse("- rust").unwrap(),
+            QueryNode::And(Box::new(t("-")), Box::new(t("rust")))
+        );
+    }
+
+    #[test]
+    fn status_filter() {
+        assert_eq!(
+            parse("is:unread").unwrap(),
+            QueryNode::Status(Status::Unread)
+        );
+        assert_eq!(
+            parse("IS:Starred").unwrap(),
+            QueryNode::Status(Status::Starred)
+        );
+    }
+
+    #[test]
+    fn unknown_is_value_errors() {
+        assert!(parse("is:archived").is_err());
+    }
+
+    #[test]
+    fn source_and_field_filters() {
+        assert_eq!(
+            parse("feed:rust").unwrap(),
+            QueryNode::Source {
+                kind: SourceKind::Feed,
+                value: "rust".into()
+            }
+        );
+        assert_eq!(
+            parse("author:jane").unwrap(),
+            QueryNode::Field {
+                field: TextField::Author,
+                value: "jane".into()
+            }
+        );
+    }
+
+    #[test]
+    fn quoted_value_with_spaces() {
+        assert_eq!(
+            parse("feed:\"Rust Blog\"").unwrap(),
+            QueryNode::Source {
+                kind: SourceKind::Feed,
+                value: "Rust Blog".into()
+            }
+        );
+    }
+
+    #[test]
+    fn quoted_keyword_is_literal_text() {
+        assert_eq!(parse("\"and\"").unwrap(), QueryNode::Text("and".into()));
+    }
+
+    #[test]
+    fn colon_in_non_field_is_literal_text() {
+        assert_eq!(
+            parse("http://example.com").unwrap(),
+            QueryNode::Text("http://example.com".into())
+        );
+    }
+
+    #[test]
+    fn date_filters_parse() {
+        assert_eq!(
+            parse("after:2026-01-01").unwrap(),
+            QueryNode::Date {
+                bound: DateBound::After,
+                date: NaiveDate::from_ymd_opt(2026, 1, 1).unwrap()
+            }
+        );
+    }
+
+    #[test]
+    fn bad_date_errors() {
+        let e = parse("before:yesterday").unwrap_err();
+        assert!(e.message.contains("YYYY-MM-DD"));
+    }
+
+    #[test]
+    fn unbalanced_paren_errors() {
+        let e = parse("(rust OR go").unwrap_err();
+        assert!(e.message.contains("'('"));
+    }
+
+    #[test]
+    fn trailing_operator_errors() {
+        assert!(parse("rust OR").is_err());
+    }
+
+    #[test]
+    fn stray_close_paren_errors() {
+        assert!(parse("rust)").is_err());
+    }
+
+    #[test]
+    fn free_text_terms_collects_text_and_title_skips_negated() {
+        let ast = parse("rust title:axum -go is:unread").unwrap();
+        let mut terms = free_text_terms(&ast);
+        terms.sort();
+        assert_eq!(terms, vec!["axum".to_string(), "rust".to_string()]);
+    }
+}

--- a/src/models/entry/query.rs
+++ b/src/models/entry/query.rs
@@ -85,7 +85,7 @@ pub fn parse(input: &str) -> Result<QueryNode, ParseError> {
     if toks.is_empty() {
         return Err(ParseError {
             position: 0,
-            message: "查詢是空的".into(),
+            message: "Query is empty".into(),
         });
     }
     let mut p = Parser {
@@ -97,7 +97,7 @@ pub fn parse(input: &str) -> Result<QueryNode, ParseError> {
     if p.pos < toks.len() {
         return Err(ParseError {
             position: toks[p.pos].pos,
-            message: "多餘的字元（可能是多出的 ')'）".into(),
+            message: "Unexpected extra input (maybe an extra ')')".into(),
         });
     }
     Ok(node)
@@ -289,7 +289,7 @@ fn read_quoted(
     }
     Err(ParseError {
         position: open_byte,
-        message: "引號未關閉".into(),
+        message: "Unclosed quote".into(),
     })
 }
 
@@ -368,7 +368,7 @@ impl<'a> Parser<'a> {
                 if !matches!(self.peek(), Some(Tok::RParen)) {
                     return Err(ParseError {
                         position: open_pos,
-                        message: "括號不對稱：'(' 未關閉".into(),
+                        message: "Unbalanced parentheses: '(' is not closed".into(),
                     });
                 }
                 self.bump();
@@ -391,7 +391,7 @@ impl<'a> Parser<'a> {
             }
             _ => Err(ParseError {
                 position: self.peek_pos(),
-                message: "此處需要一個搜尋條件".into(),
+                message: "Expected a search term here".into(),
             }),
         }
     }
@@ -401,7 +401,7 @@ fn node_from_filter(field: Field, value: &str, pos: usize) -> Result<QueryNode, 
     if value.is_empty() {
         return Err(ParseError {
             position: pos,
-            message: format!("{} 後面需要一個值", field.label()),
+            message: format!("{} needs a value", field.label()),
         });
     }
     match field {
@@ -411,7 +411,7 @@ fn node_from_filter(field: Field, value: &str, pos: usize) -> Result<QueryNode, 
             "starred" => Ok(QueryNode::Status(Status::Starred)),
             other => Err(ParseError {
                 position: pos,
-                message: format!("未知的 is: 值「{other}」（可用 unread / read / starred）"),
+                message: format!("Unknown is: value \"{other}\" (use unread / read / starred)"),
             }),
         },
         Field::Feed => Ok(QueryNode::Source {
@@ -434,7 +434,7 @@ fn node_from_filter(field: Field, value: &str, pos: usize) -> Result<QueryNode, 
             let date =
                 NaiveDate::parse_from_str(value, "%Y-%m-%d").map_err(|_parse_err| ParseError {
                     position: pos,
-                    message: format!("{} 需要 YYYY-MM-DD 格式的日期", field.label()),
+                    message: format!("{} expects a date like YYYY-MM-DD", field.label()),
                 })?;
             let bound = if field == Field::Before {
                 DateBound::Before

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -3248,12 +3248,35 @@ summary {
    Tokens matched to the repo's actual scale (no --space-sm/md/--color-danger-*
    exist): spacing mirrors .feed-http-settings/.feed-http-hint (space-4/space-3/
    space-1); the error tint mirrors .banner--error's error-colour wash. */
+/* Compact search form: keyword input and submit button share one row so the
+   button no longer drops to its own line. */
+.search-form-row {
+    display: flex;
+    gap: var(--space-2);
+    align-items: stretch;
+    margin-bottom: var(--space-3);
+}
+.search-form-row input[type="text"] {
+    flex: 1;
+    min-width: 0;
+}
+.search-form-row button {
+    padding-inline: var(--space-5);
+}
+
+/* Framed disclosure, mirroring .feed-http-settings so the two match. */
 .search-syntax-help {
-    margin: var(--space-2) 0 var(--space-4);
+    margin: 0 0 var(--space-4);
+    border: 1px solid var(--color-border-light);
+    border-radius: var(--radius-md);
+    padding: var(--space-3);
     font-size: var(--font-sm);
 }
+.search-syntax-help-body {
+    margin-top: var(--space-3);
+}
 .search-syntax-help-body ul {
-    margin: var(--space-1) 0 0;
+    margin: 0;
     padding-left: var(--space-5);
     color: var(--color-text-muted);
 }

--- a/static/css/app.css
+++ b/static/css/app.css
@@ -3243,3 +3243,30 @@ summary {
         animation: none !important;
     }
 }
+
+/* ===== /search: query-syntax help panel + inline parse-error banner =====
+   Tokens matched to the repo's actual scale (no --space-sm/md/--color-danger-*
+   exist): spacing mirrors .feed-http-settings/.feed-http-hint (space-4/space-3/
+   space-1); the error tint mirrors .banner--error's error-colour wash. */
+.search-syntax-help {
+    margin: var(--space-2) 0 var(--space-4);
+    font-size: var(--font-sm);
+}
+.search-syntax-help-body ul {
+    margin: var(--space-1) 0 0;
+    padding-left: var(--space-5);
+    color: var(--color-text-muted);
+}
+.search-syntax-help-body li {
+    margin: var(--space-1) 0;
+}
+.search-syntax-help-body code {
+    font-family: var(--font-mono);
+}
+.search-error {
+    margin: var(--space-4) 0;
+    padding: var(--space-2) var(--space-4);
+    border-radius: var(--radius-md);
+    background: light-dark(rgba(185, 28, 28, 0.06), rgba(248, 113, 113, 0.08));
+    color: var(--color-error);
+}

--- a/templates/search.html
+++ b/templates/search.html
@@ -30,7 +30,23 @@
                     });
                 </script>
 
-                {% if q.is_empty() %}
+                <details class="search-syntax-help">
+                    <summary>Search syntax</summary>
+                    <div class="search-syntax-help-body">
+                        <ul>
+                            <li><code>is:unread</code> / <code>is:read</code> / <code>is:starred</code> — by status</li>
+                            <li><code>feed:name</code> / <code>category:name</code> — by source (fuzzy, case-insensitive)</li>
+                            <li><code>title:word</code> / <code>author:name</code> — by field</li>
+                            <li><code>before:2026-01-01</code> / <code>after:2026-01-01</code> — by date (UTC)</li>
+                            <li><code>AND</code> <code>OR</code> <code>NOT</code> and <code>(&nbsp;)</code> — combine; adjacent words imply AND</li>
+                            <li><code>-term</code> — exclude; <code>"exact phrase"</code> — quote (also for values with spaces, e.g. <code>feed:"Rust Blog"</code>)</li>
+                        </ul>
+                    </div>
+                </details>
+
+                {% if let Some(err) = error %}
+                    <div class="search-error" role="alert" data-testid="search-error">{{ err }}</div>
+                {% else if q.is_empty() %}
                     <div class="empty-state">
                         <h2 class="empty-state-title">Search your library</h2>
                         <p class="empty-state-text">Type a keyword and press <kbd class="empty-state-kbd">Enter</kbd> to find entries by title or content.</p>

--- a/templates/search.html
+++ b/templates/search.html
@@ -9,11 +9,10 @@
                 <h1>Search</h1>
 
                 <form method="get" action="/search">
-                    <div class="form-group">
-                        <label for="search-q">Keywords</label>
-                        <input type="text" id="search-q" name="q" value="{{ q }}" placeholder="Find entries by title or content" autofocus required data-testid="search-input">
+                    <div class="search-form-row">
+                        <input type="text" id="search-q" name="q" value="{{ q }}" placeholder="Find entries by title or content" aria-label="Search keywords" autofocus required data-testid="search-input">
+                        <button type="submit" data-testid="search-btn">Search</button>
                     </div>
-                    <button type="submit" data-testid="search-btn">Search</button>
                 </form>
                 <script>
                     // `/` focuses the search input (matches the legacy entries.js

--- a/tests/pages_test.rs
+++ b/tests/pages_test.rs
@@ -890,6 +890,48 @@ async fn test_search_page_no_results() {
     assert!(body.contains("data-testid=\"search-empty\""));
 }
 
+#[tokio::test]
+async fn test_search_page_invalid_query_shows_error_no_results() {
+    let app = create_test_app(default_test_config()).await;
+    setup_users(&app.db).await;
+    login(&app.server, "admin").await;
+
+    // "(rust OR" — unbalanced parenthesis, url-encoded.
+    let response = app.server.get("/search?q=%28rust%20OR").await;
+    response.assert_status_ok();
+    let body = response.text();
+    assert!(body.contains("搜尋語法錯誤"));
+    assert!(body.contains("data-testid=\"search-error\""));
+    assert!(!body.contains("data-testid=\"search-results\""));
+}
+
+#[tokio::test]
+async fn test_search_page_valid_structured_query_renders_without_error() {
+    let app = create_test_app(default_test_config()).await;
+    setup_users(&app.db).await;
+    login(&app.server, "admin").await;
+
+    let response = app.server.get("/search?q=is%3Aunread").await;
+    response.assert_status_ok();
+    let body = response.text();
+    assert!(!body.contains("搜尋語法錯誤"));
+    assert!(!body.contains("data-testid=\"search-error\""));
+}
+
+#[tokio::test]
+async fn test_search_page_has_syntax_help_panel() {
+    let app = create_test_app(default_test_config()).await;
+    setup_users(&app.db).await;
+    login(&app.server, "admin").await;
+
+    let response = app.server.get("/search").await;
+    response.assert_status_ok();
+    let body = response.text();
+    assert!(body.contains("class=\"search-syntax-help\""));
+    assert!(body.contains("Search syntax"));
+    assert!(body.contains("is:unread"));
+}
+
 // ============================================================================
 // Category Entries Page Tests
 // ============================================================================

--- a/tests/pages_test.rs
+++ b/tests/pages_test.rs
@@ -900,7 +900,7 @@ async fn test_search_page_invalid_query_shows_error_no_results() {
     let response = app.server.get("/search?q=%28rust%20OR").await;
     response.assert_status_ok();
     let body = response.text();
-    assert!(body.contains("搜尋語法錯誤"));
+    assert!(body.contains("Search syntax error"));
     assert!(body.contains("data-testid=\"search-error\""));
     assert!(!body.contains("data-testid=\"search-results\""));
 }
@@ -914,7 +914,7 @@ async fn test_search_page_valid_structured_query_renders_without_error() {
     let response = app.server.get("/search?q=is%3Aunread").await;
     response.assert_status_ok();
     let body = response.text();
-    assert!(!body.contains("搜尋語法錯誤"));
+    assert!(!body.contains("Search syntax error"));
     assert!(!body.contains("data-testid=\"search-error\""));
 }
 

--- a/tests/postgres_test.rs
+++ b/tests/postgres_test.rs
@@ -16,8 +16,10 @@
 //! dialect-fork between `SQLite` and PG — the composite-cursor `to_char`
 //! comparison, `datetime('now')`→`now()`, interval arithmetic (`make_interval`),
 //! `pg_database_size`, the `DATE()`/`to_char` stats bucket, the `"user"`
-//! reserved-word quoting, and the `is_unique_violation` mapping — against a real
-//! server.
+//! reserved-word quoting, the `is_unique_violation` mapping, and the `/search`
+//! boolean query language's `ILIKE ... ESCAPE` free-text/`is:` matching plus
+//! its `EXTRACT(EPOCH FROM ...)::bigint` date-bound comparison — against a
+//! real server.
 
 use rdrs::config::Backend;
 use rdrs::db::Db;
@@ -286,4 +288,127 @@ async fn pg_dialect_smoke() {
         matches!(err, AppError::CategoryExists),
         "expected CategoryExists, got {err:?}"
     );
+
+    // --- /search boolean query language: is:unread + free text (ILIKE ESCAPE) -
+    // Everything in this file shares one live server and one test function by
+    // design (see the module doc comment) so these query-language assertions
+    // extend `pg_dialect_smoke` with more seed data rather than adding
+    // sibling `#[tokio::test]` fns, which would TRUNCATE the same tables
+    // concurrently and race.
+    entry::upsert_entry(
+        &db,
+        feed_id,
+        "guid-rust-news",
+        Some("rust news"),
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    let (rust_read, _) = entry::upsert_entry(
+        &db,
+        feed_id,
+        "guid-rust-read",
+        Some("rust read already"),
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    entry::set_read_for_user(&db, user_id, rust_read.id, true)
+        .await
+        .unwrap();
+    entry::upsert_entry(
+        &db,
+        feed_id,
+        "guid-go-news",
+        Some("go news"),
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let unread_filter = EntryFilter {
+        query: Some(entry::query::parse("is:unread rust").unwrap()),
+        ..Default::default()
+    };
+    let unread_rows = entry::list_by_user(
+        &db,
+        user_id,
+        &unread_filter,
+        EntrySortOrder::PublishedAt,
+        50,
+        0,
+    )
+    .await
+    .unwrap();
+    let unread_titles: Vec<_> = unread_rows
+        .iter()
+        .filter_map(|r| r.entry.title.clone())
+        .collect();
+    assert!(unread_titles.iter().any(|t| t == "rust news"));
+    assert!(!unread_titles.iter().any(|t| t == "rust read already")); // read -> excluded by is:unread
+    assert!(!unread_titles.iter().any(|t| t == "go news")); // no "rust" -> excluded by free text
+
+    // --- /search boolean query language: after:2026-01-01 (epoch comparison) --
+    // Exercises the PG `EXTRACT(EPOCH FROM ...)::bigint` fork for date bounds
+    // (SQLite uses `strftime('%s', ...)`; see `query_after_date_filters` in
+    // `models::entry::mod`'s unit tests for the SQLite-side mirror).
+    entry::upsert_entry(
+        &db,
+        feed_id,
+        "guid-old",
+        Some("old"),
+        None,
+        None,
+        None,
+        None,
+        Some(utc("2025-06-01T00:00:00Z")),
+    )
+    .await
+    .unwrap();
+    entry::upsert_entry(
+        &db,
+        feed_id,
+        "guid-new",
+        Some("new"),
+        None,
+        None,
+        None,
+        None,
+        Some(utc("2026-03-01T00:00:00Z")),
+    )
+    .await
+    .unwrap();
+
+    let after_filter = EntryFilter {
+        query: Some(entry::query::parse("after:2026-01-01").unwrap()),
+        ..Default::default()
+    };
+    let after_rows = entry::list_by_user(
+        &db,
+        user_id,
+        &after_filter,
+        EntrySortOrder::PublishedAt,
+        50,
+        0,
+    )
+    .await
+    .unwrap();
+    let after_titles: Vec<_> = after_rows
+        .iter()
+        .filter_map(|r| r.entry.title.clone())
+        .collect();
+    assert!(after_titles.iter().any(|t| t == "new"));
+    assert!(!after_titles.iter().any(|t| t == "old"));
 }


### PR DESCRIPTION
## Summary

Adds a hand-written boolean **query language** to the global `/search` page. Users can now combine field filters, boolean logic, grouping, quoting, and negation in one search box. Backend matching stays `LIKE`/`ILIKE` — no full-text search this round. Scope is the global `/search` page only; scoped/per-view search is unchanged.

### Supported syntax

- **Status:** `is:unread` / `is:read` / `is:starred`
- **Source:** `feed:name` / `category:name` (fuzzy, case-insensitive)
- **Field:** `title:word` / `author:name` (`author` is newly searchable)
- **Date (UTC):** `before:2026-01-01` / `after:2026-01-01`
- **Boolean:** `AND` / `OR` / `NOT`, parentheses, adjacent terms imply `AND`
- **Negation:** `-term` (tight `-`); **Quoting:** `"exact phrase"`, `feed:"Rust Blog"`

Example: `is:starred (rust OR go) -is:read after:2026-01-01`

## How it works

- **Parser** (`src/models/entry/query.rs`): tokenizer + recursive-descent parser → `QueryNode` AST. Precedence `NOT > AND > OR`; `field:` triggers a filter only for known field names (so `http://x` stays literal text); dates validated with `chrono`. Zero new dependencies.
- **AST → SQL** (`src/models/entry/filters.rs::render_query`): recurses into a parenthesized `WHERE` fragment through the existing `Dialect` seam (SQLite `LIKE … ESCAPE`, Postgres `ILIKE … ESCAPE`, epoch date comparisons). `EntryFilter` gained `query: Option<QueryNode>`.
- **Handler** (`/search`): parses `?q=`; on a parse error renders an inline English error banner and runs no query; on success runs the filtered list. A collapsed `<details>` **syntax-help panel** makes the grammar discoverable.

## Correctness notes

- **No SQL injection:** only fixed column identifiers + `$N` binds are interpolated; all user text flows through binds.
- **LIKE-wildcard escaping:** user `%` / `_` / `\` are escaped with an explicit `ESCAPE '\'`, so a literal `%` is a literal.
- **Null-safe negation:** LIKE leaves are wrapped `COALESCE(…, false)`, so `-author:jane` correctly *includes* entries with a `NULL` author instead of dropping them.
- **No new index:** every index-able predicate (status, date) hits an existing index; the leading-wildcard `LIKE` scans are unchanged from today (only FTS would help, out of scope).

## Testing

- Parser unit tests (grammar/precedence, `-` tightness, `field:` disambiguation, quoting, dates, error paths).
- SQL-shape tests for both dialects.
- Live-SQLite integration tests (each operator, boolean/negation combos, literal-`%` escaping, null-author negation).
- Env-gated Postgres parity tests (ran against a live `postgres:17` server).
- Handler tests (invalid query → error banner + no results; valid query → results).
- Full suite: **1025/1025 passing**, `cargo fmt` + `cargo clippy -D warnings` clean.

Design spec and implementation plan under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)