### PR TITLE
fix(summarizer): include title and URL when copying a summary card

### DIFF
--- a/static/js/summarizer.js
+++ b/static/js/summarizer.js
@@ -135,8 +135,20 @@ if (results) {
     }
     const copy = e.target.closest('[data-sz-copy]');
     if (copy) {
-      const body = copy.closest('[data-summarizer-card]')?.querySelector('[data-sz-body]');
-      if (body) navigator.clipboard?.writeText(body.textContent.trim());
+      const card = copy.closest('[data-summarizer-card]');
+      const body = card?.querySelector('[data-sz-body]');
+      if (body) {
+        // Mirror the entry-summary copy: title + URL + summary, so the copied
+        // text keeps the source context, not just the bare summary body.
+        const title = (card.querySelector('[data-sz-title]')?.textContent || '').trim();
+        const url = (card.dataset.summarizerUrl || '').trim();
+        const summary = body.textContent.trim();
+        const parts = [];
+        if (title) parts.push(title);
+        if (url) parts.push(url);
+        parts.push(summary);
+        navigator.clipboard?.writeText(parts.join('\n\n'));
+      }
     }
   });
 


### PR DESCRIPTION
## Summary

The summarizer card's **Copy** button only wrote the summary body to the clipboard, dropping the source title and URL. This diverged from the entry-summary Copy behaviour, which copies **title + link + summary**.

This change mirrors the entry-summary copy (`app.js`): it reads the card's existing `[data-sz-title]` and `data-summarizer-url`, then joins title + URL + summary with blank lines before writing to the clipboard.

## Details

- Root cause: `static/js/summarizer.js` copy handler read only `[data-sz-body]`.
- No DOM/template changes needed — title and URL were already present on the card, just unused by the copy handler.

## Testing

- `node --check static/js/summarizer.js` passes.
- Pure client-side JS behaviour change; no rendered-UI change (README screenshots unaffected), and clipboard copy has no existing E2E coverage for either summarizer or entry summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)