### PR TITLE
fix(summarizer): show "Copied!" feedback after copying a card

### DIFF
--- a/e2e/features/summarizer.feature
+++ b/e2e/features/summarizer.feature
@@ -14,6 +14,18 @@ Feature: Summarizer tool
     Then I should see 2 summary cards
     And each card resolves to a completed state containing "E2E mock summary body."
 
+  Scenario: Copy button confirms with a "Copied!" label
+    Given I am signed in
+    And the user has Kagi configured
+    When I open the Summarizer
+    And I enter these URLs:
+      | https://example.com/one |
+    And I submit the summarizer form
+    Then I should see 1 summary cards
+    And each card resolves to a completed state containing "E2E mock summary body."
+    When I copy the first summary card
+    Then the first summary card's copy button reads "Copied!"
+
   Scenario: Settings prompt when Kagi is not configured
     Given I am signed in
     When I open the Summarizer

--- a/e2e/steps/summarizer.steps.js
+++ b/e2e/steps/summarizer.steps.js
@@ -36,6 +36,26 @@ Then(
   },
 );
 
+When("I copy the first summary card", async ({ page }) => {
+  // The label swap only needs the clipboard write to resolve; grant the
+  // permission so navigator.clipboard.writeText doesn't reject headlessly.
+  await page.context().grantPermissions(["clipboard-read", "clipboard-write"]);
+  await page
+    .locator("[data-summarizer-card]")
+    .first()
+    .getByRole("button", { name: "Copy summary" })
+    .click();
+});
+
+Then(
+  "the first summary card's copy button reads {string}",
+  async ({ page }, text) => {
+    await expect(
+      page.locator("[data-summarizer-card]").first().locator("[data-sz-copy]"),
+    ).toHaveText(text);
+  },
+);
+
 Then("I should see a link to Settings", async ({ page }) => {
   // Scope to the page content: the sidebar always carries its own
   // data-testid="nav-settings" link to /user-settings, so a bare href

--- a/static/js/summarizer.js
+++ b/static/js/summarizer.js
@@ -111,7 +111,7 @@ if (results) {
     }
   };
 
-  results.addEventListener('click', (e) => {
+  results.addEventListener('click', async (e) => {
     if (e.target.closest('[data-sz-cancel]')) {
       currentController?.abort();
       return;
@@ -147,7 +147,17 @@ if (results) {
         if (title) parts.push(title);
         if (url) parts.push(url);
         parts.push(summary);
-        navigator.clipboard?.writeText(parts.join('\n\n'));
+        try {
+          await navigator.clipboard.writeText(parts.join('\n\n'));
+          // Mirror the entry-summary copy feedback: swap only the label span's
+          // text to "Copied!" (leaving any icon span intact) and restore it.
+          const label = copy.querySelector('.action-label') || copy;
+          const original = label.textContent;
+          label.textContent = 'Copied!';
+          setTimeout(() => { label.textContent = original; }, 2000);
+        } catch {
+          window.flash?.error('Failed to copy to clipboard');
+        }
       }
     }
   });


### PR DESCRIPTION
## Summary

The Summarizer tool's card **Copy** button wrote to the clipboard silently — clicking it gave no confirmation. This is inconsistent with the reading-pane entry summary, whose Copy button briefly swaps its label to **Copied!**.

This change mirrors that feedback in `static/js/summarizer.js`: after a successful `navigator.clipboard.writeText`, only the `.action-label` span's text is swapped to `Copied!` (leaving any icon span intact) and restored after 2s. A clipboard failure now surfaces a flash error, matching the entry-summary handler.

## Changes

- `static/js/summarizer.js`: make the results click handler `async`; add the label swap + flash-on-failure to the `data-sz-copy` branch.
- `e2e/features/summarizer.feature` / `e2e/steps/summarizer.steps.js`: new scenario asserting the card's copy button reads `Copied!` after a click (grants clipboard permission so `writeText` resolves headlessly).

## Testing

- Reverted the fix and rebuilt → new e2e scenario **fails** (button still reads `Copy`), confirming the test is meaningful.
- Restored the fix and rebuilt → all 3 `@summarizer` e2e scenarios **pass**.

No screenshot updates needed: `Copied!` is a transient post-click state outside the captured screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)