### PR TITLE
fix(search): highlight all free-text terms, not just the first

### DIFF
--- a/src/handlers/pages/mod.rs
+++ b/src/handlers/pages/mod.rs
@@ -1758,7 +1758,7 @@ pub async fn search_page(
             }
             Ok(ast) => {
                 let terms = entry::query::free_text_terms(&ast);
-                let needle = terms.first().cloned().unwrap_or_default();
+                let needles: Vec<&str> = terms.iter().map(String::as_str).collect();
                 let filter = entry::EntryFilter {
                     query: Some(ast),
                     ..Default::default()
@@ -1785,18 +1785,18 @@ pub async fn search_page(
                             .unwrap_or_else(|| "(no title)".to_string());
                         let snippet = build_snippet(
                             e.entry.content.as_deref().or(e.entry.summary.as_deref()),
-                            &needle,
+                            &needles,
                             200,
                         );
                         let (published_relative, published_at_iso) =
                             format_relative_time(e.entry.published_at);
                         SearchResultView {
                             entry_id: e.entry.id,
-                            title_html: highlight_html(&title, &needle),
+                            title_html: highlight_html(&title, &needles),
                             feed_title: e.feed_title.clone().unwrap_or_else(|| e.feed_url.clone()),
                             published_relative,
                             published_at_iso,
-                            snippet_html: highlight_html(&snippet, &needle),
+                            snippet_html: highlight_html(&snippet, &needles),
                         }
                     })
                     .collect()
@@ -3121,42 +3121,64 @@ mod tests {
 
     #[test]
     fn highlight_wraps_simple_match() {
-        let out = highlight_html("Bitcoin Price Soars", "bitcoin");
-        assert_eq!(out, "<mark>Bitcoin</mark> Price Soars");
+        let out = highlight_html("Sunrise Over Kyoto", &["sunrise"]);
+        assert_eq!(out, "<mark>Sunrise</mark> Over Kyoto");
     }
 
     #[test]
     fn highlight_wraps_multiple_matches_case_insensitive() {
-        let out = highlight_html("BITCOIN bitcoin Bitcoin", "bitcoin");
+        let out = highlight_html("SUNRISE sunrise Sunrise", &["sunrise"]);
         assert_eq!(
             out,
-            "<mark>BITCOIN</mark> <mark>bitcoin</mark> <mark>Bitcoin</mark>"
+            "<mark>SUNRISE</mark> <mark>sunrise</mark> <mark>Sunrise</mark>"
         );
     }
 
     #[test]
+    fn highlight_wraps_all_terms_regardless_of_order() {
+        // Every free-text term is highlighted, not just the first — the bug
+        // where "人工智慧 AI" only marked "人工智慧" (and "AI 人工智慧" only "AI").
+        let expected = "<mark>人工智慧</mark> and <mark>AI</mark> news";
+        assert_eq!(
+            highlight_html("人工智慧 and AI news", &["人工智慧", "AI"]),
+            expected
+        );
+        assert_eq!(
+            highlight_html("人工智慧 and AI news", &["AI", "人工智慧"]),
+            expected
+        );
+    }
+
+    #[test]
+    fn highlight_merges_overlapping_term_ranges() {
+        // "learn" is contained in "learning"; ranges merge into one wrapper.
+        let out = highlight_html("machine learning", &["learn", "learning"]);
+        assert_eq!(out, "machine <mark>learning</mark>");
+    }
+
+    #[test]
     fn highlight_no_match_returns_escaped_only() {
-        let out = highlight_html("Ethereum news", "bitcoin");
-        assert_eq!(out, "Ethereum news");
+        let out = highlight_html("Weather report", &["sunrise"]);
+        assert_eq!(out, "Weather report");
     }
 
     #[test]
     fn highlight_escapes_html_special_chars() {
-        let out = highlight_html("<b>bitcoin</b>", "bitcoin");
-        assert_eq!(out, "&lt;b&gt;<mark>bitcoin</mark>&lt;/b&gt;");
+        let out = highlight_html("<b>sunrise</b>", &["sunrise"]);
+        assert_eq!(out, "&lt;b&gt;<mark>sunrise</mark>&lt;/b&gt;");
     }
 
     #[test]
-    fn highlight_empty_query_returns_escaped() {
-        let out = highlight_html("Hi <world>", "");
-        assert_eq!(out, "Hi &lt;world&gt;");
+    fn highlight_empty_terms_returns_escaped() {
+        assert_eq!(highlight_html("Hi <world>", &[]), "Hi &lt;world&gt;");
+        assert_eq!(highlight_html("Hi <world>", &[""]), "Hi &lt;world&gt;");
     }
 
     #[test]
     fn build_snippet_strips_script_and_style_bodies() {
         let out = build_snippet(
             Some("<p>hello</p><script>alert('x')</script><style>.a{}</style> world"),
-            "",
+            &[],
             200,
         );
         assert!(out.contains("hello"));
@@ -3169,26 +3191,40 @@ mod tests {
     fn build_snippet_centers_window_on_match() {
         // Match buried far past the leading 200 chars.
         let lead = "lorem ipsum ".repeat(40);
-        let html = format!("<p>{}Bitcoin price soars today across exchanges.</p>", lead);
-        let out = build_snippet(Some(&html), "bitcoin", 80);
+        let html = format!(
+            "<p>{}Sunrise lit the harbor early today over calm water.</p>",
+            lead
+        );
+        let out = build_snippet(Some(&html), &["sunrise"], 80);
         assert!(
-            out.contains("Bitcoin"),
+            out.contains("Sunrise"),
             "snippet should include match: {out}"
         );
         assert!(out.starts_with('…'), "should ellipsis-prefix: {out}");
     }
 
     #[test]
+    fn build_snippet_centers_on_earliest_matching_term() {
+        // The first term in the list appears later than the second; the window
+        // must center on whichever term matches earliest in the text.
+        let lead = "lorem ipsum ".repeat(40);
+        let html = format!("<p>{}Harbor then meadow later.</p>", lead);
+        let out = build_snippet(Some(&html), &["meadow", "harbor"], 80);
+        assert!(out.contains("Harbor"), "should center on earliest: {out}");
+        assert!(out.starts_with('…'), "should ellipsis-prefix: {out}");
+    }
+
+    #[test]
     fn build_snippet_falls_back_to_lead_when_no_match() {
-        let html = "<p>Ethereum dominated headlines this week as the merge approached.</p>";
-        let out = build_snippet(Some(html), "bitcoin", 30);
-        assert!(out.starts_with("Ethereum"));
+        let html = "<p>Monsoon clouds gathered over the valley before the rains arrived.</p>";
+        let out = build_snippet(Some(html), &["sunrise"], 30);
+        assert!(out.starts_with("Monsoon"));
         assert!(out.ends_with('…'));
     }
 
     #[test]
     fn build_snippet_strips_html_comments() {
-        let out = build_snippet(Some("hello <!-- secret note --> world"), "", 200);
+        let out = build_snippet(Some("hello <!-- secret note --> world"), &[], 200);
         assert_eq!(out, "hello world");
     }
 

--- a/src/handlers/pages/search_text.rs
+++ b/src/handlers/pages/search_text.rs
@@ -4,11 +4,11 @@
 use crate::utils::text::strip_to_plain_text;
 
 /// Build a query-aware snippet: returns a `max_chars`-wide window centered on
-/// the first case-insensitive match of `query` in the plain-text content, with
-/// `…` prefix/suffix where the window doesn't reach the original boundaries.
-/// Falls back to the leading `max_chars` characters if no match is found
-/// (or if `query` is empty).
-pub fn build_snippet(html: Option<&str>, query: &str, max_chars: usize) -> String {
+/// the first case-insensitive match of any of `terms` in the plain-text content,
+/// with `…` prefix/suffix where the window doesn't reach the original boundaries.
+/// Falls back to the leading `max_chars` characters if no term matches
+/// (or if `terms` is empty).
+pub fn build_snippet(html: Option<&str>, terms: &[&str], max_chars: usize) -> String {
     let raw = match html {
         Some(s) if !s.is_empty() => s,
         _ => return String::new(),
@@ -19,29 +19,31 @@ pub fn build_snippet(html: Option<&str>, query: &str, max_chars: usize) -> Strin
         return plain;
     }
 
-    // Try to center on the first match (ASCII-case-insensitive).
-    let q = query.trim();
-    if !q.is_empty() {
-        let plain_lower = plain.to_ascii_lowercase();
-        let q_lower = q.to_ascii_lowercase();
-        if let Some(byte_pos) = plain_lower.find(&q_lower) {
-            // Convert byte position → char index.
-            let match_char_idx = plain[..byte_pos].chars().count();
-            let context_before = max_chars / 3;
-            let start_char = match_char_idx.saturating_sub(context_before);
-            let end_char = (start_char + max_chars).min(total_chars);
-            // Recompute start to fill the window if we hit the tail.
-            let start_char = end_char.saturating_sub(max_chars);
+    // Try to center on the earliest match of any term (ASCII-case-insensitive).
+    let plain_lower = plain.to_ascii_lowercase();
+    let first_match = terms
+        .iter()
+        .map(|t| t.trim())
+        .filter(|t| !t.is_empty())
+        .filter_map(|t| plain_lower.find(&t.to_ascii_lowercase()))
+        .min();
+    if let Some(byte_pos) = first_match {
+        // Convert byte position → char index.
+        let match_char_idx = plain[..byte_pos].chars().count();
+        let context_before = max_chars / 3;
+        let start_char = match_char_idx.saturating_sub(context_before);
+        let end_char = (start_char + max_chars).min(total_chars);
+        // Recompute start to fill the window if we hit the tail.
+        let start_char = end_char.saturating_sub(max_chars);
 
-            let window: String = plain
-                .chars()
-                .skip(start_char)
-                .take(end_char - start_char)
-                .collect();
-            let prefix = if start_char > 0 { "…" } else { "" };
-            let suffix = if end_char < total_chars { "…" } else { "" };
-            return format!("{}{}{}", prefix, window.trim(), suffix);
-        }
+        let window: String = plain
+            .chars()
+            .skip(start_char)
+            .take(end_char - start_char)
+            .collect();
+        let prefix = if start_char > 0 { "…" } else { "" };
+        let suffix = if end_char < total_chars { "…" } else { "" };
+        return format!("{}{}{}", prefix, window.trim(), suffix);
     }
 
     // Fallback: leading window.
@@ -50,35 +52,54 @@ pub fn build_snippet(html: Option<&str>, query: &str, max_chars: usize) -> Strin
 }
 
 /// Wrap case-insensitive (ASCII-only — matches the `SQLite` LIKE COLLATE NOCASE
-/// behavior of the search query) matches of `query` in `<mark>` tags. Returns
-/// HTML with the non-match parts and the matched text both escaped, plus the
-/// `<mark>...</mark>` wrappers around hits. Use with `|safe` in templates.
-pub fn highlight_html(text: &str, query: &str) -> String {
-    if query.is_empty() {
-        return html_escape_minimal(text);
-    }
-    let q_lower = query.to_ascii_lowercase();
-    let q_bytes = q_lower.len();
-    if q_bytes == 0 {
-        return html_escape_minimal(text);
-    }
+/// behavior of the search query) matches of any of `terms` in `<mark>` tags.
+/// Returns HTML with the non-match parts and the matched text both escaped, plus
+/// the `<mark>...</mark>` wrappers around hits. Overlapping matches from
+/// different terms are merged into a single wrapper. Use with `|safe` in
+/// templates.
+pub fn highlight_html(text: &str, terms: &[&str]) -> String {
+    // `to_ascii_lowercase` preserves byte length, so offsets into `t_lower`
+    // index `text` identically.
     let t_lower = text.to_ascii_lowercase();
-    let mut out = String::with_capacity(text.len() + 16);
-    let mut last = 0;
-    let mut start = 0;
-    while start <= t_lower.len() {
-        match t_lower[start..].find(&q_lower) {
-            Some(rel) => {
-                let abs = start + rel;
-                out.push_str(&html_escape_minimal(&text[last..abs]));
-                out.push_str("<mark>");
-                out.push_str(&html_escape_minimal(&text[abs..abs + q_bytes]));
-                out.push_str("</mark>");
-                last = abs + q_bytes;
-                start = last;
-            }
-            None => break,
+
+    // Collect every match range (byte offsets) across all non-empty terms.
+    let mut ranges: Vec<(usize, usize)> = Vec::new();
+    for term in terms {
+        let needle = term.to_ascii_lowercase();
+        if needle.is_empty() {
+            continue;
         }
+        let n = needle.len();
+        let mut start = 0;
+        while let Some(rel) = t_lower[start..].find(&needle) {
+            let abs = start + rel;
+            ranges.push((abs, abs + n));
+            start = abs + n;
+        }
+    }
+    if ranges.is_empty() {
+        return html_escape_minimal(text);
+    }
+
+    // Sort by start and merge overlapping/adjacent ranges so nested or crossing
+    // matches (e.g. "learn" inside "learning") produce one contiguous wrapper.
+    ranges.sort_unstable();
+    let mut merged: Vec<(usize, usize)> = Vec::with_capacity(ranges.len());
+    for (s, e) in ranges {
+        match merged.last_mut() {
+            Some(last) if s <= last.1 => last.1 = last.1.max(e),
+            _ => merged.push((s, e)),
+        }
+    }
+
+    let mut out = String::with_capacity(text.len() + 16 * merged.len());
+    let mut last = 0;
+    for (s, e) in merged {
+        out.push_str(&html_escape_minimal(&text[last..s]));
+        out.push_str("<mark>");
+        out.push_str(&html_escape_minimal(&text[s..e]));
+        out.push_str("</mark>");
+        last = e;
     }
     out.push_str(&html_escape_minimal(&text[last..]));
     out


### PR DESCRIPTION
## Problem

The global `/search` results page only ever highlighted **one** query term. The
handler collapsed the parsed free-text terms into a single needle via
`terms.first()`, so highlighting depended purely on token order:

- `人工智慧 AI` → only `人工智慧` was marked
- `AI 人工智慧` → only `AI` was marked

## Fix

`highlight_html` and `build_snippet` now take `&[&str]` (all free-text terms) instead of a single string:

- **highlight** collects match ranges across every term, then sorts and merges overlapping/adjacent ranges (e.g. `learn` inside `learning`) into a single `<mark>` wrapper. `to_ascii_lowercase()` preserves byte length, so lowercased offsets index the original text directly.
- **snippet** centers its window on the *earliest* matching term in the text, regardless of term order.
- the handler passes the full term list through to both.

## Tests

Added coverage and updated existing tests to the new slice signature:

- `highlight_wraps_all_terms_regardless_of_order` — both `["人工智慧","AI"]` and `["AI","人工智慧"]` mark both terms
- `highlight_merges_overlapping_term_ranges` — nested-term ranges merge into one wrapper
- `build_snippet_centers_on_earliest_matching_term` — window centers on earliest match, not first term in list

`cargo fmt`, `cargo clippy -D warnings`, and the 12 highlight/snippet unit tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)