### PR TITLE
fix(deny): restore green cargo-deny by ignoring rustybuzz RUSTSEC-2026-0206

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -32,11 +32,16 @@ ignore = [
     # upstream releases against 0.41. Drop these once both paths are clean.
     "RUSTSEC-2026-0194",
     "RUSTSEC-2026-0195",
-    # ttf-parser unmaintained (transitive via resvg/usvg/fontdb, favicon render).
-    # No maintained fix — 0.25.1 is the latest release — so this can't be cleared
-    # by a version bump; revisit when the resvg chain drops or replaces it.
-    # Tracked in issue #346 (the ammonia/anyhow entries there are now resolved).
+    # ttf-parser (RUSTSEC-2026-0192) and rustybuzz (RUSTSEC-2026-0206) are both
+    # unmaintained, pulled in transitively via the same resvg/usvg text stack we
+    # use only as a build-dependency for favicon rendering. Neither has a
+    # maintained fix — ttf-parser 0.25.1 and rustybuzz 0.20.1 are the latest
+    # releases and resvg 0.47.0 (our current, latest) still pins them — so they
+    # can't be cleared by a version bump; revisit when the resvg chain drops or
+    # replaces them. Tracked in issue #346 (the ammonia/anyhow entries there are
+    # now resolved).
     "RUSTSEC-2026-0192",
+    "RUSTSEC-2026-0206",
     # crossbeam-epoch invalid pointer deref in the `fmt::Display`/`fmt::Pointer`
     # impls for `Atomic`/`Shared` on a null pointer (transitive via image and
     # moka; we never format those pointers, so it's unreachable here). Sole fix


### PR DESCRIPTION
## Summary

Closes the remaining goal of #346 — a green `cargo deny check` on `main`.

The two dependency bumps #346 tracked were already landed in #365 (`ammonia` → 4.1.3 for RUSTSEC-2026-0193, `anyhow` → 1.0.103 for RUSTSEC-2026-0190), and the unmaintained `ttf-parser` (RUSTSEC-2026-0192) already has a scoped ignore.

Since then a **new** unmaintained advisory started failing the gate on `main`:

- **RUSTSEC-2026-0206** — `rustybuzz` is unmaintained.

`rustybuzz` is pulled in transitively via the same `resvg`/`usvg` text stack that `rdrs` uses **only as a build-dependency for favicon rendering** — the identical situation to the already-ignored `ttf-parser`. There is no maintained fix (`rustybuzz 0.20.1` and `ttf-parser 0.25.1` are the latest releases, and `resvg 0.47.0` — our current, latest — still pins both), so it can't be cleared by a version bump. A scoped ignore mirroring the `ttf-parser` entry is the only resolution, to be revisited if/when the `resvg` chain drops or replaces these crates.

## Verification

- `cargo deny check` — advisories ok, bans ok, licenses ok, sources ok (was `advisories FAILED` on `main`)
- No source or `Cargo.lock` change — this is a supply-chain allowlist entry only, so the test suite is unaffected.

Closes #346

🤖 Generated with [Claude Code](https://claude.com/claude-code)